### PR TITLE
fix: fault NoteItem mapper — added_by/added_at field names

### DIFF
--- a/apps/web/src/components/lens-v2/entity/FaultContent.tsx
+++ b/apps/web/src/components/lens-v2/entity/FaultContent.tsx
@@ -252,8 +252,8 @@ export function FaultContent() {
   // Notes → NoteItems
   const noteItems: NoteItem[] = notes.map((n, i) => ({
     id: (n.id as string) ?? `note-${i}`,
-    author: (n.author ?? n.created_by ?? n.user_name) as string ?? 'Unknown',
-    timestamp: (n.created_at ?? n.timestamp) as string ?? '',
+    author: (n.author ?? n.created_by ?? n.user_name ?? n.added_by) as string ?? 'Unknown',
+    timestamp: (n.created_at ?? n.timestamp ?? n.added_at) as string ?? '',
     body: (n.body ?? n.note_text ?? n.text) as string ?? '',
   }));
 


### PR DESCRIPTION
## Summary

- `pms_faults.metadata['notes']` stores note objects as `{ text, added_by, added_at }` (fault-specific naming, inconsistent with pms_notes table convention)
- FaultContent NoteItem mapper was only checking `author`/`created_by`/`user_name` for author and `created_at`/`timestamp` for timestamp — all misses
- Every fault note would render "Unknown" author and blank timestamp despite the note saving correctly

**Fix:** Added `added_by` to author fallback chain and `added_at` to timestamp fallback chain in FaultContent.tsx. `text` was already the last fallback for body — no change needed there.

## Test plan
- [ ] Add a note on a fault lens view
- [ ] Confirm note appears with correct author name (not "Unknown")
- [ ] Confirm note appears with correct timestamp (not blank)

🤖 Generated with [Claude Code](https://claude.com/claude-code)