### PR TITLE
fix(shell): HoR page body stuck in 46px subbar row

### DIFF
--- a/apps/web/src/components/shell/AppShell.tsx
+++ b/apps/web/src/components/shell/AppShell.tsx
@@ -158,7 +158,9 @@ export function AppShell({ children }: AppShellProps) {
     }
   }, [activeDomain]);
 
-  const showSubbar = activeDomain !== 'surface';
+  // hours-of-rest has its own role-aware header — no Subbar needed
+  const SUBBAR_EXCLUDED: DomainId[] = ['surface', 'hours-of-rest'];
+  const showSubbar = !SUBBAR_EXCLUDED.includes(activeDomain);
 
   return (
     <ShellProvider activeDomain={activeDomain}>


### PR DESCRIPTION
## Root Cause

`showSubbar` was `activeDomain !== 'surface'` — so `true` for `hours-of-rest`.

This allocates a 3-row grid: `48px 46px 1fr`. But `Subbar` returns `null` for `hours-of-rest` (intentional — HoR has its own role-aware header). With no DOM node for row 2, the body div (sidebar + main content) becomes the 2nd grid child and lands in the **46px** subbar row instead of the **1fr** content row.

Result: main content area = 46px. `offsetHeight: 46`, `scrollHeight: 624`. Everything rendered, nothing visible.

## Fix

Exclude `hours-of-rest` from `showSubbar`, same as `surface`. Body div now gets the `1fr` row.

```js
const SUBBAR_EXCLUDED: DomainId[] = ['surface', 'hours-of-rest'];
const showSubbar = !SUBBAR_EXCLUDED.includes(activeDomain);
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)