### PR TITLE
fix: HoR ledger metadata + rolling/dept bugs

### DIFF
--- a/apps/api/routes/hor_compliance_routes.py
+++ b/apps/api/routes/hor_compliance_routes.py
@@ -163,9 +163,10 @@ async def get_my_week(
         ).eq("yacht_id", yacht_id).eq("user_id", user_id).gte(
             "record_date", rolling_start.isoformat()
         ).lte("record_date", today.isoformat()).execute()
+        rolling_data = rolling_r.data or []
         rolling_7day = sum(
-            (r.get("total_rest_hours") or 0) for r in (rolling_r.data or [])
-        ) or None
+            (r.get("total_rest_hours") or 0) for r in rolling_data
+        ) if rolling_data else None
 
         summary_data = summary_r.data if summary_r else None
         compliance = {
@@ -404,10 +405,11 @@ async def get_department_status(
             "signoff_ids":  [r["id"] for r in pending_rows],
         }
 
+        dept_label = department if user_role.lower() not in _CAPTAIN_ROLES else "all"
         return JSONResponse(content={
             "status":          "success",
             "week_start":      week_monday.isoformat(),
-            "department":      department,
+            "department":      dept_label,
             "total_crew":      len(crew_user_ids),
             "submitted_count": submitted_count,
             "compliant_count": compliant_count,


### PR DESCRIPTION
## Summary
- Add upsert_hours_of_rest to ACTION_METADATA (Phase B safety net catches ledger gap)
- Fix rolling_7day_rest returning None when sum is 0 (Python `0 or None` bug)
- Fix captain department-status returning own dept instead of "all"

## Test plan
- [x] ENGINEER02 live-tested all 3 endpoints with crew/HOD/captain JWTs
- [x] Rolling fields confirmed populated after upsert
- [x] Ledger safety net entry added

🤖 Generated with [Claude Code](https://claude.com/claude-code)