### PR TITLE
fix: add_fault_note accepts note_text as canonical field

### DIFF
--- a/apps/api/action_router/dispatchers/internal_dispatcher.py
+++ b/apps/api/action_router/dispatchers/internal_dispatcher.py
@@ -1303,7 +1303,7 @@ async def add_fault_note(params: Dict[str, Any]) -> Dict[str, Any]:
     yacht_id = params["yacht_id"]
     fault_id = params["fault_id"]
     user_id = params["user_id"]
-    text = params.get("text") or params.get("note")  # Support both param names
+    text = params.get("note_text") or params.get("text") or params.get("note")  # note_text is canonical
     note_type = params.get("note_type", "observation")
 
     if not text:


### PR DESCRIPTION
## Summary

- `add_fault_note` in `internal_dispatcher.py` previously only checked `text` then `note` for the note content field
- All other note actions (`add_note`, `add_equipment_note`) use `note_text` as the primary field
- Frontend (PR #489) sends `note_text` uniformly across all 7 note actions
- Without this fix, fault note submissions would fail with "Note text is required"

**Change**: `params.get("text") or params.get("note")` → `params.get("note_text") or params.get("text") or params.get("note")`

`note_text` is now canonical across all note actions. Old callers using `text` or `note` still work.

## Test plan

- [ ] `POST /v1/actions/execute` with `action: "add_fault_note"`, payload `{ note_text: "test note" }` → 200, note created
- [ ] Old callers using `text` field still work (backwards compatible)

🤖 Generated with [Claude Code](https://claude.com/claude-code)