### PR TITLE
fix: correct work_order_priority enum (routine/critical only)

### DIFF
--- a/apps/api/routes/handlers/work_order_handler.py
+++ b/apps/api/routes/handlers/work_order_handler.py
@@ -772,10 +772,10 @@ async def create_work_order_for_equipment(
     equipment_id = payload.get("equipment_id") or context.get("equipment_id")
     title = payload.get("title", "Work Order")
     description = payload.get("description", "")
-    priority = payload.get("priority", "medium")
-    # DB enum only has medium/high/critical — map legacy "low" and "routine" to "medium"
-    if priority in ("low", "routine"):
-        priority = "medium"
+    priority = payload.get("priority", "routine")
+    # DB enum only has routine/critical — map anything else to routine
+    if priority not in ("routine", "critical"):
+        priority = "routine"
     wo_type = payload.get("type", "corrective")
     if not equipment_id:
         raise HTTPException(status_code=400, detail="equipment_id is required")


### PR DESCRIPTION
## Summary

PR #488 introduced an incorrect priority mapping for `create_work_order_for_equipment`. The PR assumed the DB enum included "medium" — it does not.

**Actual DB enum values**: `routine`, `critical` only.

**Before (broken)**: default "medium", mapped "low"/"routine" → "medium" (still invalid)
**After**: default "routine", maps any non-enum value → "routine"

Verified via live DB enum probe — only `routine` and `critical` are accepted.

## Test plan

- [ ] `POST /v1/actions/execute` with `action: "create_work_order_for_equipment"` and `priority: "low"` → 200, work order created with priority "routine"
- [ ] Same with no priority → 200, priority "routine"
- [ ] Same with `priority: "critical"` → 200, priority "critical"

🤖 Generated with [Claude Code](https://claude.com/claude-code)