### PR TITLE
fix: HoR views — error state on API failure, no silent mock fallback

### DIFF
--- a/apps/web/src/components/hours-of-rest/DepartmentView.tsx
+++ b/apps/web/src/components/hours-of-rest/DepartmentView.tsx
@@ -168,7 +168,6 @@ function statusDot(status: CrewDay['status']): string {
 // Maps real API response shapes to component types.
 // Real API uses: crew[].daily[], pending_signoffs{awaiting_hod,signoff_ids}, compliance.missing_today[]
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
 function normalizeDepStatus(raw: any, ws: string): DepartmentStatus {
   const comp = raw.compliance ?? {};
   const ps = raw.pending_signoffs ?? {};
@@ -223,28 +222,30 @@ export function DepartmentView() {
   const [weekStart, setWeekStart] = React.useState(getCurrentWeekStart);
   const [data, setData] = React.useState<DepartmentStatus | null>(null);
   const [loading, setLoading] = React.useState(true);
+  const [error, setError] = React.useState<string | null>(null);
   const [signingId, setSigningId] = React.useState<string | null>(null);
 
   // ── Load ──
 
   async function loadData(ws: string) {
     setLoading(true);
+    setError(null);
     try {
       const token = session?.access_token;
-      if (!token) throw new Error('no token');
+      if (!token) throw new Error('Not authenticated');
       const res = await fetch(`/api/v1/hours-of-rest/department-status?week_start=${ws}`, {
         headers: { Authorization: `Bearer ${token}` },
       });
-      if (!res.ok) throw new Error('not ready');
+      if (!res.ok) throw new Error(`Failed to load department status (${res.status})`);
       const json = await res.json();
       const raw = json.success ? json.data : json;
       if (raw) {
         setData(normalizeDepStatus(raw, ws));
         return;
       }
-      throw new Error('unexpected shape');
-    } catch {
-      setData(buildMockDepartmentStatus(ws));
+      throw new Error('Unexpected response shape from department-status endpoint');
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load department data');
     } finally {
       setLoading(false);
     }
@@ -277,10 +278,18 @@ export function DepartmentView() {
     setWeekStart(d.toISOString().slice(0, 10));
   }
 
-  if (loading || !data) {
+  if (loading) {
     return (
       <div style={{ padding: 32, color: 'rgba(255,255,255,0.4)', fontFamily: 'var(--font-mono)', fontSize: 12 }}>
         Loading department data…
+      </div>
+    );
+  }
+
+  if (error || !data) {
+    return (
+      <div style={{ padding: 32, color: 'rgba(239,68,68,0.7)', fontFamily: 'var(--font-mono)', fontSize: 12 }}>
+        {error ?? 'No department data available.'}
       </div>
     );
   }

--- a/apps/web/src/components/hours-of-rest/MyTimeView.tsx
+++ b/apps/web/src/components/hours-of-rest/MyTimeView.tsx
@@ -187,10 +187,11 @@ export function MyTimeView() {
         }
         setData(json);
       } else {
-        setData(MOCK_MY_WEEK);
+        const text = await resp.text().catch(() => '');
+        setError(`Failed to load hours of rest (${resp.status})${text ? `: ${text.slice(0, 120)}` : ''}`);
       }
-    } catch {
-      setData(MOCK_MY_WEEK);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load hours of rest');
     } finally {
       setLoading(false);
     }

--- a/apps/web/src/components/hours-of-rest/VesselComplianceView.tsx
+++ b/apps/web/src/components/hours-of-rest/VesselComplianceView.tsx
@@ -186,14 +186,11 @@ const WEEK_DAYS = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'];
 // Real API: all_crew[] (flat, has .department field), analytics{} (not vessel_analytics{})
 // Real analytics fields: compliance_rate, violations_this_quarter, avg_work_hours
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
 function normalizeVesselCompliance(raw: any, ws: string): VesselCompliance {
   const a = raw.analytics ?? raw.vessel_analytics ?? {};
 
   // Build departments — may have nested crew[] OR we join from all_crew[]
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const allCrewFlat: any[] = Array.isArray(raw.all_crew) ? raw.all_crew : [];
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const rawDepts: any[] = Array.isArray(raw.departments) ? raw.departments : [];
 
   const departments: DepartmentCard[] = rawDepts.map((d: any) => {
@@ -255,6 +252,7 @@ export function VesselComplianceView() {
   const [weekStart, setWeekStart] = React.useState(getCurrentWeekStart);
   const [data, setData] = React.useState<VesselCompliance | null>(null);
   const [loading, setLoading] = React.useState(true);
+  const [error, setError] = React.useState<string | null>(null);
   const [expandedDept, setExpandedDept] = React.useState<string | null>(null);
   const [signingId, setSigningId] = React.useState<string | null>(null);
 
@@ -262,19 +260,20 @@ export function VesselComplianceView() {
 
   async function loadData(ws: string) {
     setLoading(true);
+    setError(null);
     try {
       const token = session?.access_token;
-      if (!token) throw new Error('no token');
+      if (!token) throw new Error('Not authenticated');
       const res = await fetch(`/api/v1/hours-of-rest/vessel-compliance?week_start=${ws}`, {
         headers: { Authorization: `Bearer ${token}` },
       });
-      if (!res.ok) throw new Error('not ready');
+      if (!res.ok) throw new Error(`Failed to load vessel compliance (${res.status})`);
       const json = await res.json();
       const raw = json.success ? json.data : json;
       if (raw) { setData(normalizeVesselCompliance(raw, ws)); return; }
-      throw new Error('unexpected shape');
-    } catch {
-      setData(buildMockVesselCompliance(ws));
+      throw new Error('Unexpected response shape from vessel-compliance endpoint');
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load vessel compliance data');
     } finally {
       setLoading(false);
     }
@@ -305,10 +304,18 @@ export function VesselComplianceView() {
     setWeekStart(d.toISOString().slice(0, 10));
   }
 
-  if (loading || !data) {
+  if (loading) {
     return (
       <div style={{ padding: 32, color: 'rgba(255,255,255,0.4)', fontFamily: 'var(--font-mono)', fontSize: 12 }}>
         Loading vessel compliance…
+      </div>
+    );
+  }
+
+  if (error || !data) {
+    return (
+      <div style={{ padding: 32, color: 'rgba(239,68,68,0.7)', fontFamily: 'var(--font-mono)', fontSize: 12 }}>
+        {error ?? 'No vessel compliance data available.'}
       </div>
     );
   }


### PR DESCRIPTION
## Summary

**Compliance safety fix.** Three HoR views were silently falling back to mock/fabricated data when the API returned a non-200 response or threw a network error. On a compliance surface (MLC 2006 Hours of Rest), a crew member could see fake hours of rest that never existed.

**Changes:**

- **MyTimeView**: `setError(status + message)` on non-ok response; `setError(err.message)` on network failure. Removed `setData(MOCK_MY_WEEK)` fallback paths.
- **DepartmentView**: Added `error` state; `setError()` on all failure paths; error render guard shows red message. Removed `setData(buildMockDepartmentStatus())` fallback.
- **VesselComplianceView**: Same pattern. Removed `setData(buildMockVesselCompliance())` fallback.
- Removed invalid `eslint-disable-next-line @typescript-eslint/no-explicit-any` comments (rule not configured in this project — caused build ESLint errors).

MOCK data constants remain in file for local dev only — they are no longer reachable in production code paths.

## Test plan

- [ ] Verify: when API returns 500, view shows `"Failed to load hours of rest (500)"` — NOT fabricated data
- [ ] Verify: when API returns 403, view shows error message
- [ ] Verify: when API succeeds, view renders real data normally
- [ ] `tsc --noEmit`: clean
- [ ] `next build`: clean (no ESLint errors on HoR files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)