### PR TITLE
fix(hor): content area collapsed — height:100% → flex:1

### DIFF
--- a/apps/web/src/app/hours-of-rest/page.tsx
+++ b/apps/web/src/app/hours-of-rest/page.tsx
@@ -53,7 +53,8 @@ function HoursOfRestContent() {
 
   return (
     <div style={{
-      height: '100%',
+      flex: 1,
+      minHeight: 0,
       display: 'flex',
       flexDirection: 'column',
       background: 'var(--surface-base, #0e0c09)',


### PR DESCRIPTION
## Root Cause

`HoursOfRestContent` outer div used `height: '100%'` inside `<main style={{display:'flex', flexDirection:'column'}}>`.

`height: 100%` on a flex column item doesn't reliably resolve to the parent grid cell height — the browser computes it as `auto` in certain layout contexts, leaving the div at its intrinsic content height (~40px, the header only).

DOM confirmation: `offsetHeight: 40`, `scrollHeight: 1263` — content was fully rendered, just invisible behind a 40px container with `overflow: auto`.

## Fix

Replaced `height: '100%'` with `flex: 1` + `minHeight: 0`.

`flex: 1` is the correct pattern for filling remaining space in a flex column container. `minHeight: 0` allows the flex item to shrink below its content size when needed.

## Rule going forward

Any page root rendered inside AppShell's `<main>` (which is `display:flex, flexDirection:column`) must use `flex: 1` — not `height: 100%` — to fill available viewport space.

🤖 Generated with [Claude Code](https://claude.com/claude-code)