### PR TITLE
fix: Phase A ledger writes — 6 mutation handlers

### DIFF
--- a/apps/api/routes/handlers/document_handler.py
+++ b/apps/api/routes/handlers/document_handler.py
@@ -14,6 +14,7 @@ import logging
 
 from fastapi import HTTPException
 from supabase import Client
+from routes.handlers.ledger_utils import build_ledger_event
 
 logger = logging.getLogger(__name__)
 
@@ -154,7 +155,24 @@ async def upload_document(
     user_context: dict, db_client: Client,
 ) -> dict:
     _enforce_doc_rbac("upload_document", user_context)
-    return await _delegate_to_doc_handler("upload_document", db_client, yacht_id, user_id, payload)
+    result = await _delegate_to_doc_handler("upload_document", db_client, yacht_id, user_id, payload)
+    if isinstance(result, dict) and result.get("status") != "error":
+        try:
+            ledger_event = build_ledger_event(
+                yacht_id=yacht_id,
+                user_id=user_id,
+                event_type="create",
+                entity_type="document",
+                entity_id=result.get("document_id") or result.get("id") or yacht_id,
+                action="upload_document",
+                user_role=user_context.get("role"),
+                change_summary=f"Document uploaded: {payload.get('file_name', '')}",
+            )
+            db_client.table("ledger_events").insert(ledger_event).execute()
+        except Exception as ledger_err:
+            if "204" not in str(ledger_err):
+                logger.warning(f"[Ledger] Failed to record upload_document: {ledger_err}")
+    return result
 
 
 async def update_document(
@@ -170,7 +188,25 @@ async def delete_document(
     user_context: dict, db_client: Client,
 ) -> dict:
     _enforce_doc_rbac("delete_document", user_context)
-    return await _delegate_to_doc_handler("delete_document", db_client, yacht_id, user_id, payload)
+    document_id = payload.get("document_id")
+    result = await _delegate_to_doc_handler("delete_document", db_client, yacht_id, user_id, payload)
+    if isinstance(result, dict) and result.get("status") != "error":
+        try:
+            ledger_event = build_ledger_event(
+                yacht_id=yacht_id,
+                user_id=user_id,
+                event_type="delete",
+                entity_type="document",
+                entity_id=document_id or yacht_id,
+                action="delete_document",
+                user_role=user_context.get("role"),
+                change_summary=f"Document deleted: reason={payload.get('reason', '')}",
+            )
+            db_client.table("ledger_events").insert(ledger_event).execute()
+        except Exception as ledger_err:
+            if "204" not in str(ledger_err):
+                logger.warning(f"[Ledger] Failed to record delete_document: {ledger_err}")
+    return result
 
 
 async def add_document_tags(

--- a/apps/api/routes/handlers/fault_handler.py
+++ b/apps/api/routes/handlers/fault_handler.py
@@ -213,6 +213,21 @@ async def resolve_fault(
         .execute()
     )
     if fault_result.data:
+        try:
+            ledger_event = build_ledger_event(
+                yacht_id=yacht_id,
+                user_id=user_id,
+                event_type="status_change",
+                entity_type="fault",
+                entity_id=fault_id,
+                action="resolve_fault",
+                user_role=user_context.get("role"),
+                change_summary="Fault resolved",
+            )
+            db_client.table("ledger_events").insert(ledger_event).execute()
+        except Exception as ledger_err:
+            if "204" not in str(ledger_err):
+                logger.warning(f"[Ledger] Failed to record resolve_fault: {ledger_err}")
         return {"status": "success", "message": "Fault resolved"}
     return {"status": "error", "error_code": "UPDATE_FAILED", "message": "Failed to resolve fault"}
 

--- a/apps/api/routes/handlers/handover_handler.py
+++ b/apps/api/routes/handlers/handover_handler.py
@@ -150,6 +150,22 @@ async def add_to_handover(
                     "message": result.get("message")
                 }
             )
+        try:
+            from routes.handlers.ledger_utils import build_ledger_event
+            ledger_event = build_ledger_event(
+                yacht_id=yacht_id,
+                user_id=user_id,
+                event_type="create",
+                entity_type="handover_item",
+                entity_id=result.get("item_id", entity_id or yacht_id),
+                action="add_to_handover",
+                user_role=user_context.get("role"),
+                change_summary=f"Added to handover: {summary[:80]}",
+            )
+            db_client.table("ledger_events").insert(ledger_event).execute()
+        except Exception as ledger_err:
+            if "204" not in str(ledger_err):
+                logger.warning(f"[Ledger] Failed to record add_to_handover: {ledger_err}")
         return result
 
     except HTTPException:

--- a/apps/api/routes/handlers/work_order_handler.py
+++ b/apps/api/routes/handlers/work_order_handler.py
@@ -114,6 +114,21 @@ async def close_work_order(
 
     wo_result = db_client.table("pms_work_orders").update(update_data).eq("id", work_order_id).eq("yacht_id", yacht_id).execute()
     if wo_result.data:
+        try:
+            ledger_event = build_ledger_event(
+                yacht_id=yacht_id,
+                user_id=user_id,
+                event_type="status_change",
+                entity_type="work_order",
+                entity_id=work_order_id,
+                action="close_work_order",
+                user_role=user_context.get("role"),
+                change_summary="Work order closed",
+            )
+            db_client.table("ledger_events").insert(ledger_event).execute()
+        except Exception as ledger_err:
+            if "204" not in str(ledger_err):
+                logger.warning(f"[Ledger] Failed to record close_work_order: {ledger_err}")
         return {"status": "success", "message": "Work order closed"}
     else:
         return {"status": "error", "error_code": "UPDATE_FAILED", "message": "Failed to close work order"}
@@ -145,6 +160,21 @@ async def add_wo_hours(
     }
     note_result = db_client.table("pms_work_order_notes").insert(note_data).execute()
     if note_result.data:
+        try:
+            ledger_event = build_ledger_event(
+                yacht_id=yacht_id,
+                user_id=user_id,
+                event_type="update",
+                entity_type="work_order",
+                entity_id=work_order_id,
+                action="add_wo_hours",
+                user_role=user_context.get("role"),
+                change_summary=f"Logged {hours} hours",
+            )
+            db_client.table("ledger_events").insert(ledger_event).execute()
+        except Exception as ledger_err:
+            if "204" not in str(ledger_err):
+                logger.warning(f"[Ledger] Failed to record add_wo_hours: {ledger_err}")
         return {"status": "success", "message": f"Logged {hours} hours"}
     else:
         return {"status": "error", "error_code": "INSERT_FAILED", "message": "Failed to log hours"}
@@ -191,6 +221,21 @@ async def add_wo_part(
     }
     part_result = db_client.table("pms_work_order_parts").upsert(part_data, on_conflict="work_order_id,part_id").execute()
     if part_result.data:
+        try:
+            ledger_event = build_ledger_event(
+                yacht_id=yacht_id,
+                user_id=user_id,
+                event_type="update",
+                entity_type="work_order",
+                entity_id=work_order_id,
+                action="add_wo_part",
+                user_role=user_context.get("role"),
+                change_summary=f"Part added: part_id={part_id}, qty={quantity}",
+            )
+            db_client.table("ledger_events").insert(ledger_event).execute()
+        except Exception as ledger_err:
+            if "204" not in str(ledger_err):
+                logger.warning(f"[Ledger] Failed to record add_wo_part: {ledger_err}")
         return {"status": "success", "message": "Part added to work order"}
     else:
         return {"status": "error", "error_code": "INSERT_FAILED", "message": "Failed to add part"}


### PR DESCRIPTION
## Summary
- Adds `build_ledger_event` writes to 6 mutation handlers that were silently completing without audit trail
- Handlers patched: `close_work_order`, `add_wo_hours`, `add_wo_part` (work_order_handler.py), `resolve_fault` (fault_handler.py), `add_to_handover` (handover_handler.py), `upload_document` + `delete_document` (document_handler.py)
- All writes are fire-and-forget (non-blocking): failure logs a warning but never breaks the mutation
- This is Phase A of the ledger gap remediation. Phase B (dispatcher-level safety net) will follow.

## Test plan
- [ ] `close_work_order` via POST /v1/actions/execute — check ledger_events row created
- [ ] `resolve_fault` via POST /v1/actions/execute — check ledger_events row created
- [ ] `add_to_handover` via POST /v1/actions/execute — check ledger_events row created
- [ ] `upload_document` / `delete_document` — verify ledger entry on success, no error on failure
- [ ] Verify existing unit tests still pass (ledger writes are additive, no behaviour change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)