### PR TITLE
fix: Activity Log in hamburger menu + handover queue 404

### DIFF
--- a/apps/web/src/components/shell/AppShell.tsx
+++ b/apps/web/src/components/shell/AppShell.tsx
@@ -27,6 +27,7 @@ import { useBreakpoint } from './useBreakpoint';
 import SettingsModal from '@/components/SettingsModal';
 import { CreateWorkOrderModal } from '@/components/actions/modals/CreateWorkOrderModal';
 import { ReportFaultModal } from '@/components/modals/ReportFaultModal';
+import { LedgerPanel } from '@/components/ledger';
 
 /** Map URL pathnames to domain IDs */
 const PATH_TO_DOMAIN: Record<string, DomainId> = {
@@ -126,6 +127,8 @@ export function AppShell({ children }: AppShellProps) {
   const [searchOpen, setSearchOpen] = React.useState(false);
   // Settings modal state (rendered here, not inside SpotlightSearch)
   const [settingsOpen, setSettingsOpen] = React.useState(false);
+  // Ledger panel state
+  const [ledgerOpen, setLedgerOpen] = React.useState(false);
   // Create modal state for primary action buttons
   const [createWOOpen, setCreateWOOpen] = React.useState(false);
   const [reportFaultOpen, setReportFaultOpen] = React.useState(false);
@@ -168,7 +171,7 @@ export function AppShell({ children }: AppShellProps) {
         onClearScope={handleClearScope}
         onSearchFocus={() => setSearchOpen(true)}
         onEmailClick={handleEmailClick}
-        onCommandCenterClick={() => setSearchOpen(true)}
+        onLedgerClick={() => setLedgerOpen(true)}
         onSettingsClick={handleSettingsClick}
         onPrimaryAction={handlePrimaryAction}
       >
@@ -176,6 +179,7 @@ export function AppShell({ children }: AppShellProps) {
       </AppShellInner>
       <SearchOverlay open={searchOpen} onClose={() => setSearchOpen(false)} />
       <SettingsModal isOpen={settingsOpen} onClose={() => setSettingsOpen(false)} />
+      <LedgerPanel isOpen={ledgerOpen} onClose={() => setLedgerOpen(false)} />
       <CreateWorkOrderModal open={createWOOpen} onOpenChange={setCreateWOOpen} />
       <ReportFaultModal open={reportFaultOpen} onOpenChange={setReportFaultOpen} />
     </ShellProvider>
@@ -192,7 +196,7 @@ function AppShellInner({
   onClearScope,
   onSearchFocus,
   onEmailClick,
-  onCommandCenterClick,
+  onLedgerClick,
   onSettingsClick,
   onPrimaryAction,
   children,
@@ -205,7 +209,7 @@ function AppShellInner({
   onClearScope: () => void;
   onSearchFocus: () => void;
   onEmailClick: () => void;
-  onCommandCenterClick: () => void;
+  onLedgerClick: () => void;
   onSettingsClick: () => void;
   onPrimaryAction: () => void;
   children: React.ReactNode;
@@ -263,7 +267,7 @@ function AppShellInner({
         onClearScope={onClearScope}
         onSearchFocus={onSearchFocus}
         onEmailClick={onEmailClick}
-        onCommandCenterClick={onCommandCenterClick}
+        onLedgerClick={onLedgerClick}
         onSettingsClick={onSettingsClick}
         compact={breakpoint === 'tablet' || breakpoint === 'mobile'}
         showNavToggle={isMobile}

--- a/apps/web/src/components/shell/Topbar.tsx
+++ b/apps/web/src/components/shell/Topbar.tsx
@@ -14,7 +14,7 @@
  */
 
 import * as React from 'react';
-import { Search, X, Menu, LogOut, User, Settings, LayoutGrid } from 'lucide-react';
+import { Search, X, Menu, LogOut, User, Settings, ScrollText } from 'lucide-react';
 import { useRouter } from 'next/navigation';
 import { useAuth } from '@/hooks/useAuth';
 import { useActiveVessel } from '@/contexts/VesselContext';
@@ -33,8 +33,8 @@ interface TopbarProps {
   onMenuClick?: () => void;
   /** Called when Email is selected from the menu */
   onEmailClick?: () => void;
-  /** Called when Command Center is selected from the menu */
-  onCommandCenterClick?: () => void;
+  /** Called when Activity Log (Ledger) is selected from the menu */
+  onLedgerClick?: () => void;
   /** Called when Settings is selected from the menu */
   onSettingsClick?: () => void;
   /** Compact mode: hide vessel name, separators, role badge */
@@ -52,7 +52,7 @@ export function Topbar({
   onSearchFocus,
   onMenuClick,
   onEmailClick,
-  onCommandCenterClick,
+  onLedgerClick,
   onSettingsClick,
   compact,
   onNavToggle,
@@ -143,7 +143,7 @@ export function Topbar({
           onMouseEnter={(e) => { e.currentTarget.style.background = 'var(--surface-hover)'; }}
           onMouseLeave={(e) => { e.currentTarget.style.background = 'transparent'; }}
         >
-          <LayoutGrid style={{ width: 14, height: 14 }} />
+          <Menu style={{ width: 14, height: 14 }} />
         </button>
       )}
 
@@ -343,9 +343,9 @@ export function Topbar({
               </div>
             </div>
 
-            {/* Command Center */}
+            {/* Activity Log */}
             <button
-              onClick={() => { setMenuOpen(false); onCommandCenterClick?.(); }}
+              onClick={() => { setMenuOpen(false); onLedgerClick?.(); }}
               style={{
                 display: 'flex',
                 alignItems: 'center',
@@ -362,8 +362,8 @@ export function Topbar({
               onMouseEnter={(e) => { e.currentTarget.style.background = 'var(--surface-hover)'; }}
               onMouseLeave={(e) => { e.currentTarget.style.background = 'transparent'; }}
             >
-              <LayoutGrid style={{ width: 13, height: 13 }} />
-              Command Center
+              <ScrollText style={{ width: 13, height: 13 }} />
+              Activity Log
             </button>
 
             {/* Settings */}

--- a/apps/web/src/components/shell/api.ts
+++ b/apps/web/src/components/shell/api.ts
@@ -224,7 +224,7 @@ export interface HandoverQueueResponse {
 
 /** Fetch items auto-detected as relevant for next handover */
 export function fetchHandoverQueue(vesselId: string): Promise<HandoverQueueResponse> {
-  return apiFetch(`/v1/handover/queue?vessel_id=${encodeURIComponent(vesselId)}`);
+  return apiFetch(`/v1/actions/handover/queue?vessel_id=${encodeURIComponent(vesselId)}`);
 }
 
 /* ─────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Two bugs fixed:

**1. Command Center → Activity Log**
- Removed "Command Center" from the topbar hamburger dropdown (was wired to global search — wrong behaviour)
- Replaced with "Activity Log" (ScrollText icon) which opens `LedgerPanel` drawer
- `LedgerPanel` is now mounted at the AppShell level — previously it was buried inside `SpotlightSearch` with a state that was never set to true, making it permanently unreachable

**2. Handover queue 404**
- `p0_actions_routes.py` router prefix is `/v1/actions`, so the endpoint is at `/v1/actions/handover/queue` — not `/v1/handover/queue`
- Frontend was calling the wrong path. Fixed `fetchHandoverQueue` in `api.ts`

## Test plan

- [ ] Hamburger menu shows "Activity Log" (not "Command Center")
- [ ] Clicking "Activity Log" opens the LedgerPanel drawer
- [ ] `/handover-export` Queue tab no longer shows 404 error — sections populate with real data
- [ ] Settings and Sign out still work in hamburger dropdown

🤖 Generated with [Claude Code](https://claude.com/claude-code)