### PR TITLE
fix: 5 backend audit bugs

### DIFF
--- a/apps/api/action_router/dispatchers/internal_dispatcher.py
+++ b/apps/api/action_router/dispatchers/internal_dispatcher.py
@@ -1201,6 +1201,7 @@ async def diagnose_fault(params: Dict[str, Any]) -> Dict[str, Any]:
     fault = fault_result.data[0]
 
     return {
+        "status": "success",
         "fault_id": params["fault_id"],
         "fault": fault,
         "diagnosis": {

--- a/apps/api/routes/entity_routes.py
+++ b/apps/api/routes/entity_routes.py
@@ -748,8 +748,6 @@ async def get_work_order_entity(work_order_id: str, auth: dict = Depends(get_aut
 
         response = supabase.table('pms_work_orders').select('*').eq('id', work_order_id).eq('yacht_id', yacht_id).maybe_single().execute()
         if not response or not response.data:
-            response = supabase.table('pms_work_orders').select('*').eq('work_order_id', work_order_id).eq('yacht_id', yacht_id).maybe_single().execute()
-        if not response or not response.data:
             raise HTTPException(status_code=404, detail="Work order not found")
 
         data = response.data

--- a/apps/api/routes/handlers/internal_adapter.py
+++ b/apps/api/routes/handlers/internal_adapter.py
@@ -12,6 +12,29 @@ from typing import Any, Dict, Callable
 # It causes a circular import: internal_dispatcher → handlers → routes/handlers/__init__ → this file.
 # Instead, import lazily inside each adapter call.
 
+# Soft-delete actions require entity_type in params (for universal_handlers.soft_delete_entity).
+# The adapter must inject it since resolve_entity_context only maps entity_id → domain key.
+_SOFT_DELETE_ENTITY_TYPES: Dict[str, str] = {
+    "archive_fault": "fault",
+    "delete_fault": "fault",
+    "cancel_po": "purchase_order",
+    "delete_po": "purchase_order",
+    "archive_part": "part",
+    "delete_part": "part",
+    "archive_certificate": "certificate",
+    "suspend_certificate": "certificate",
+    "revoke_certificate": "certificate",
+    "archive_document": "document",
+    "archive_warranty": "warranty",
+    "void_warranty": "warranty",
+    "archive_list": "shopping_list",
+    "delete_list": "shopping_list",
+    "archive_handover": "handover",
+    "delete_handover": "handover",
+    "delete_work_order": "work_order",
+    "archive_equipment": "equipment",
+}
+
 
 def _make_adapter(action_id: str) -> Callable:
     """
@@ -40,6 +63,9 @@ def _make_adapter(action_id: str) -> Callable:
             **context,
             **payload,
         }
+        # Inject entity_type for soft-delete actions (soft_delete_entity requires it)
+        if action_id in _SOFT_DELETE_ENTITY_TYPES:
+            params.setdefault("entity_type", _SOFT_DELETE_ENTITY_TYPES[action_id])
         return await handler_fn(params)
 
     _adapted.__name__ = f"adapted_{action_id}"

--- a/apps/api/routes/handlers/work_order_handler.py
+++ b/apps/api/routes/handlers/work_order_handler.py
@@ -772,7 +772,10 @@ async def create_work_order_for_equipment(
     equipment_id = payload.get("equipment_id") or context.get("equipment_id")
     title = payload.get("title", "Work Order")
     description = payload.get("description", "")
-    priority = payload.get("priority", "routine")
+    priority = payload.get("priority", "medium")
+    # DB enum only has medium/high/critical — map legacy "low" and "routine" to "medium"
+    if priority in ("low", "routine"):
+        priority = "medium"
     wo_type = payload.get("type", "corrective")
     if not equipment_id:
         raise HTTPException(status_code=400, detail="equipment_id is required")

--- a/apps/api/routes/p0_actions_routes.py
+++ b/apps/api/routes/p0_actions_routes.py
@@ -2268,32 +2268,10 @@ async def get_pending_handovers_route(
     return result
 
 
-@router.get("/handover/{export_id}/verify")
-async def verify_export_route(
-    export_id: str,
-    auth: dict = Depends(get_authenticated_user)
-):
-    """Get verification data for an export."""
-    yacht_id = auth["yacht_id"]
-
-    handlers = get_handlers_for_tenant(auth["tenant_key_alias"])
-    _handover_wf = handlers.get("handover_workflow_handlers")
-    if not _handover_wf:
-        raise HTTPException(status_code=500, detail="Handover workflow handlers not initialized")
-
-    result = await _handover_wf.verify_export(
-        export_id=export_id,
-        yacht_id=yacht_id
-    )
-
-    if result.get("status") == "error":
-        raise HTTPException(status_code=404, detail=result.get("message"))
-
-    return result
-
-
 # ============================================================================
 # GET /v1/handover/queue — aggregated candidates for next handover draft
+# NOTE: MUST be declared before /{export_id}/verify — static routes must
+# precede dynamic routes in FastAPI or the dynamic pattern matches "queue".
 # ============================================================================
 
 @router.get("/handover/queue")
@@ -2412,6 +2390,30 @@ async def get_handover_queue(
             "already_queued": len(already_queued),
         },
     }
+
+
+@router.get("/handover/{export_id}/verify")
+async def verify_export_route(
+    export_id: str,
+    auth: dict = Depends(get_authenticated_user)
+):
+    """Get verification data for an export."""
+    yacht_id = auth["yacht_id"]
+
+    handlers = get_handlers_for_tenant(auth["tenant_key_alias"])
+    _handover_wf = handlers.get("handover_workflow_handlers")
+    if not _handover_wf:
+        raise HTTPException(status_code=500, detail="Handover workflow handlers not initialized")
+
+    result = await _handover_wf.verify_export(
+        export_id=export_id,
+        yacht_id=yacht_id
+    )
+
+    if result.get("status") == "error":
+        raise HTTPException(status_code=404, detail=result.get("message"))
+
+    return result
 
 
 # ============================================================================

--- a/apps/web/src/components/lens-v2/__tests__/RelatedDrawer.test.tsx
+++ b/apps/web/src/components/lens-v2/__tests__/RelatedDrawer.test.tsx
@@ -8,7 +8,7 @@
  * - Entity type label rendering
  */
 
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen, within, act } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import * as React from 'react';


### PR DESCRIPTION
## Summary

- **Route ordering**: `/handover/queue` moved before `/{export_id}/verify` — FastAPI was matching "queue" as a path param, returning 404
- **Priority enum**: `create_work_order_for_equipment` maps "low"/"routine" → "medium" — DB enum only has medium/high/critical
- **investigate_fault**: `diagnose_fault` return now includes `status: "success"` — dispatcher was treating it as unknown status
- **cancel_po entity_type**: `internal_adapter.py` now injects `entity_type` for 17 soft-delete actions — `soft_delete_entity` was receiving `entity_type=None` and raising ValueError
- **Entity work_order column**: Removed fallback `eq('work_order_id', ...)` in `GET /v1/entity/work_order/{id}` — column doesn't exist in `pms_work_orders`, PK is `id`

## Test plan

- [ ] `POST /v1/actions/execute` with `action: "archive_fault"` returns 200 (not 404)  
- [ ] `POST /v1/actions/execute` with `action: "create_work_order_for_equipment"` and `priority: "low"` inserts with `priority: "medium"`  
- [ ] `POST /v1/actions/execute` with `action: "investigate_fault"` returns `{"status": "success", ...}`  
- [ ] `POST /v1/actions/execute` with `action: "cancel_po"` and valid `purchase_order_id` returns 200 (no ValueError)  
- [ ] `GET /v1/entity/work_order/{real_id}` returns 200; missing ID returns 404 (not 500)

🤖 Generated with [Claude Code](https://claude.com/claude-code)