### PR TITLE
fix: wire AddNoteModal × 7 entities, fix phantom action IDs

### DIFF
--- a/apps/web/src/components/lens-v2/entity/CertificateContent.tsx
+++ b/apps/web/src/components/lens-v2/entity/CertificateContent.tsx
@@ -42,6 +42,7 @@ import {
   type HistoryPeriod,
 } from '../sections';
 import { ActionPopup, type ActionPopupField } from '../ActionPopup';
+import { AddNoteModal } from '@/components/lens-v2/actions/AddNoteModal';
 
 // ─── Colour mapping helpers ───
 
@@ -317,7 +318,16 @@ export function CertificateContent() {
     kind: (((a.mime_type ?? a.content_type) as string) ?? '').startsWith('image') ? 'image' as const : 'document' as const,
   }));
 
-  const handleAddNote = React.useCallback(() => {}, []);
+  const [addNoteOpen, setAddNoteOpen] = React.useState(false);
+  const handleNoteSubmit = React.useCallback(
+    async (noteText: string) => {
+      const result = await executeAction('add_certificate_note', { note_text: noteText });
+      const isSuccess = result.success === true ||
+        (result as unknown as { status?: string }).status === 'success';
+      return { success: isSuccess, error: result.error ?? result.message };
+    },
+    [executeAction]
+  );
 
   return (
     <>
@@ -400,8 +410,8 @@ export function CertificateContent() {
       <ScrollReveal>
         <NotesSection
           notes={noteItems}
-          onAddNote={handleAddNote}
-          canAddNote
+          onAddNote={addNoteAction ? () => setAddNoteOpen(true) : undefined}
+          canAddNote={!!addNoteAction}
         />
       </ScrollReveal>
 
@@ -409,7 +419,7 @@ export function CertificateContent() {
       <ScrollReveal>
         <AttachmentsSection
           attachments={attachmentItems}
-          onAddFile={() => {}}
+          onAddFile={() => {/* TODO: file upload modal (no component exists yet) */}}
           canAddFile
         />
       </ScrollReveal>
@@ -420,6 +430,12 @@ export function CertificateContent() {
           onSubmit={async (values) => { await executeAction(actionPopupConfig.actionId, values); setActionPopupConfig(null); }}
           onClose={() => setActionPopupConfig(null)} />
       )}
+      <AddNoteModal
+        open={addNoteOpen}
+        onClose={() => setAddNoteOpen(false)}
+        onSubmit={handleNoteSubmit}
+        isLoading={isLoading}
+      />
     </>
   );
 }

--- a/apps/web/src/components/lens-v2/entity/DocumentContent.tsx
+++ b/apps/web/src/components/lens-v2/entity/DocumentContent.tsx
@@ -41,6 +41,7 @@ import {
   type HistoryPeriod,
 } from '../sections';
 import { ActionPopup, type ActionPopupField } from '../ActionPopup';
+import { AddNoteModal } from '@/components/lens-v2/actions/AddNoteModal';
 
 // ─── Colour mapping helpers ───
 
@@ -117,12 +118,21 @@ export function DocumentContent() {
   const auditTrail = ((entity?.audit_trail ?? payload.audit_trail ?? entity?.audit_history ?? payload.audit_history) as Array<Record<string, unknown>> | undefined) ?? [];
 
   // ── Action gates ──
-  const createRevisionAction = getAction('create_revision');
-  const acknowledgeAction = getAction('acknowledge_document');
   const archiveAction = getAction('archive_document');
   const addNoteAction = getAction('add_document_note');
 
   // BACKEND_AUTO moved to mapActionFields.ts
+  const [addNoteOpen, setAddNoteOpen] = React.useState(false);
+  const handleNoteSubmit = React.useCallback(
+    async (noteText: string) => {
+      const result = await executeAction('add_document_note', { note_text: noteText });
+      const isSuccess = result.success === true ||
+        (result as unknown as { status?: string }).status === 'success';
+      return { success: isSuccess, error: result.error ?? result.message };
+    },
+    [executeAction]
+  );
+
   const [actionPopupConfig, setActionPopupConfig] = React.useState<{
     actionId: string; title: string; fields: ActionPopupField[]; signatureLevel: 0|1|2|3|4|5;
   } | null>(null);
@@ -433,8 +443,8 @@ export function DocumentContent() {
       <ScrollReveal>
         <NotesSection
           notes={noteItems}
-          onAddNote={addNoteAction !== null ? () => {} : undefined}
-          canAddNote
+          onAddNote={addNoteAction ? () => setAddNoteOpen(true) : undefined}
+          canAddNote={!!addNoteAction}
         />
       </ScrollReveal>
 
@@ -442,7 +452,7 @@ export function DocumentContent() {
       <ScrollReveal>
         <AttachmentsSection
           attachments={attachmentItems}
-          onAddFile={() => {}}
+          onAddFile={() => {/* TODO: file upload modal (no component exists yet) */}}
           canAddFile
         />
       </ScrollReveal>
@@ -464,6 +474,12 @@ export function DocumentContent() {
           onClose={() => setActionPopupConfig(null)}
         />
       )}
+      <AddNoteModal
+        open={addNoteOpen}
+        onClose={() => setAddNoteOpen(false)}
+        onSubmit={handleNoteSubmit}
+        isLoading={isLoading}
+      />
     </>
   );
 }

