### PR TITLE
fix: 5 round-trip bugs (validation, severity clobber, orphaned notes, fault note exposure)

### DIFF
--- a/apps/api/action_router/dispatchers/internal_dispatcher.py
+++ b/apps/api/action_router/dispatchers/internal_dispatcher.py
@@ -220,6 +220,16 @@ async def add_note(params: Dict[str, Any]) -> Dict[str, Any]:
         note_data["fault_id"] = params["fault_id"]
     if params.get("work_order_id"):
         note_data["work_order_id"] = params["work_order_id"]
+    if params.get("document_id"):
+        note_data["document_id"] = params["document_id"]
+    if params.get("part_id"):
+        note_data["part_id"] = params["part_id"]
+    if params.get("purchase_order_id"):
+        note_data["purchase_order_id"] = params["purchase_order_id"]
+    if params.get("warranty_id"):
+        note_data["warranty_id"] = params["warranty_id"]
+    if params.get("certificate_id"):
+        note_data["certificate_id"] = params["certificate_id"]
 
     result = supabase.table("pms_notes").insert(note_data).execute()
 

--- a/apps/api/routes/entity_routes.py
+++ b/apps/api/routes/entity_routes.py
@@ -684,6 +684,7 @@ async def get_fault_entity(fault_id: str, auth: dict = Depends(get_authenticated
         except Exception:
             pass
 
+        fault_metadata = data.get('metadata', {}) or {}
         _entity_response = {
             "id": data.get('id'),
             "title": data.get('title') or data.get('fault_code', 'Unknown Fault'),
@@ -700,6 +701,7 @@ async def get_fault_entity(fault_id: str, auth: dict = Depends(get_authenticated
             "updated_at": data.get('updated_at'),
             "attachments": attachments,
             "related_entities": nav,
+            "notes": fault_metadata.get("notes", []),
         }
         _entity_response["available_actions"] = get_available_actions(
             "fault", _entity_response, auth.get("role", "crew")

--- a/apps/api/routes/handlers/fault_handler.py
+++ b/apps/api/routes/handlers/fault_handler.py
@@ -710,7 +710,7 @@ async def add_fault_note(
 
     current = (
         db_client.table("pms_faults")
-        .select("id, metadata")
+        .select("id, metadata, severity")
         .eq("id", fault_id)
         .eq("yacht_id", yacht_id)
         .single()
@@ -720,6 +720,7 @@ async def add_fault_note(
         raise HTTPException(status_code=404, detail="Fault not found")
 
     metadata = current.data.get("metadata", {}) or {}
+    current_severity = current.data.get("severity") or "medium"
     notes = metadata.get("notes", []) or []
     notes.append({
         "text": note_text,
@@ -730,9 +731,8 @@ async def add_fault_note(
 
     note_result = db_client.table("pms_faults").update({
         "metadata": metadata,
-        # DB invariant: pms_faults check constraint requires a non-null severity on every UPDATE.
-        # "medium" is the safe sentinel — this does not reflect a business-logic change.
-        "severity": "medium",
+        # Preserve original severity — NOT NULL constraint requires it on every UPDATE.
+        "severity": current_severity,
         "updated_by": user_id,
         "updated_at": datetime.now(timezone.utc).isoformat(),
     }).eq("id", fault_id).eq("yacht_id", yacht_id).execute()

--- a/apps/api/routes/p0_actions_routes.py
+++ b/apps/api/routes/p0_actions_routes.py
@@ -781,7 +781,7 @@ async def execute_action(
         "add_worklist_task": ["task_description"],
         "check_stock_level": ["part_id"],
         "log_part_usage": ["part_id", "quantity", "usage_reason"],
-        "add_to_handover": ["title"],
+        "add_to_handover": ["summary"],
         "show_manual_section": ["equipment_id"],
         "update_equipment_status": ["equipment_id", "new_status"],
         # Document Lens v2 Actions
@@ -799,7 +799,7 @@ async def execute_action(
         "add_wo_note": ["work_order_id", "note_text"],
         # Tier 1 - Fault/WO History
         "view_fault_history": ["equipment_id"],
-        "add_fault_note": ["fault_id", "note_text"],
+        "add_fault_note": ["note_text"],
         "view_work_order_history": ["equipment_id"],
         "suggest_parts": ["fault_id"],
         # Tier 2 - Equipment Views


### PR DESCRIPTION
## Summary

Five bugs found during live round-trip audit (POST action → verify DB row).

### Fix 1 — add_fault_note REQUIRED_FIELDS
`fault_id` removed from validation. It resolves from `context.entity_id` after `resolve_entity_context` — validating it in payload blocked every fault note submission from the entity lens.

### Fix 2 — add_to_handover REQUIRED_FIELDS  
Changed `["title"]` → `["summary"]`. Handler reads `summary` first; frontend sends `summary`. Mismatched validation was blocking all handover queue submissions.

### Fix 3 — add_fault_note severity clobber
Handler was hardcoding `severity: "medium"` on every note update, silently overwriting the fault's actual severity. Now reads current severity and preserves it.

### Fix 4 — Orphaned note entity linkage
`add_note` generic handler (used by add_document_note, add_part_note, add_po_note, add_warranty_note, add_certificate_note) resolved entity_id but only stored equipment_id/fault_id/work_order_id in the note row. Added: document_id, part_id, purchase_order_id, warranty_id, certificate_id.

### Fix 5 — Fault notes not exposed in entity response
`GET /v1/entity/fault/{id}` omitted the notes array entirely. add_fault_note stores notes in `pms_faults.metadata['notes']` — now exposed as `notes: []` in the entity response so the UI can display them after submit.

## Test plan

- [ ] `add_fault_note` via entity lens (no fault_id in payload, only context.entity_id) → 200, note in metadata.notes
- [ ] `GET /v1/entity/fault/{id}` → response includes `notes` array with submitted note
- [ ] `add_fault_note` on fault with severity "high" → fault severity remains "high" after note added
- [ ] `add_to_handover` with `summary` only (no title) → 200, row in handover_items
- [ ] `add_document_note` → pms_notes row has document_id set (not NULL)
- [ ] `add_part_note` → pms_notes row has part_id set
- [ ] `add_po_note` → pms_notes row has purchase_order_id set
- [ ] `add_warranty_note` → pms_notes row has warranty_id set

🤖 Generated with [Claude Code](https://claude.com/claude-code)