### PR TITLE
fix: HoR infinite re-render loop — memoize AuthContext + guard fetch

### DIFF
--- a/apps/web/src/components/hours-of-rest/MyTimeView.tsx
+++ b/apps/web/src/components/hours-of-rest/MyTimeView.tsx
@@ -251,6 +251,9 @@ export function MyTimeView() {
   // Unsigned alert
   const [unsignedAlert, setUnsignedAlert] = React.useState(false);
 
+  // Guard against double-mount (React StrictMode / auth re-renders)
+  const fetchedRef = React.useRef(false);
+
   // ── Load week data ──
 
   async function loadWeekData() {
@@ -301,6 +304,8 @@ export function MyTimeView() {
   }
 
   React.useEffect(() => {
+    if (fetchedRef.current) return;
+    fetchedRef.current = true;
     loadWeekData();
     checkUnsignedAlert();
   }, []);

--- a/apps/web/src/contexts/AuthContext.tsx
+++ b/apps/web/src/contexts/AuthContext.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { createContext, useEffect, useState, useCallback, useRef } from 'react';
+import React, { createContext, useEffect, useState, useCallback, useRef, useMemo } from 'react';
 import { supabase } from '@/lib/supabaseClient';
 import type { Session, User } from '@supabase/supabase-js';
 
@@ -496,17 +496,19 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     window.location.href = '/login';
   }, []);
 
+  const contextValue = useMemo(() => ({
+    user,
+    session,
+    loading,
+    bootstrapping,
+    error,
+    login,
+    logout,
+    refreshBootstrap
+  }), [user, session, loading, bootstrapping, error, login, logout, refreshBootstrap]);
+
   return (
-    <AuthContext.Provider value={{
-      user,
-      session,
-      loading,
-      bootstrapping,
-      error,
-      login,
-      logout,
-      refreshBootstrap
-    }}>
+    <AuthContext.Provider value={contextValue}>
       {children}
     </AuthContext.Provider>
   );


### PR DESCRIPTION
## Summary
- **Root cause:** AuthContext.Provider value was a new object literal on every render. Auth events (SIGNED_IN, INITIAL_SESSION, Bootstrap) each created new context value, re-rendering all useAuth() consumers infinitely.
- **Fix 1:** `useMemo()` on AuthContext value — consumers only re-render when state actually changes
- **Fix 2:** `useRef` guard in MyTimeView to prevent double-fetch on remount

## Test plan
- [ ] /hours-of-rest renders content (not blank page)
- [ ] No ol/or infinite loop in console
- [ ] Other pages still work (auth context change affects entire app)

🤖 Generated with [Claude Code](https://claude.com/claude-code)