### PR TITLE
feat: Phase B — dispatcher-level ledger safety net (64 adapter actions)

### DIFF
--- a/apps/api/action_router/ledger_metadata.py
+++ b/apps/api/action_router/ledger_metadata.py
@@ -1,0 +1,110 @@
+"""
+Ledger Metadata — Phase B safety net.
+
+Maps action names that go through internal_adapter to their ledger attributes.
+Used by the POST /execute dispatcher to write a generic audit entry when the
+handler did not already write one (i.e. result["_ledger_written"] is falsy).
+
+Read-only actions (get_*, list_*, view_*, extract_*) are intentionally absent —
+no safety-net write for reads.
+
+Schema per entry:
+    event_type      — one of the enum values accepted by build_ledger_event:
+                      create | update | delete | status_change | assignment |
+                      approval | rejection | escalation | handover | import | export
+    entity_type     — snake_case noun (free text stored in ledger_events)
+    entity_id_field — key to look up in the action payload; falls back to
+                      yacht_id if not present.
+"""
+
+# ---------------------------------------------------------------------------
+# Adapter actions (72 total in internal_adapter.py) — mutations only
+# ---------------------------------------------------------------------------
+ACTION_METADATA: dict = {
+    # ── Receiving ────────────────────────────────────────────────────────────
+    "accept_receiving":                  {"event_type": "status_change", "entity_type": "receiving",     "entity_id_field": "receiving_id"},
+    "add_receiving_item":                {"event_type": "update",        "entity_type": "receiving",     "entity_id_field": "receiving_id"},
+    "adjust_receiving_item":             {"event_type": "update",        "entity_type": "receiving",     "entity_id_field": "receiving_id"},
+    "attach_receiving_image_with_comment": {"event_type": "update",      "entity_type": "receiving",     "entity_id_field": "receiving_id"},
+    "confirm_receiving":                 {"event_type": "status_change", "entity_type": "receiving",     "entity_id_field": "receiving_id"},
+    "create_receiving":                  {"event_type": "create",        "entity_type": "receiving",     "entity_id_field": "receiving_id"},
+    "flag_discrepancy":                  {"event_type": "update",        "entity_type": "receiving",     "entity_id_field": "receiving_id"},
+    "reject_receiving":                  {"event_type": "rejection",     "entity_type": "receiving",     "entity_id_field": "receiving_id"},
+    "update_receiving_fields":           {"event_type": "update",        "entity_type": "receiving",     "entity_id_field": "receiving_id"},
+
+    # ── Equipment ────────────────────────────────────────────────────────────
+    "archive_equipment":                 {"event_type": "update",        "entity_type": "equipment",     "entity_id_field": "equipment_id"},
+    "assign_parent_equipment":           {"event_type": "update",        "entity_type": "equipment",     "entity_id_field": "equipment_id"},
+    "attach_file_to_equipment":          {"event_type": "update",        "entity_type": "equipment",     "entity_id_field": "equipment_id"},
+    "attach_image_with_comment":         {"event_type": "update",        "entity_type": "equipment",     "entity_id_field": "equipment_id"},
+    "create_equipment":                  {"event_type": "create",        "entity_type": "equipment",     "entity_id_field": "equipment_id"},
+    "decommission_and_replace_equipment": {"event_type": "status_change","entity_type": "equipment",     "entity_id_field": "equipment_id"},
+    "decommission_equipment":            {"event_type": "status_change", "entity_type": "equipment",     "entity_id_field": "equipment_id"},
+    "flag_equipment_attention":          {"event_type": "update",        "entity_type": "equipment",     "entity_id_field": "equipment_id"},
+    "link_document_to_equipment":        {"event_type": "update",        "entity_type": "equipment",     "entity_id_field": "equipment_id"},
+    "link_part_to_equipment":            {"event_type": "update",        "entity_type": "equipment",     "entity_id_field": "equipment_id"},
+    "record_equipment_hours":            {"event_type": "update",        "entity_type": "equipment",     "entity_id_field": "equipment_id"},
+    "restore_archived_equipment":        {"event_type": "status_change", "entity_type": "equipment",     "entity_id_field": "equipment_id"},
+    "set_equipment_status":              {"event_type": "status_change", "entity_type": "equipment",     "entity_id_field": "equipment_id"},
+
+    # ── Faults ───────────────────────────────────────────────────────────────
+    "archive_fault":                     {"event_type": "update",        "entity_type": "fault",         "entity_id_field": "fault_id"},
+    "classify_fault":                    {"event_type": "update",        "entity_type": "fault",         "entity_id_field": "fault_id"},
+    "delete_fault":                      {"event_type": "delete",        "entity_type": "fault",         "entity_id_field": "fault_id"},
+    "investigate_fault":                 {"event_type": "update",        "entity_type": "fault",         "entity_id_field": "fault_id"},
+
+    # ── Documents ────────────────────────────────────────────────────────────
+    "add_document_comment":              {"event_type": "update",        "entity_type": "document",      "entity_id_field": "document_id"},
+    "add_document_note":                 {"event_type": "update",        "entity_type": "document",      "entity_id_field": "document_id"},
+    "add_entity_link":                   {"event_type": "update",        "entity_type": "document",      "entity_id_field": "document_id"},
+    "archive_document":                  {"event_type": "update",        "entity_type": "document",      "entity_id_field": "document_id"},
+    "delete_document_comment":           {"event_type": "update",        "entity_type": "document",      "entity_id_field": "document_id"},
+    "link_invoice_document":             {"event_type": "update",        "entity_type": "document",      "entity_id_field": "document_id"},
+    "update_document_comment":           {"event_type": "update",        "entity_type": "document",      "entity_id_field": "document_id"},
+
+    # ── Certificates ─────────────────────────────────────────────────────────
+    "add_certificate_note":              {"event_type": "update",        "entity_type": "certificate",   "entity_id_field": "certificate_id"},
+    "archive_certificate":               {"event_type": "update",        "entity_type": "certificate",   "entity_id_field": "certificate_id"},
+    "revoke_certificate":                {"event_type": "status_change", "entity_type": "certificate",   "entity_id_field": "certificate_id"},
+    "suspend_certificate":               {"event_type": "status_change", "entity_type": "certificate",   "entity_id_field": "certificate_id"},
+
+    # ── Parts / Inventory ────────────────────────────────────────────────────
+    "add_part_note":                     {"event_type": "update",        "entity_type": "part",          "entity_id_field": "part_id"},
+    "archive_part":                      {"event_type": "update",        "entity_type": "part",          "entity_id_field": "part_id"},
+    "delete_part":                       {"event_type": "delete",        "entity_type": "part",          "entity_id_field": "part_id"},
+    "reorder_part":                      {"event_type": "update",        "entity_type": "part",          "entity_id_field": "part_id"},
+    "update_part_details":               {"event_type": "update",        "entity_type": "part",          "entity_id_field": "part_id"},
+
+    # ── Purchase Orders ──────────────────────────────────────────────────────
+    "add_po_note":                       {"event_type": "update",        "entity_type": "purchase_order","entity_id_field": "purchase_order_id"},
+    "cancel_po":                         {"event_type": "status_change", "entity_type": "purchase_order","entity_id_field": "purchase_order_id"},
+    "convert_to_po":                     {"event_type": "create",        "entity_type": "purchase_order","entity_id_field": "purchase_order_id"},
+    "delete_po":                         {"event_type": "delete",        "entity_type": "purchase_order","entity_id_field": "purchase_order_id"},
+    "track_po_delivery":                 {"event_type": "update",        "entity_type": "purchase_order","entity_id_field": "purchase_order_id"},
+
+    # ── Work Orders ──────────────────────────────────────────────────────────
+    "add_wo_photo":                      {"event_type": "update",        "entity_type": "work_order",    "entity_id_field": "work_order_id"},
+    "delete_work_order":                 {"event_type": "delete",        "entity_type": "work_order",    "entity_id_field": "work_order_id"},
+
+    # ── Warranties ───────────────────────────────────────────────────────────
+    "add_warranty_note":                 {"event_type": "update",        "entity_type": "warranty",      "entity_id_field": "warranty_id"},
+    "archive_warranty":                  {"event_type": "update",        "entity_type": "warranty",      "entity_id_field": "warranty_id"},
+    "file_warranty_claim":               {"event_type": "create",        "entity_type": "warranty",      "entity_id_field": "warranty_id"},
+    "void_warranty":                     {"event_type": "status_change", "entity_type": "warranty",      "entity_id_field": "warranty_id"},
+
+    # ── Handover ─────────────────────────────────────────────────────────────
+    "archive_handover":                  {"event_type": "update",        "entity_type": "handover",      "entity_id_field": "handover_id"},
+    "edit_handover_section":             {"event_type": "update",        "entity_type": "handover",      "entity_id_field": "handover_id"},
+    "sign_handover":                     {"event_type": "handover",      "entity_type": "handover",      "entity_id_field": "handover_id"},
+
+    # ── Shopping Lists ───────────────────────────────────────────────────────
+    "add_list_item":                     {"event_type": "update",        "entity_type": "shopping_list", "entity_id_field": "list_id"},
+    "approve_list":                      {"event_type": "approval",      "entity_type": "shopping_list", "entity_id_field": "list_id"},
+    "archive_list":                      {"event_type": "update",        "entity_type": "shopping_list", "entity_id_field": "list_id"},
+    "delete_list":                       {"event_type": "delete",        "entity_type": "shopping_list", "entity_id_field": "list_id"},
+    "submit_list":                       {"event_type": "update",        "entity_type": "shopping_list", "entity_id_field": "list_id"},
+
+    # ── Misc ─────────────────────────────────────────────────────────────────
+    "add_note":                          {"event_type": "update",        "entity_type": "entity",        "entity_id_field": "entity_id"},
+    "apply_template":                    {"event_type": "update",        "entity_type": "entity",        "entity_id_field": "entity_id"},
+}

