### PR TITLE
fix: HandoverQueueView wired to real endpoint schema

### DIFF
--- a/apps/web/src/components/handover/HandoverQueueView.tsx
+++ b/apps/web/src/components/handover/HandoverQueueView.tsx
@@ -7,10 +7,7 @@
  *   Open Faults / Overdue Work Orders / Low Stock Parts / Pending Orders
  *
  * Each row has an "Add to draft" button. Items already in handover_items
- * (already_queued) show a checkmark instead.
- *
- * The endpoint is mocked while ENGINEER02 ships it. The component handles
- * 404 gracefully with an "endpoint not yet available" empty state.
+ * (already_queued[].entity_id) show a checkmark instead.
  */
 
 import * as React from 'react';
@@ -35,6 +32,10 @@ interface SectionConfig {
   accentVar: string;
   bgVar: string;
   entityType: string;
+  /** Returns the primary display label for an item in this section */
+  getLabel: (item: HandoverQueueItem) => string;
+  /** Returns secondary meta text, or null to hide the meta row */
+  getMeta: (item: HandoverQueueItem) => string | null;
 }
 
 const SECTIONS: SectionConfig[] = [
@@ -45,6 +46,8 @@ const SECTIONS: SectionConfig[] = [
     accentVar: 'var(--red)',
     bgVar: 'var(--red-bg)',
     entityType: 'fault',
+    getLabel: (item) => item.title || 'Untitled fault',
+    getMeta: (item) => [item.severity, item.equipment_name].filter(Boolean).join(' · ') || null,
   },
   {
     key: 'overdue_work_orders',
@@ -53,6 +56,13 @@ const SECTIONS: SectionConfig[] = [
     accentVar: 'var(--amber)',
     bgVar: 'var(--amber-bg)',
     entityType: 'work_order',
+    getLabel: (item) => item.title || 'Untitled work order',
+    getMeta: (item) => {
+      const parts: string[] = [];
+      if (item.priority) parts.push(item.priority.replace(/_/g, ' '));
+      if (item.due_at) parts.push(`due ${new Date(item.due_at).toLocaleDateString()}`);
+      return parts.join(' · ') || null;
+    },
   },
   {
     key: 'low_stock_parts',
@@ -61,6 +71,10 @@ const SECTIONS: SectionConfig[] = [
     accentVar: 'var(--mark)',
     bgVar: 'var(--teal-bg)',
     entityType: 'part',
+    getLabel: (item) => item.name || 'Unnamed part',
+    getMeta: (item) => item.current_qty !== undefined
+      ? `${item.current_qty} on hand · min ${item.reorder_threshold ?? 0}`
+      : null,
   },
   {
     key: 'pending_orders',
@@ -69,6 +83,8 @@ const SECTIONS: SectionConfig[] = [
     accentVar: 'var(--txt2)',
     bgVar: 'var(--neutral-bg)',
     entityType: 'purchase_order',
+    getLabel: (item) => item.title || 'Untitled order',
+    getMeta: (item) => item.status?.replace(/_/g, ' ') || null,
   },
 ];
 
@@ -106,11 +122,11 @@ function QueueSection({
   items: HandoverQueueItem[];
   alreadyQueued: Set<string>;
   loading: boolean;
-  onAdd: (item: HandoverQueueItem, entityType: string) => Promise<void>;
+  onAdd: (item: HandoverQueueItem, entityType: string, label: string) => Promise<void>;
   addingId: string | null;
 }) {
   const [expanded, setExpanded] = React.useState(true);
-  const { Icon, label, accentVar, bgVar, key } = config;
+  const { Icon, label, accentVar, bgVar } = config;
   const count = items.length;
 
   return (
@@ -172,12 +188,14 @@ function QueueSection({
               No items in this category
             </div>
           ) : (
-            items.map((item, idx) => {
-              const queued = alreadyQueued.has(item.entity_id);
-              const adding = addingId === item.entity_id;
+            items.map((item) => {
+              const queued = alreadyQueued.has(item.id);
+              const adding = addingId === item.id;
+              const itemLabel = config.getLabel(item);
+              const itemMeta = config.getMeta(item);
               return (
                 <div
-                  key={item.entity_id}
+                  key={item.id}
                   style={{
                     display: 'flex', alignItems: 'center', gap: 10,
                     padding: '10px 14px',
@@ -194,36 +212,22 @@ function QueueSection({
                       fontSize: 13, fontWeight: 500, color: 'var(--txt)',
                       whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis',
                     }}>
-                      {item.ref && (
-                        <span style={{ fontFamily: 'var(--font-mono)', fontSize: 10, color: 'var(--txt3)', marginRight: 6 }}>
-                          {item.ref}
-                        </span>
-                      )}
-                      {item.title}
+                      {itemLabel}
                     </div>
-                    <div style={{
-                      marginTop: 2, display: 'flex', alignItems: 'center', gap: 8,
-                      fontSize: 10, fontFamily: 'var(--font-mono)', color: 'var(--txt3)',
-                    }}>
-                      {item.status && (
-                        <span style={{
-                          padding: '1px 6px', borderRadius: 3,
-                          background: 'var(--neutral-bg)', color: 'var(--txt3)',
-                          border: '1px solid var(--border-sub)',
-                          fontSize: 9, fontWeight: 600, letterSpacing: '0.04em',
-                          textTransform: 'uppercase',
-                        }}>
-                          {item.status.replace(/_/g, ' ')}
-                        </span>
-                      )}
-                      {item.age_display && <span>{item.age_display}</span>}
-                    </div>
+                    {itemMeta && (
+                      <div style={{
+                        marginTop: 2, fontSize: 10, fontFamily: 'var(--font-mono)',
+                        color: 'var(--txt3)', whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis',
+                      }}>
+                        {itemMeta}
+                      </div>
+                    )}
                   </div>
 
                   {/* Add button */}
                   <button
                     disabled={queued || adding}
-                    onClick={() => onAdd(item, config.entityType)}
+                    onClick={() => onAdd(item, config.entityType, itemLabel)}
                     style={{
                       display: 'flex', alignItems: 'center', gap: 5,
                       padding: '5px 10px', borderRadius: 5,
@@ -279,15 +283,11 @@ export function HandoverQueueView() {
     try {
       const result = await fetchHandoverQueue(vesselId);
       setData(result);
-      setAlreadyQueued(new Set(result.already_queued));
+      // Build set of entity_ids already in the handover draft
+      setAlreadyQueued(new Set(result.already_queued.map(q => q.entity_id)));
     } catch (err: unknown) {
       const msg = err instanceof Error ? err.message : 'Failed to load queue';
-      // 404 means endpoint not yet deployed — show graceful message
-      if (msg.includes('404') || msg.includes('not found')) {
-        setError('endpoint_pending');
-      } else {
-        setError(msg);
-      }
+      setError(msg);
     } finally {
       setLoading(false);
     }
@@ -295,9 +295,9 @@ export function HandoverQueueView() {
 
   React.useEffect(() => { load(); }, [load]);
 
-  const handleAdd = React.useCallback(async (item: HandoverQueueItem, entityType: string) => {
+  const handleAdd = React.useCallback(async (item: HandoverQueueItem, entityType: string, entityLabel: string) => {
     if (!user?.id || !vesselId) return;
-    setAddingId(item.entity_id);
+    setAddingId(item.id);
     try {
       const { data: sessionData } = await supabase.auth.getSession();
       const token = sessionData?.session?.access_token;
@@ -310,9 +310,9 @@ export function HandoverQueueView() {
           action: 'add_to_handover',
           context: { yacht_id: vesselId },
           payload: {
-            entity_id: item.entity_id,
+            entity_id: item.id,
             entity_type: entityType,
-            summary: item.title,
+            summary: entityLabel,
             category: 'standard',
           },
         }),
@@ -322,7 +322,7 @@ export function HandoverQueueView() {
         throw new Error(errBody?.message || `Failed (${res.status})`);
       }
       // Optimistic update
-      setAlreadyQueued(prev => new Set([...prev, item.entity_id]));
+      setAlreadyQueued(prev => new Set([...prev, item.id]));
       toast.success('Added to handover draft');
     } catch (err) {
       toast.error(err instanceof Error ? err.message : 'Failed to add to draft');
@@ -330,21 +330,6 @@ export function HandoverQueueView() {
       setAddingId(null);
     }
   }, [user?.id, vesselId]);
-
-  if (error === 'endpoint_pending') {
-    return (
-      <div style={{
-        display: 'flex', flexDirection: 'column', alignItems: 'center',
-        justifyContent: 'center', padding: '60px 24px', textAlign: 'center', gap: 8,
-      }}>
-        <Loader2 size={28} style={{ color: 'var(--txt-ghost)', marginBottom: 4 }} />
-        <div style={{ fontSize: 14, fontWeight: 500, color: 'var(--txt2)' }}>Queue endpoint deploying</div>
-        <div style={{ fontSize: 12, color: 'var(--txt-ghost)', maxWidth: 320 }}>
-          The handover queue endpoint is being deployed. Once available, this view will automatically populate with open faults, overdue work orders, and more.
-        </div>
-      </div>
-    );
-  }
 
   if (error) {
     return (

--- a/apps/web/src/components/handover/__tests__/HandoverQueueView.test.tsx
+++ b/apps/web/src/components/handover/__tests__/HandoverQueueView.test.tsx
@@ -2,11 +2,9 @@
  * HandoverQueueView unit tests
  *
  * Tests cover:
- * - Loading skeleton renders per section
  * - Sections render with items from mocked queue response
  * - "No items" empty state per section
  * - "Already added" state shows checkmark
- * - Endpoint-pending graceful state (404 response)
  * - Error + retry state
  */
 
@@ -47,25 +45,25 @@ const EMPTY_QUEUE = {
   low_stock_parts: [],
   pending_orders: [],
   already_queued: [],
-  counts: { open_faults: 0, overdue_work_orders: 0, low_stock_parts: 0, pending_orders: 0, total: 0 },
+  counts: { faults: 0, work_orders: 0, parts: 0, orders: 0, already_queued: 0 },
 };
 
 const QUEUE_WITH_ITEMS = {
   open_faults: [
-    { id: 'f1', entity_type: 'fault', entity_id: 'fault-01', title: 'Port engine vibration', ref: 'F-0061', status: 'open', age_display: '3d' },
+    { id: 'fault-01', title: 'Port engine vibration', severity: 'high', equipment_name: 'Port Engine', created_at: '2026-04-01T00:00:00Z' },
   ],
   overdue_work_orders: [
-    { id: 'w1', entity_type: 'work_order', entity_id: 'wo-01', title: 'Engine mount replacement', ref: 'WO-441', status: 'overdue' },
+    { id: 'wo-01', title: 'Engine mount replacement', priority: 'urgent', due_at: '2026-03-28T00:00:00Z', assigned_to: 'John' },
   ],
   low_stock_parts: [],
   pending_orders: [],
   already_queued: [],
-  counts: { open_faults: 1, overdue_work_orders: 1, low_stock_parts: 0, pending_orders: 0, total: 2 },
+  counts: { faults: 1, work_orders: 1, parts: 0, orders: 0, already_queued: 0 },
 };
 
 const QUEUE_WITH_QUEUED = {
   ...QUEUE_WITH_ITEMS,
-  already_queued: ['fault-01'],
+  already_queued: [{ id: 'qi-01', entity_type: 'fault', entity_id: 'fault-01', summary: 'Port engine vibration' }],
 };
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
@@ -100,12 +98,12 @@ describe('HandoverQueueView — sections render', () => {
     });
   });
 
-  it('renders ref codes alongside item titles', async () => {
+  it('renders meta text alongside item titles', async () => {
     mockFetchHandoverQueue.mockResolvedValue(QUEUE_WITH_ITEMS);
     await act(async () => { await renderView(); });
     await waitFor(() => {
-      expect(screen.getByText('F-0061')).toBeInTheDocument();
-      expect(screen.getByText('WO-441')).toBeInTheDocument();
+      // Fault meta: severity · equipment_name
+      expect(screen.getByText(/high.*Port Engine/i)).toBeInTheDocument();
     });
   });
 });
@@ -134,15 +132,7 @@ describe('HandoverQueueView — already queued', () => {
 });
 
 describe('HandoverQueueView — error states', () => {
-  it('shows endpoint-pending message on 404 response', async () => {
-    mockFetchHandoverQueue.mockRejectedValue(new Error('API 404: Not Found'));
-    await act(async () => { await renderView(); });
-    await waitFor(() => {
-      expect(screen.getByText('Queue endpoint deploying')).toBeInTheDocument();
-    });
-  });
-
-  it('shows retry button on non-404 error', async () => {
+  it('shows retry button on error', async () => {
     mockFetchHandoverQueue.mockRejectedValue(new Error('Network error'));
     await act(async () => { await renderView(); });
     await waitFor(() => {

--- a/apps/web/src/components/shell/api.ts
+++ b/apps/web/src/components/shell/api.ts
@@ -182,16 +182,29 @@ export async function fetchEmailUnreadCount(): Promise<number> {
    HANDOVER QUEUE
    ───────────────────────────────────────────── */
 
+/** Single item in a queue section. Fields vary by section type. */
 export interface HandoverQueueItem {
+  id: string;
+  title?: string;           // faults, work_orders, pending_orders
+  name?: string;            // low_stock_parts
+  severity?: string;        // faults
+  equipment_name?: string;  // faults
+  created_at?: string;      // faults, pending_orders
+  priority?: string;        // work_orders
+  due_at?: string;          // work_orders
+  assigned_to?: string;     // work_orders
+  current_qty?: number;     // low_stock_parts
+  reorder_threshold?: number; // low_stock_parts
+  status?: string;          // pending_orders
+}
+
+/** An entity already added to the active handover draft */
+export interface HandoverQueuedItem {
   id: string;
   entity_type: string;
   entity_id: string;
-  title: string;
-  ref?: string;
-  status: string;
+  summary: string;
   priority?: string;
-  age_display?: string;
-  meta?: string;
 }
 
 export interface HandoverQueueResponse {
@@ -199,14 +212,13 @@ export interface HandoverQueueResponse {
   overdue_work_orders: HandoverQueueItem[];
   low_stock_parts: HandoverQueueItem[];
   pending_orders: HandoverQueueItem[];
-  /** entity_ids already added to handover_items (not yet exported) */
-  already_queued: string[];
+  already_queued: HandoverQueuedItem[];
   counts: {
-    open_faults: number;
-    overdue_work_orders: number;
-    low_stock_parts: number;
-    pending_orders: number;
-    total: number;
+    faults: number;
+    work_orders: number;
+    parts: number;
+    orders: number;
+    already_queued: number;
   };
 }
 


### PR DESCRIPTION
## Summary

- **Real endpoint live** (PR #482 merged) — removes 404 graceful path
- **Types updated**: `HandoverQueueItem` now has section-specific fields (`severity`, `equipment_name`, `due_at`, `current_qty`, `reorder_threshold`); `HandoverQueuedItem` is a new interface for the `already_queued` array (was `string[]`)
- **alreadyQueued set**: now built from `already_queued[].entity_id` (not raw strings)
- **handleAdd fixed**: sends `item.id` as `entity_id` and computed `getLabel()` as `summary`
- **Per-section display**: `SectionConfig` gains `getLabel`/`getMeta` helpers so each section renders correct fields (fault shows severity · equipment, WO shows priority · due date, part shows qty/threshold, order shows status)
- **Tests**: fixtures updated to real field shapes, 404 test removed, 6/6 passing

## Test plan

- [ ] Queue tab at /handover-export loads four sections with real data from GET /v1/handover/queue
- [ ] Open Faults shows title + severity/equipment meta
- [ ] Overdue Work Orders shows title + priority/due date meta
- [ ] Low Stock Parts shows name + qty/threshold meta
- [ ] Pending Orders shows title + status meta
- [ ] "Add" button fires add_to_handover → item moves to "Added" state optimistically
- [ ] After add, item appears in Draft tab (handover_items written via action)
- [ ] `npx vitest run src/components/handover/__tests__/HandoverQueueView.test.tsx` passes 6/6

🤖 Generated with [Claude Code](https://claude.com/claude-code)