--- a/apps/web/src/components/lens-v2/entity/EquipmentContent.tsx
+++ b/apps/web/src/components/lens-v2/entity/EquipmentContent.tsx
@@ -44,6 +44,7 @@ import {
   type PartItem,
 } from '../sections';
 import { ActionPopup, type ActionPopupField } from '../ActionPopup';
+import { AddNoteModal } from '@/components/lens-v2/actions/AddNoteModal';
 
 // ─── Helpers ───
 
@@ -95,6 +96,16 @@ export function EquipmentContent() {
   const decommissionAction = getAction('decommission_equipment');
 
   // BACKEND_AUTO moved to mapActionFields.ts
+  const [addNoteOpen, setAddNoteOpen] = React.useState(false);
+  const handleNoteSubmit = React.useCallback(
+    async (noteText: string) => {
+      const result = await executeAction('add_equipment_note', { note_text: noteText });
+      const isSuccess = result.success === true ||
+        (result as unknown as { status?: string }).status === 'success';
+      return { success: isSuccess, error: result.error ?? result.message };
+    },
+    [executeAction]
+  );
 
   const [actionPopupConfig, setActionPopupConfig] = React.useState<{
     actionId: string; title: string; subtitle?: string;
@@ -423,8 +434,8 @@ export function EquipmentContent() {
       <ScrollReveal>
         <NotesSection
           notes={noteItems}
-          onAddNote={() => {}}
-          canAddNote
+          onAddNote={addNoteAction ? () => setAddNoteOpen(true) : undefined}
+          canAddNote={!!addNoteAction}
         />
       </ScrollReveal>
 
@@ -442,7 +453,7 @@ export function EquipmentContent() {
       <ScrollReveal>
         <AttachmentsSection
           attachments={attachmentItems}
-          onAddFile={() => {}}
+          onAddFile={() => {/* TODO: file upload modal (no component exists yet) */}}
           canAddFile
         />
       </ScrollReveal>
@@ -461,6 +472,12 @@ export function EquipmentContent() {
           onClose={() => setActionPopupConfig(null)}
         />
       )}
+      <AddNoteModal
+        open={addNoteOpen}
+        onClose={() => setAddNoteOpen(false)}
+        onSubmit={handleNoteSubmit}
+        isLoading={isLoading}
+      />
     </>
   );
 }

--- a/apps/web/src/components/lens-v2/entity/FaultContent.tsx
+++ b/apps/web/src/components/lens-v2/entity/FaultContent.tsx
@@ -26,6 +26,7 @@ import { ScrollReveal } from '../ScrollReveal';
 import { useEntityLensContext } from '@/contexts/EntityLensContext';
 import { getEntityRoute } from '@/lib/entityRoutes';
 import { ActionPopup, type ActionPopupField } from '../ActionPopup';
+import { AddNoteModal } from '@/components/lens-v2/actions/AddNoteModal';
 
 // Sections
 import {
@@ -312,7 +313,17 @@ export function FaultContent() {
   }));
 
   // Add note handler