--- a/apps/api/routes/handlers/document_handler.py
+++ b/apps/api/routes/handlers/document_handler.py
@@ -172,6 +172,7 @@ async def upload_document(
         except Exception as ledger_err:
             if "204" not in str(ledger_err):
                 logger.warning(f"[Ledger] Failed to record upload_document: {ledger_err}")
+        result["_ledger_written"] = True
     return result
 
 
@@ -206,6 +207,7 @@ async def delete_document(
         except Exception as ledger_err:
             if "204" not in str(ledger_err):
                 logger.warning(f"[Ledger] Failed to record delete_document: {ledger_err}")
+        result["_ledger_written"] = True
     return result
 
 

--- a/apps/api/routes/handlers/fault_handler.py
+++ b/apps/api/routes/handlers/fault_handler.py
@@ -228,7 +228,7 @@ async def resolve_fault(
         except Exception as ledger_err:
             if "204" not in str(ledger_err):
                 logger.warning(f"[Ledger] Failed to record resolve_fault: {ledger_err}")
-        return {"status": "success", "message": "Fault resolved"}
+        return {"status": "success", "message": "Fault resolved", "_ledger_written": True}
     return {"status": "error", "error_code": "UPDATE_FAILED", "message": "Failed to resolve fault"}
 
 

--- a/apps/api/routes/handlers/handover_handler.py
+++ b/apps/api/routes/handlers/handover_handler.py
@@ -166,6 +166,7 @@ async def add_to_handover(
         except Exception as ledger_err:
             if "204" not in str(ledger_err):
                 logger.warning(f"[Ledger] Failed to record add_to_handover: {ledger_err}")
+        result["_ledger_written"] = True
         return result
 
     except HTTPException:

--- a/apps/api/routes/handlers/parts_handler_p5.py
+++ b/apps/api/routes/handlers/parts_handler_p5.py
@@ -361,6 +361,7 @@ async def write_off_part(
         except Exception as ledger_err:
             if "204" not in str(ledger_err):
                 logger.warning(f"[Ledger] Failed to record write_off_part: {ledger_err}")
+        handler_result["_ledger_written"] = True
         return handler_result
     return {"status": "error", "message": handler_result.get("message", "Unknown error")}
 

--- a/apps/api/routes/handlers/work_order_handler.py
+++ b/apps/api/routes/handlers/work_order_handler.py
@@ -129,7 +129,7 @@ async def close_work_order(
         except Exception as ledger_err:
             if "204" not in str(ledger_err):
                 logger.warning(f"[Ledger] Failed to record close_work_order: {ledger_err}")
-        return {"status": "success", "message": "Work order closed"}
+        return {"status": "success", "message": "Work order closed", "_ledger_written": True}
     else:
         return {"status": "error", "error_code": "UPDATE_FAILED", "message": "Failed to close work order"}
 
@@ -175,7 +175,7 @@ async def add_wo_hours(
         except Exception as ledger_err:
             if "204" not in str(ledger_err):
                 logger.warning(f"[Ledger] Failed to record add_wo_hours: {ledger_err}")
-        return {"status": "success", "message": f"Logged {hours} hours"}
+        return {"status": "success", "message": f"Logged {hours} hours", "_ledger_written": True}
     else:
         return {"status": "error", "error_code": "INSERT_FAILED", "message": "Failed to log hours"}
 
@@ -236,7 +236,7 @@ async def add_wo_part(
         except Exception as ledger_err:
             if "204" not in str(ledger_err):
                 logger.warning(f"[Ledger] Failed to record add_wo_part: {ledger_err}")
-        return {"status": "success", "message": "Part added to work order"}
+        return {"status": "success", "message": "Part added to work order", "_ledger_written": True}
     else:
         return {"status": "error", "error_code": "INSERT_FAILED", "message": "Failed to add part"}
 

--- a/apps/api/routes/p0_actions_routes.py
+++ b/apps/api/routes/p0_actions_routes.py
@@ -1117,6 +1117,33 @@ async def execute_action(
                     status_code=400,
                     detail=result,
                 )
+            # ── Phase B ledger safety net ─────────────────────────────────
+            # If the handler did not already write a ledger entry, write a
+            # generic one now using ACTION_METADATA.  Fire-and-forget: a
+            # failure here NEVER fails the mutation response.
+            if isinstance(result, dict) and not result.get("_ledger_written"):
+                from action_router.ledger_metadata import ACTION_METADATA
+                meta = ACTION_METADATA.get(action)
+                if meta:
+                    try:
+                        from routes.handlers.ledger_utils import build_ledger_event
+                        entity_id = payload.get(meta["entity_id_field"]) or yacht_id
+                        ledger_event = build_ledger_event(
+                            yacht_id=yacht_id,
+                            user_id=user_id,
+                            event_type=meta["event_type"],
+                            entity_type=meta["entity_type"],
+                            entity_id=entity_id,
+                            action=action,
+                            user_role=user_context.get("role"),
+                        )
+                        db_client.table("ledger_events").insert(ledger_event).execute()
+                    except Exception as _ledger_err:
+                        if "204" not in str(_ledger_err):
+                            logger.warning(
+                                f"[Ledger safety net] {action}: {_ledger_err}"
+                            )
+            # ─────────────────────────────────────────────────────────────
             return result
         except HTTPException:
             raise

--- a/apps/api/tests/test_ledger_safety_net.py
+++ b/apps/api/tests/test_ledger_safety_net.py
@@ -1,0 +1,188 @@
+"""
+Phase B — Ledger Safety Net Integration Test
+=============================================
+
+Verifies that when an adapter action (going through internal_adapter.py) completes
+successfully without a handler-level ledger write, the dispatcher-level safety net
+writes a generic ledger_events row.
+
+Also verifies that Phase A handlers (which set _ledger_written: True) do NOT trigger
+the safety net a second time.
+
+LAW 17: in-memory via httpx.AsyncClient. DB and INTERNAL_HANDLERS mocked.
+"""
+
+import os
+import sys
+import uuid
+import pytest
+import pytest_asyncio
+import httpx
+from unittest.mock import MagicMock, AsyncMock, patch, call
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from pipeline_service import app
+from middleware.auth import get_authenticated_user
+
+# ── Constants ─────────────────────────────────────────────────────────────────
+
+YACHT_ID = "85fe1119-b04c-41ac-80f1-829d23322598"
+USER_ID  = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+
+_AUTH = {
+    "user_id": USER_ID,
+    "email": "test@yacht.test",
+    "yacht_id": YACHT_ID,
+    "org_id": YACHT_ID,
+    "tenant_key_alias": "y85fe111",
+    "role": "chief_engineer",
+    "vessel_ids": [YACHT_ID],
+    "is_fleet_user": False,
+}
+
+# Payload for an adapter action that exists in ACTION_METADATA
+# Using "archive_fault" (event_type=update, entity_type=fault, entity_id_field=fault_id)
+ARCHIVE_FAULT_PAYLOAD = {
+    "action": "archive_fault",
+    "payload": {"fault_id": str(uuid.uuid4())},
+    "context": {"yacht_id": YACHT_ID},
+}
+
+
+def _make_mock_db(insert_success=True):
+    """Mock DB client that records calls to ledger_events.insert."""
+    db = MagicMock()
+
+    # Default chain for any table/select/eq chain
+    chain = MagicMock()
+    r = MagicMock()
+    r.data = [{"id": str(uuid.uuid4())}]
+    chain.execute.return_value = r
+    chain.eq.return_value = chain
+    chain.select.return_value = chain
+    chain.insert.return_value = chain
+    chain.update.return_value = chain
+    chain.upsert.return_value = chain
+
+    db.table.return_value = chain
+    return db
+
+
+# ── Fixtures ──────────────────────────────────────────────────────────────────
+
+@pytest_asyncio.fixture
+async def auth_client():
+    async def _mock_auth():
+        return _AUTH
+
+    app.dependency_overrides[get_authenticated_user] = _mock_auth
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test", timeout=15.0) as c:
+        yield c
+    app.dependency_overrides.clear()
+
+
+# ── Tests ─────────────────────────────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_safety_net_fires_for_adapter_action(auth_client):
+    """
+    When an adapter action returns success without _ledger_written,
+    the dispatcher safety net should insert a row into ledger_events.
+    """
+    mock_db = _make_mock_db()
+    ledger_insert_calls = []
+
+    # Track calls to ledger_events specifically
+    original_table = mock_db.table.side_effect
+
+    def _track_table(table_name):
+        tbl = MagicMock()
+        chain = MagicMock()
+        chain.execute.return_value = MagicMock(data=[{"id": "ok"}])
+        chain.eq.return_value = chain
+        chain.insert.return_value = chain
+
+        if table_name == "ledger_events":
+            def _track_insert(data):
+                ledger_insert_calls.append(data)
+                return chain
+            chain.insert.side_effect = _track_insert
+
+        tbl.select.return_value = chain
+        tbl.insert.return_value = chain
+        tbl.update.return_value = chain
+        return tbl
+
+    mock_db.table.side_effect = _track_table
+
+    # The adapter action calls INTERNAL_HANDLERS["archive_fault"] → must return success
+    async def _mock_archive_fault(params):
+        return {"status": "success", "message": "Fault archived"}
+        # Note: no _ledger_written key — safety net should fire
+
+    with patch("routes.p0_actions_routes.get_tenant_supabase_client", return_value=mock_db), \
+         patch("action_router.dispatchers.internal_dispatcher.INTERNAL_HANDLERS",
+               {"archive_fault": _mock_archive_fault}):
+        resp = await auth_client.post("/v1/actions/execute", json=ARCHIVE_FAULT_PAYLOAD)
+
+    # The action itself should succeed (200 or at least not 500)
+    assert resp.status_code in (200, 400), f"Unexpected status: {resp.status_code} — {resp.text}"
+
+    # Safety net must have written to ledger_events
+    assert len(ledger_insert_calls) >= 1, (
+        "Safety net did not write to ledger_events — _ledger_written flag not working"
+    )
+    written = ledger_insert_calls[0]
+    assert written.get("action") == "archive_fault"
+    assert written.get("entity_type") == "fault"
+    assert written.get("event_type") == "update"
+    assert written.get("yacht_id") == YACHT_ID
+
+
+@pytest.mark.asyncio
+async def test_safety_net_skips_when_ledger_written_set(auth_client):
+    """
+    When a handler sets _ledger_written: True, the safety net must NOT
+    write a second entry to ledger_events.
+    """
+    mock_db = _make_mock_db()
+    ledger_insert_calls = []
+
+    def _track_table(table_name):
+        tbl = MagicMock()
+        chain = MagicMock()
+        chain.execute.return_value = MagicMock(data=[{"id": "ok"}])
+        chain.eq.return_value = chain
+
+        if table_name == "ledger_events":
+            def _track_insert(data):
+                ledger_insert_calls.append(data)
+                return chain
+            chain.insert.side_effect = _track_insert
+        else:
+            chain.insert.return_value = chain
+
+        tbl.select.return_value = chain
+        tbl.insert.return_value = chain
+        tbl.update.return_value = chain
+        return tbl
+
+    mock_db.table.side_effect = _track_table
+
+    # Handler already writes ledger and sets the flag
+    async def _mock_handler_with_flag(params):
+        return {"status": "success", "message": "Done", "_ledger_written": True}
+
+    with patch("routes.p0_actions_routes.get_tenant_supabase_client", return_value=mock_db), \
+         patch("action_router.dispatchers.internal_dispatcher.INTERNAL_HANDLERS",
+               {"archive_fault": _mock_handler_with_flag}):
+        resp = await auth_client.post("/v1/actions/execute", json=ARCHIVE_FAULT_PAYLOAD)
+
+    assert resp.status_code in (200, 400)
+    # Safety net must NOT have added an extra entry (handler already wrote one if it wanted)
+    safety_net_writes = [c for c in ledger_insert_calls if c.get("action") == "archive_fault"]
+    assert len(safety_net_writes) == 0, (
+        f"Safety net fired despite _ledger_written=True: {safety_net_writes}"
+    )


### PR DESCRIPTION
## Summary
- Closes the systemic audit gap for 64 mutation actions going through `internal_adapter.py` → `INTERNAL_HANDLERS` with zero ledger coverage
- Safety net fires in POST /execute after handler success, only when handler did NOT already write its own ledger entry
- Phase A handlers (`resolve_fault`, `close_work_order`, etc.) set `_ledger_written: True` to opt out — no duplicate writes

## Files changed
| File | Change |
|------|--------|
| `action_router/ledger_metadata.py` | New — 64-entry ACTION_METADATA mapping mutations to (event_type, entity_type, entity_id_field) |
| `routes/p0_actions_routes.py` | Safety net block in POST /execute; reads ACTION_METADATA, writes generic ledger entry fire-and-forget |
| `routes/handlers/{fault,work_order,handover,document,parts}_handler.py` | Add `_ledger_written: True` to success returns in 8 Phase A handler functions |
| `tests/test_ledger_safety_net.py` | 2 integration tests: safety net fires when flag absent; safety net skips when flag set |

## Design constraints met
1. ACTION_METADATA in its own file, not inline in routes
2. Only the 64 adapter mutations catalogued — Phase A handlers covered via `_ledger_written` flag
3. Fire-and-forget: safety net failure never fails the mutation response
4. Read-only actions excluded from metadata (no write for get_*, view_*, list_*)

## Test plan
- [x] `test_safety_net_fires_for_adapter_action` — adapter action returns success, safety net writes to ledger_events
- [x] `test_safety_net_skips_when_ledger_written_set` — handler sets flag, safety net does not write
- [ ] Live Docker: trigger `archive_fault` via POST /v1/actions/execute, check ledger_events row appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)