### PR TITLE
fix: add missing vitest imports to RelatedDrawer.test.tsx

### DIFF
--- a/apps/web/src/components/lens-v2/__tests__/RelatedDrawer.test.tsx
+++ b/apps/web/src/components/lens-v2/__tests__/RelatedDrawer.test.tsx
@@ -8,7 +8,7 @@
  * - Entity type label rendering
  */
 
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen, within, act } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import * as React from 'react';


### PR DESCRIPTION
## Summary

- `beforeEach` and `afterEach` were used in `RelatedDrawer.test.tsx` but not imported from vitest
- Caused `tsc --noEmit` to fail in CI with TS2304 errors
- Pre-existing issue, not introduced by recent PRs

## Test plan
- [ ] CI Web Frontend / TypeScript check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)