-  const handleAddNote = React.useCallback(() => {}, []);
+  const [addNoteOpen, setAddNoteOpen] = React.useState(false);
+  const handleAddNote = React.useCallback(() => setAddNoteOpen(true), []);
+  const handleNoteSubmit = React.useCallback(
+    async (noteText: string) => {
+      const result = await executeAction('add_fault_note', { note_text: noteText });
+      const isSuccess = result.success === true ||
+        (result as unknown as { status?: string }).status === 'success';
+      return { success: isSuccess, error: result.error ?? result.message };
+    },
+    [executeAction]
+  );
 
   return (
     <>
@@ -411,8 +422,8 @@ export function FaultContent() {
       <ScrollReveal>
         <NotesSection
           notes={noteItems}
-          onAddNote={handleAddNote}
-          canAddNote
+          onAddNote={addNoteAction ? handleAddNote : undefined}
+          canAddNote={!!addNoteAction}
         />
       </ScrollReveal>
 
@@ -427,7 +438,7 @@ export function FaultContent() {
       <ScrollReveal>
         <AttachmentsSection
           attachments={attachmentItems}
-          onAddFile={() => {}}
+          onAddFile={() => {/* TODO: file upload modal (no component exists yet) */}}
           canAddFile
         />
       </ScrollReveal>
@@ -449,6 +460,12 @@ export function FaultContent() {
           onSubmit={async (values) => { await executeAction(actionPopupConfig.actionId, values); setActionPopupConfig(null); }}
           onClose={() => setActionPopupConfig(null)} />
       )}
+      <AddNoteModal
+        open={addNoteOpen}
+        onClose={() => setAddNoteOpen(false)}
+        onSubmit={handleNoteSubmit}
+        isLoading={isLoading}
+      />
     </>
   );
 }

