### PR TITLE
feat: GET /v1/handover/queue — aggregated handover candidates

### DIFF
--- a/apps/api/routes/p0_actions_routes.py
+++ b/apps/api/routes/p0_actions_routes.py
@@ -12,15 +12,15 @@ Endpoints:
 All routes require JWT authentication and yacht isolation validation.
 """
 
-from fastapi import APIRouter, HTTPException, Depends
+from fastapi import APIRouter, HTTPException, Depends, Query
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel, Field
-from typing import Dict, Any, Optional
+from typing import Dict, Any, List, Optional
 import logging
 import os
 import hashlib
 import json
-from datetime import datetime
+from datetime import datetime, timezone
 from supabase import create_client, Client
 from dotenv import load_dotenv
 
@@ -2263,6 +2263,128 @@ async def verify_export_route(
         raise HTTPException(status_code=404, detail=result.get("message"))
 
     return result
+
+
+# ============================================================================
+# GET /v1/handover/queue — aggregated candidates for next handover draft
+# ============================================================================
+
+@router.get("/handover/queue")
+async def get_handover_queue(
+    auth: dict = Depends(get_authenticated_user),
+    yacht_id_param: Optional[str] = Query(None, alias="yacht_id"),
+    include: Optional[List[str]] = Query(None),
+):
+    """
+    Return open items that are candidates for inclusion in the next handover.
+    Sections: open_faults, overdue_work_orders, low_stock_parts, pending_orders, already_queued.
+    Pass ?include[]=faults&include[]=work_orders to filter sections (default: all).
+    Read-only — no ledger writes.
+    """
+    yacht_id = resolve_yacht_id(auth, yacht_id_param)
+    db_client = get_tenant_supabase_client(auth["tenant_key_alias"])
+
+    # Determine which sections to return
+    all_sections = {"faults", "work_orders", "parts", "orders", "queued"}
+    requested = set(include) if include else all_sections
+
+    open_faults = []
+    overdue_work_orders = []
+    low_stock_parts = []
+    pending_orders = []
+    already_queued = []
+
+    # ── open faults ──────────────────────────────────────────────────────────
+    if "faults" in requested:
+        try:
+            result = db_client.table("pms_faults").select(
+                "id, title, severity, equipment_name, created_at"
+            ).eq("yacht_id", yacht_id).neq(
+                "status", "resolved"
+            ).order("created_at", desc=True).limit(20).execute()
+            open_faults = result.data or []
+        except Exception as e:
+            logger.warning(f"[handover/queue] faults query failed: {e}")
+
+    # ── overdue work orders ───────────────────────────────────────────────────
+    if "work_orders" in requested:
+        try:
+            now_iso = datetime.now(timezone.utc).isoformat()
+            result = db_client.table("pms_work_orders").select(
+                "id, title, priority, due_at, assigned_to"
+            ).eq("yacht_id", yacht_id).not_.in_(
+                "status", ["completed", "cancelled", "closed"]
+            ).lt("due_at", now_iso).order("due_at").limit(20).execute()
+            overdue_work_orders = result.data or []
+        except Exception as e:
+            logger.warning(f"[handover/queue] work_orders query failed: {e}")
+
+    # ── low stock parts ───────────────────────────────────────────────────────
+    if "parts" in requested:
+        try:
+            result = db_client.table("pms_parts").select(
+                "id, name, quantity_on_hand, minimum_quantity"
+            ).eq("yacht_id", yacht_id).execute()
+            raw = result.data or []
+            low_stock_parts = [
+                {
+                    "id": p["id"],
+                    "name": p.get("name", ""),
+                    "current_qty": p.get("quantity_on_hand", 0),
+                    "reorder_threshold": p.get("minimum_quantity", 0),
+                }
+                for p in raw
+                if (p.get("quantity_on_hand") or 0) <= (p.get("minimum_quantity") or 0)
+            ][:20]
+        except Exception as e:
+            logger.warning(f"[handover/queue] parts query failed: {e}")
+
+    # ── pending purchase orders ───────────────────────────────────────────────
+    if "orders" in requested:
+        try:
+            result = db_client.table("pms_purchase_orders").select(
+                "id, po_number, status, created_at"
+            ).eq("yacht_id", yacht_id).in_(
+                "status", ["draft", "pending", "submitted", "pending_approval"]
+            ).order("created_at", desc=True).limit(20).execute()
+            pending_orders = [
+                {
+                    "id": p["id"],
+                    "title": p.get("po_number") or f"PO {p['id'][:8]}",
+                    "status": p.get("status", ""),
+                    "created_at": p.get("created_at", ""),
+                }
+                for p in (result.data or [])
+            ]
+        except Exception as e:
+            logger.warning(f"[handover/queue] orders query failed: {e}")
+
+    # ── already queued handover items ─────────────────────────────────────────
+    if "queued" in requested:
+        try:
+            result = db_client.table("handover_items").select(
+                "id, entity_type, entity_id, summary, priority"
+            ).eq("yacht_id", yacht_id).eq(
+                "status", "pending"
+            ).order("priority", desc=True).limit(50).execute()
+            already_queued = result.data or []
+        except Exception as e:
+            logger.warning(f"[handover/queue] handover_items query failed: {e}")
+
+    return {
+        "open_faults": open_faults,
+        "overdue_work_orders": overdue_work_orders,
+        "low_stock_parts": low_stock_parts,
+        "pending_orders": pending_orders,
+        "already_queued": already_queued,
+        "counts": {
+            "faults": len(open_faults),
+            "work_orders": len(overdue_work_orders),
+            "parts": len(low_stock_parts),
+            "orders": len(pending_orders),
+            "already_queued": len(already_queued),
+        },
+    }
 
 
 # ============================================================================

--- a/apps/api/tests/test_handover_queue.py
+++ b/apps/api/tests/test_handover_queue.py
@@ -1,0 +1,245 @@
+"""
+GET /v1/handover/queue — Integration Tests
+==========================================
+
+Tests the aggregated handover candidates endpoint.
+
+Three test groups:
+  200 happy path   — all 5 sections return arrays (never null)
+  200 partial      — ?include[]=faults returns only faults, others empty
+  401 unauthed     — no token → 401
+
+LAW 17: in-memory via httpx.AsyncClient, DB mocked via patch.
+"""
+
+import os
+import sys
+import uuid
+import pytest
+import pytest_asyncio
+import httpx
+from unittest.mock import MagicMock, patch
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from pipeline_service import app
+from middleware.auth import get_authenticated_user
+
+# ── Constants ─────────────────────────────────────────────────────────────────
+
+YACHT_ID = "85fe1119-b04c-41ac-80f1-829d23322598"
+USER_ID = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+
+_AUTH = {
+    "user_id": USER_ID,
+    "email": "test@yacht.test",
+    "yacht_id": YACHT_ID,
+    "org_id": YACHT_ID,
+    "tenant_key_alias": "y85fe111",
+    "role": "chief_engineer",
+    "vessel_ids": [YACHT_ID],
+    "is_fleet_user": False,
+    "yacht_name": "M/Y Test",
+}
+
+FAULT_ROW = {
+    "id": str(uuid.uuid4()),
+    "title": "Main engine oil leak",
+    "severity": "high",
+    "equipment_name": "Main Engine",
+    "created_at": "2026-04-01T10:00:00+00:00",
+}
+
+WO_ROW = {
+    "id": str(uuid.uuid4()),
+    "title": "Replace fuel filter",
+    "priority": "high",
+    "due_at": "2026-03-01T00:00:00+00:00",
+    "assigned_to": USER_ID,
+}
+
+PART_ROW_LOW = {
+    "id": str(uuid.uuid4()),
+    "name": "Oil Filter",
+    "quantity_on_hand": 0,
+    "minimum_quantity": 2,
+}
+
+PART_ROW_OK = {
+    "id": str(uuid.uuid4()),
+    "name": "Fuel Filter",
+    "quantity_on_hand": 5,
+    "minimum_quantity": 1,
+}
+
+ORDER_ROW = {
+    "id": str(uuid.uuid4()),
+    "po_number": "PO-2026-001",
+    "status": "pending",
+    "created_at": "2026-04-02T08:00:00+00:00",
+}
+
+QUEUED_ROW = {
+    "id": str(uuid.uuid4()),
+    "entity_type": "fault",
+    "entity_id": str(uuid.uuid4()),
+    "summary": "Fuel leak reported by deckhand",
+    "priority": "high",
+}
+
+
+def _build_db_mock(
+    faults=None, work_orders=None, parts=None, orders=None, queued=None
+):
+    """Build a Supabase mock that returns configured data per table."""
+    m = MagicMock()
+
+    def _chain(data):
+        c = MagicMock()
+        r = MagicMock()
+        r.data = data if data is not None else []
+        # All filter/order chains ultimately return the same result
+        c.execute.return_value = r
+        c.eq.return_value = c
+        c.neq.return_value = c
+        c.lt.return_value = c
+        c.in_.return_value = c
+        c.not_ = c
+        c.order.return_value = c
+        c.limit.return_value = c
+        return c
+
+    def _select(table_name):
+        tbl = MagicMock()
+        if "fault" in table_name:
+            tbl.select.return_value = _chain(faults if faults is not None else [])
+        elif "work_order" in table_name:
+            tbl.select.return_value = _chain(work_orders if work_orders is not None else [])
+        elif "pms_parts" in table_name:
+            tbl.select.return_value = _chain(parts if parts is not None else [])
+        elif "purchase_order" in table_name:
+            tbl.select.return_value = _chain(orders if orders is not None else [])
+        elif "handover_items" in table_name:
+            tbl.select.return_value = _chain(queued if queued is not None else [])
+        else:
+            tbl.select.return_value = _chain([])
+        return tbl
+
+    m.table.side_effect = _select
+    return m
+
+
+# ── Fixtures ──────────────────────────────────────────────────────────────────
+
+@pytest_asyncio.fixture
+async def client():
+    """Unauthenticated client."""
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test", timeout=10.0) as c:
+        yield c
+
+
+@pytest_asyncio.fixture
+async def auth_client():
+    """Authenticated client with mocked auth."""
+    async def _mock_auth():
+        return _AUTH
+
+    app.dependency_overrides[get_authenticated_user] = _mock_auth
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test", timeout=10.0) as c:
+        yield c
+    app.dependency_overrides.clear()
+
+
+# ── Tests ─────────────────────────────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_handover_queue_200_all_sections(auth_client):
+    """Happy path: all 5 sections return arrays with correct shape."""
+    db = _build_db_mock(
+        faults=[FAULT_ROW],
+        work_orders=[WO_ROW],
+        parts=[PART_ROW_LOW, PART_ROW_OK],
+        orders=[ORDER_ROW],
+        queued=[QUEUED_ROW],
+    )
+    with patch("routes.p0_actions_routes.get_tenant_supabase_client", return_value=db):
+        resp = await auth_client.get("/v1/handover/queue")
+
+    assert resp.status_code == 200
+    body = resp.json()
+
+    # All sections present and are lists
+    assert isinstance(body["open_faults"], list)
+    assert isinstance(body["overdue_work_orders"], list)
+    assert isinstance(body["low_stock_parts"], list)
+    assert isinstance(body["pending_orders"], list)
+    assert isinstance(body["already_queued"], list)
+    assert isinstance(body["counts"], dict)
+
+    # Correct data returned
+    assert len(body["open_faults"]) == 1
+    assert body["open_faults"][0]["title"] == "Main engine oil leak"
+
+    assert len(body["overdue_work_orders"]) == 1
+    assert body["overdue_work_orders"][0]["priority"] == "high"
+
+    # Only the low-stock part returned (qty 0 <= min 2), not the ok one (qty 5 > min 1)
+    assert len(body["low_stock_parts"]) == 1
+    assert body["low_stock_parts"][0]["current_qty"] == 0
+
+    assert len(body["pending_orders"]) == 1
+    assert body["pending_orders"][0]["title"] == "PO-2026-001"
+
+    assert len(body["already_queued"]) == 1
+    assert body["already_queued"][0]["entity_type"] == "fault"
+
+    # counts matches lengths
+    assert body["counts"]["faults"] == 1
+    assert body["counts"]["work_orders"] == 1
+    assert body["counts"]["parts"] == 1
+    assert body["counts"]["orders"] == 1
+    assert body["counts"]["already_queued"] == 1
+
+
+@pytest.mark.asyncio
+async def test_handover_queue_200_empty_arrays_not_null(auth_client):
+    """When tables return no rows, response is empty arrays — never null/None."""
+    db = _build_db_mock()  # all empty
+    with patch("routes.p0_actions_routes.get_tenant_supabase_client", return_value=db):
+        resp = await auth_client.get("/v1/handover/queue")
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["open_faults"] == []
+    assert body["overdue_work_orders"] == []
+    assert body["low_stock_parts"] == []
+    assert body["pending_orders"] == []
+    assert body["already_queued"] == []
+    assert body["counts"] == {
+        "faults": 0, "work_orders": 0, "parts": 0, "orders": 0, "already_queued": 0
+    }
+
+
+@pytest.mark.asyncio
+async def test_handover_queue_200_include_filter(auth_client):
+    """?include[]=faults should return only faults; other sections empty."""
+    db = _build_db_mock(faults=[FAULT_ROW], work_orders=[WO_ROW])
+    with patch("routes.p0_actions_routes.get_tenant_supabase_client", return_value=db):
+        resp = await auth_client.get("/v1/handover/queue?include=faults")
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert len(body["open_faults"]) == 1
+    assert body["overdue_work_orders"] == []
+    assert body["low_stock_parts"] == []
+    assert body["pending_orders"] == []
+    assert body["already_queued"] == []
+
+
+@pytest.mark.asyncio
+async def test_handover_queue_401_no_token(client):
+    """No token → 401 from get_authenticated_user."""
+    resp = await client.get("/v1/handover/queue")
+    assert resp.status_code == 401


### PR DESCRIPTION
## Summary
- New read-only endpoint returning aggregated candidates for inclusion in the next handover draft
- 5 sections: `open_faults`, `overdue_work_orders`, `low_stock_parts`, `pending_orders`, `already_queued`
- Supports `?include[]=section` filter (default: all sections)
- Each section fails gracefully — if a table is unavailable, it logs a warning and returns `[]` (never throws)
- Response shape approved by CEO01 prior to implementation
- No ledger writes (read-only)

## Response shape
```json
{
  "open_faults": [{"id": "...", "title": "...", "severity": "...", "equipment_name": "...", "created_at": "..."}],
  "overdue_work_orders": [{"id": "...", "title": "...", "priority": "...", "due_at": "...", "assigned_to": "..."}],
  "low_stock_parts": [{"id": "...", "name": "...", "current_qty": 0, "reorder_threshold": 0}],
  "pending_orders": [{"id": "...", "title": "...", "status": "...", "created_at": "..."}],
  "already_queued": [{"id": "...", "entity_type": "...", "entity_id": "...", "summary": "...", "priority": "..."}],
  "counts": {"faults": 0, "work_orders": 0, "parts": 0, "orders": 0, "already_queued": 0}
}
```

## Test plan
- [x] `test_handover_queue_200_all_sections` — all 5 sections populated with correct data
- [x] `test_handover_queue_200_empty_arrays_not_null` — empty tables → `[]`, never `null`
- [x] `test_handover_queue_200_include_filter` — `?include=faults` only returns faults
- [x] `test_handover_queue_401_no_token` — missing auth → 401
- [ ] Live Docker test: `curl -H "Authorization: Bearer <token>" http://localhost:8000/v1/handover/queue`

## For FRONTEND02
This endpoint is ready for the Queue tab at `/handover-export`. Use `?include[]=faults&include[]=work_orders` etc. to fetch only needed sections.

🤖 Generated with [Claude Code](https://claude.com/claude-code)