### PR TITLE
fix: equipment and part entity endpoints return notes from pms_notes

### DIFF
--- a/apps/api/routes/entity_routes.py
+++ b/apps/api/routes/entity_routes.py
@@ -846,6 +846,14 @@ async def get_equipment_entity(equipment_id: str, auth: dict = Depends(get_authe
 
         attachments = _get_attachments(supabase, "equipment", equipment_id, yacht_id)
 
+        try:
+            notes_r = supabase.table('pms_notes').select(
+                'id, text, note_type, created_by, created_at'
+            ).eq('equipment_id', equipment_id).eq('yacht_id', yacht_id).order('created_at', desc=True).execute()
+            equipment_notes = notes_r.data or []
+        except Exception:
+            equipment_notes = []
+
         # Find linked work orders and faults
         nav = []
         try:
@@ -889,6 +897,7 @@ async def get_equipment_entity(equipment_id: str, auth: dict = Depends(get_authe
             "updated_at": data.get('updated_at'),
             "attachments": attachments,
             "related_entities": nav,
+            "notes": equipment_notes,
         }
         _entity_response["available_actions"] = get_available_actions(
             "equipment", _entity_response, auth.get("role", "crew")
@@ -925,6 +934,14 @@ async def get_part_entity(part_id: str, auth: dict = Depends(get_authenticated_u
 
         attachments = _get_attachments(supabase, "part", part_id, yacht_id)
 
+        try:
+            notes_r = supabase.table('pms_notes').select(
+                'id, text, note_type, created_by, created_at'
+            ).eq('part_id', part_id).eq('yacht_id', yacht_id).order('created_at', desc=True).execute()
+            part_notes = notes_r.data or []
+        except Exception:
+            part_notes = []
+
         _entity_response = {
             "id": data.get('id'),
             "name": data.get('name') or 'Unknown Part',
@@ -945,6 +962,7 @@ async def get_part_entity(part_id: str, auth: dict = Depends(get_authenticated_u
             "image_url": image_url,
             "attachments": attachments,
             "related_entities": [],
+            "notes": part_notes,
         }
         _entity_response["available_actions"] = get_available_actions(
             "part", _entity_response, auth.get("role", "crew")


### PR DESCRIPTION
## Summary

- `GET /v1/entity/equipment/{id}` now queries `pms_notes` by `equipment_id` and returns `notes` array
- `GET /v1/entity/part/{id}` now queries `pms_notes` by `part_id` and returns `notes` array

Without this fix: `add_equipment_note` and `add_part_note` succeed (note stored in DB), but the entity refetch returns no notes field — UI never shows the submitted note.

Pattern follows `GET /v1/entity/work_order/{id}` which queries `pms_work_order_notes` directly.

## Test plan

- [ ] Submit `add_equipment_note` → `GET /v1/entity/equipment/{id}` → response includes `notes` array with new note
- [ ] Submit `add_part_note` → `GET /v1/entity/part/{id}` → response includes `notes` array with new note
- [ ] Entity with no notes → `notes: []` (not null, not missing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)