--- a/apps/web/src/components/lens-v2/entity/HandoverContent.tsx
+++ b/apps/web/src/components/lens-v2/entity/HandoverContent.tsx
@@ -576,7 +576,7 @@ export function HandoverContent() {
       <ScrollReveal>
         <AttachmentsSection
           attachments={attachmentItems}
-          onAddFile={() => {}}
+          onAddFile={() => {/* TODO: file upload modal (no component exists yet) */}}
           canAddFile
         />
       </ScrollReveal>

--- a/apps/web/src/components/lens-v2/entity/HoursOfRestContent.tsx
+++ b/apps/web/src/components/lens-v2/entity/HoursOfRestContent.tsx
@@ -104,7 +104,7 @@ export function HoursOfRestContent() {
   const verified_at = (entity?.verified_at ?? payload.verified_at) as string | undefined;
 
   // -- Action gates --
-  const submitAction = getAction('submit_hours');
+  const submitAction = getAction('upsert_hours_of_rest');
   const templateAction = getAction('apply_template');
   // flag_violation removed — holds no value per user directive
 
@@ -173,12 +173,12 @@ export function HoursOfRestContent() {
   const primaryDisabledReason = canSubmit ? submitAction?.disabled_reason : undefined;
 
   const handlePrimary = React.useCallback(async () => {
-    await executeAction('submit_hours', {});
+    await executeAction('upsert_hours_of_rest', {});
   }, [executeAction]);
 
   const SPECIAL_HANDLERS: Record<string, () => void> = {};
   const DANGER_ACTIONS = new Set<string>();
-  const primaryActionId = 'submit_hours';
+  const primaryActionId = 'upsert_hours_of_rest';
 
   const dropdownItems: DropdownItem[] = availableActions
     .filter((a) => a.action_id !== primaryActionId)
@@ -438,8 +438,8 @@ export function HoursOfRestContent() {
       <ScrollReveal>
         <NotesSection
           notes={noteItems}
-          onAddNote={() => {}}
-          canAddNote
+          onAddNote={undefined}
+          canAddNote={false}
         />
       </ScrollReveal>
 
@@ -447,7 +447,7 @@ export function HoursOfRestContent() {
       <ScrollReveal>
         <AttachmentsSection
           attachments={attachmentItems}
-          onAddFile={() => {}}
+          onAddFile={() => {/* TODO: file upload modal (no component exists yet) */}}
           canAddFile
         />
       </ScrollReveal>

--- a/apps/web/src/components/lens-v2/entity/PartsInventoryContent.tsx
+++ b/apps/web/src/components/lens-v2/entity/PartsInventoryContent.tsx
@@ -42,6 +42,7 @@ import {
   type HistoryPeriod,
 } from '../sections';
 import { ActionPopup, type ActionPopupField } from '../ActionPopup';
+import { AddNoteModal } from '@/components/lens-v2/actions/AddNoteModal';
 
 // ─── Status colour mapping ───
 
@@ -103,7 +104,6 @@ export function PartsInventoryContent() {
   const auditTrail = ((entity?.audit_trail ?? payload.audit_trail) as Array<Record<string, unknown>> | undefined) ?? [];
 
   // ── Action gates ──
-  const takeStockAction = getAction('take_stock');
   const reorderAction = getAction('reorder_part');
   const updateAction = getAction('update_part_details');
   const archiveAction = getAction('archive_part');
@@ -288,7 +288,16 @@ export function PartsInventoryContent() {
     kind: (((a.mime_type ?? a.content_type) as string) ?? '').startsWith('image') ? 'image' as const : 'document' as const,
   }));
 
-  const handleAddNote = React.useCallback(() => {}, []);
+  const [addNoteOpen, setAddNoteOpen] = React.useState(false);
+  const handleNoteSubmit = React.useCallback(
+    async (noteText: string) => {
+      const result = await executeAction('add_part_note', { note_text: noteText });
+      const isSuccess = result.success === true ||
+        (result as unknown as { status?: string }).status === 'success';
+      return { success: isSuccess, error: result.error ?? result.message };
+    },
+    [executeAction]
+  );
 
   return (
     <>
@@ -426,8 +435,8 @@ export function PartsInventoryContent() {
       <ScrollReveal>
         <NotesSection
           notes={noteItems}
-          onAddNote={handleAddNote}
-          canAddNote
+          onAddNote={addNoteAction ? () => setAddNoteOpen(true) : undefined}
+          canAddNote={!!addNoteAction}
         />
       </ScrollReveal>
 
@@ -435,7 +444,7 @@ export function PartsInventoryContent() {
       <ScrollReveal>
         <AttachmentsSection
           attachments={attachmentItems}
-          onAddFile={() => {}}
+          onAddFile={() => {/* TODO: file upload modal (no component exists yet) */}}
           canAddFile
         />
       </ScrollReveal>
@@ -446,6 +455,12 @@ export function PartsInventoryContent() {
           onSubmit={async (values) => { await executeAction(actionPopupConfig.actionId, values); setActionPopupConfig(null); }}
           onClose={() => setActionPopupConfig(null)} />
       )}
+      <AddNoteModal
+        open={addNoteOpen}
+        onClose={() => setAddNoteOpen(false)}
+        onSubmit={handleNoteSubmit}
+        isLoading={isLoading}
+      />
     </>
   );
 }

--- a/apps/web/src/components/lens-v2/entity/PurchaseOrderContent.tsx
+++ b/apps/web/src/components/lens-v2/entity/PurchaseOrderContent.tsx
@@ -26,6 +26,7 @@ import { ScrollReveal } from '../ScrollReveal';
 import { useEntityLensContext } from '@/contexts/EntityLensContext';
 import { getEntityRoute } from '@/lib/entityRoutes';
 import { ActionPopup, type ActionPopupField } from '../ActionPopup';
+import { AddNoteModal } from '@/components/lens-v2/actions/AddNoteModal';
 
 // Sections
 import {
@@ -189,8 +190,9 @@ export function PurchaseOrderContent() {
   const primaryDisabledReason = primaryAction?.disabled_reason;
 
   const handlePrimary = React.useCallback(async () => {
+    if (!primaryAction) return;
     await executeAction(primaryActionKey, {});
-  }, [primaryActionKey, executeAction]);
+  }, [primaryAction, primaryActionKey, executeAction]);
 
   const SPECIAL_HANDLERS: Record<string, () => void> = {};
   const DANGER_ACTIONS = new Set(['cancel_po', 'delete_po']);
@@ -321,7 +323,16 @@ export function PurchaseOrderContent() {
     summary: (p.summary ?? p.period_summary) as string ?? '',
   }));
 
-  const handleAddNote = React.useCallback(() => {}, []);
+  const [addNoteOpen, setAddNoteOpen] = React.useState(false);
+  const handleNoteSubmit = React.useCallback(
+    async (noteText: string) => {
+      const result = await executeAction('add_po_note', { note_text: noteText });
+      const isSuccess = result.success === true ||
+        (result as unknown as { status?: string }).status === 'success';
+      return { success: isSuccess, error: result.error ?? result.message };
+    },
+    [executeAction]
+  );
 
   return (
     <>
@@ -407,8 +418,8 @@ export function PurchaseOrderContent() {
       <ScrollReveal>
         <NotesSection
           notes={noteItems}
-          onAddNote={handleAddNote}
-          canAddNote
+          onAddNote={addNoteAction ? () => setAddNoteOpen(true) : undefined}
+          canAddNote={!!addNoteAction}
         />
       </ScrollReveal>
 
@@ -416,7 +427,7 @@ export function PurchaseOrderContent() {
       <ScrollReveal>
         <AttachmentsSection
           attachments={attachmentItems}
-          onAddFile={() => {}}
+          onAddFile={() => {/* TODO: file upload modal (no component exists yet) */}}
           canAddFile
         />
       </ScrollReveal>
@@ -440,6 +451,12 @@ export function PurchaseOrderContent() {
           onSubmit={async (values) => { await executeAction(actionPopupConfig.actionId, values); setActionPopupConfig(null); }}
           onClose={() => setActionPopupConfig(null)} />
       )}
+      <AddNoteModal
+        open={addNoteOpen}
+        onClose={() => setAddNoteOpen(false)}
+        onSubmit={handleNoteSubmit}
+        isLoading={isLoading}
+      />
     </>
   );
 }

--- a/apps/web/src/components/lens-v2/entity/ReceivingContent.tsx
+++ b/apps/web/src/components/lens-v2/entity/ReceivingContent.tsx
@@ -92,10 +92,9 @@ export function ReceivingContent() {
   const linked_entities = ((entity?.linked_entities ?? payload.linked_entities ?? entity?.related_entities ?? payload.related_entities) as Array<Record<string, unknown>> | undefined) ?? [];
 
   // -- Action gates --
-  const acceptAction = getAction('accept_delivery');
+  const acceptAction = getAction('accept_receiving');
   const flagAction = getAction('flag_discrepancy');
   const confirmAction = getAction('confirm_receiving');
-  const barcodeAction = getAction('generate_barcode');
 
   const isConfirmable = ['pending', 'in_progress'].includes(status);
 
@@ -269,8 +268,6 @@ export function ReceivingContent() {
       : undefined,
   }));
 
-  const handleAddNote = React.useCallback(() => {}, []);
-
   return (
     <>
       {/* Identity Strip */}
@@ -300,26 +297,6 @@ export function ReceivingContent() {
         />
       </ScrollReveal>
 
-      {/* Print Barcodes button */}
-      {barcodeAction !== null && (
-        <ScrollReveal>
-          <div style={{ padding: '0 0 8px' }}>
-            <button
-              className={styles.printBtn}
-              onClick={() => executeAction('generate_barcode', {})}
-              disabled={barcodeAction.disabled ?? false}
-            >
-              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round">
-                <polyline points="6 9 6 2 18 2 18 9" />
-                <path d="M6 18H4a2 2 0 01-2-2v-5a2 2 0 012-2h16a2 2 0 012 2v5a2 2 0 01-2 2h-2" />
-                <rect x="6" y="14" width="12" height="8" />
-              </svg>
-              Print Labels
-            </button>
-          </div>
-        </ScrollReveal>
-      )}
-
       {/* Related Work (linked entities) */}
       {docItems.length > 0 && (
         <ScrollReveal>
@@ -331,8 +308,8 @@ export function ReceivingContent() {
       <ScrollReveal>
         <NotesSection
           notes={noteItems}
-          onAddNote={handleAddNote}
-          canAddNote
+          onAddNote={undefined}
+          canAddNote={false}
         />
       </ScrollReveal>
 
@@ -340,7 +317,7 @@ export function ReceivingContent() {
       <ScrollReveal>
         <AttachmentsSection
           attachments={attachmentItems}
-          onAddFile={() => {}}
+          onAddFile={() => {/* TODO: file upload modal (no component exists yet) */}}
           canAddFile
         />
       </ScrollReveal>

--- a/apps/web/src/components/lens-v2/entity/ShoppingListContent.tsx
+++ b/apps/web/src/components/lens-v2/entity/ShoppingListContent.tsx
@@ -289,10 +289,6 @@ export function ShoppingListContent() {
     summary: (p.summary ?? p.period_summary) as string ?? '',
   }));
 
-  const handleAddNote = React.useCallback(
-    () => {},
-    []
-  );
 
   const handleAddPart = React.useCallback(
     () => {},
@@ -407,8 +403,8 @@ export function ShoppingListContent() {
       <ScrollReveal>
         <NotesSection
           notes={noteItems}
-          onAddNote={handleAddNote}
-          canAddNote
+          onAddNote={undefined}
+          canAddNote={false}
         />
       </ScrollReveal>
 
@@ -424,7 +420,7 @@ export function ShoppingListContent() {
       <ScrollReveal>
         <AttachmentsSection
           attachments={attachmentItems}
-          onAddFile={() => {}}
+          onAddFile={() => {/* TODO: file upload modal (no component exists yet) */}}
           canAddFile
         />
       </ScrollReveal>

--- a/apps/web/src/components/lens-v2/entity/WarrantyContent.tsx
+++ b/apps/web/src/components/lens-v2/entity/WarrantyContent.tsx
@@ -42,6 +42,7 @@ import {
   type HistoryPeriod,
 } from '../sections';
 import { ActionPopup, type ActionPopupField } from '../ActionPopup';
+import { AddNoteModal } from '@/components/lens-v2/actions/AddNoteModal';
 
 // ─── Colour mapping helpers ───
 
@@ -113,7 +114,6 @@ export function WarrantyContent() {
 
   // ── Action gates ──
   const fileClaimAction = getAction('file_warranty_claim');
-  const extendAction = getAction('extend_warranty');
   const archiveAction = getAction('archive_warranty');
   const addNoteAction = getAction('add_warranty_note');
   const uploadDocAction = getAction('add_warranty_attachment');
@@ -307,7 +307,16 @@ export function WarrantyContent() {
     kind: (((a.mime_type ?? a.content_type) as string) ?? '').startsWith('image') ? 'image' as const : 'document' as const,
   }));
 
-  const handleAddNote = React.useCallback(() => {}, []);
+  const [addNoteOpen, setAddNoteOpen] = React.useState(false);
+  const handleNoteSubmit = React.useCallback(
+    async (noteText: string) => {
+      const result = await executeAction('add_warranty_note', { note_text: noteText });
+      const isSuccess = result.success === true ||
+        (result as unknown as { status?: string }).status === 'success';
+      return { success: isSuccess, error: result.error ?? result.message };
+    },
+    [executeAction]
+  );
 
   return (
     <>
@@ -390,8 +399,8 @@ export function WarrantyContent() {
       <ScrollReveal>
         <NotesSection
           notes={noteItems}
-          onAddNote={handleAddNote}
-          canAddNote
+          onAddNote={addNoteAction ? () => setAddNoteOpen(true) : undefined}
+          canAddNote={!!addNoteAction}
         />
       </ScrollReveal>
 
@@ -399,7 +408,7 @@ export function WarrantyContent() {
       <ScrollReveal>
         <AttachmentsSection
           attachments={attachmentItems}
-          onAddFile={() => {}}
+          onAddFile={() => {/* TODO: file upload modal (no component exists yet) */}}
           canAddFile
         />
       </ScrollReveal>
@@ -410,6 +419,12 @@ export function WarrantyContent() {
           onSubmit={async (values) => { await executeAction(actionPopupConfig.actionId, values); setActionPopupConfig(null); }}
           onClose={() => setActionPopupConfig(null)} />
       )}
+      <AddNoteModal
+        open={addNoteOpen}
+        onClose={() => setAddNoteOpen(false)}
+        onSubmit={handleNoteSubmit}
+        isLoading={isLoading}
+      />
     </>
   );
 }


### PR DESCRIPTION
## Summary

- **Priority 1 — AddNoteModal wired to 7 entity views**: Fault, Equipment, PurchaseOrder, Certificate, Document, Warranty, PartsInventory now open a real note modal on click; handler calls correct per-entity action ID and returns `{success, error}`. `onAddNote`/`canAddNote` gated on action availability from backend.
- **Priority 1 — 3 entities without note action cleaned up**: Receiving, ShoppingList, HoursOfRest had dead `canAddNote` / `onAddNote={() => {}}` props — removed since no note action exists in the action registry for these entities.
- **Priority 2 — phantom action IDs fixed**: `submit_hours` → `upsert_hours_of_rest` (×3 in HoursOfRest), `accept_delivery` → `accept_receiving` in Receiving, removed `generate_barcode` + Print Labels button block (action not in registry), guarded `handlePrimary` against null in PurchaseOrder, removed dead `takeStockAction`, `createRevisionAction`, `acknowledgeAction`, `extendAction` variables.
- **Priority 3 — upload handlers annotated**: All 11 entity files now have `// TODO: file upload modal (no component exists yet)` comment on `onAddFile` noops.

## Test plan

- [ ] TypeScript: `npx tsc --noEmit` — exits 0 ✅
- [ ] Verify Note button appears on Fault/Equipment/PO/Certificate/Document/Warranty/Parts lens when `add_*_note` is in `availableActions`
- [ ] Verify Note button is hidden when action not returned by backend
- [ ] Verify Note modal submits and shows success toast
- [ ] Verify Hours of Rest Submit button calls correct backend action (`upsert_hours_of_rest`)
- [ ] Verify Receiving page no longer shows Print Labels button

🤖 Generated with [Claude Code](https://claude.com/claude-code)