### PR TITLE
feat(ledger): enrich events with entity names, before/after state, rich summaries

### DIFF
--- a/apps/api/routes/handlers/fault_handler.py
+++ b/apps/api/routes/handlers/fault_handler.py
@@ -35,11 +35,12 @@ async def report_fault(
     if severity not in ("low", "medium", "high", "critical"):
         severity = "medium"
 
+    fault_title = payload.get("title", description[:100] if description else "Reported fault")
     fault_data = {
         "yacht_id": yacht_id,
         "equipment_id": payload.get("equipment_id"),
         "fault_code": payload.get("fault_code", "MANUAL"),
-        "title": payload.get("title", description[:100] if description else "Reported fault"),
+        "title": fault_title,
         "description": description,
         "severity": severity,
         "status": "open",
@@ -48,16 +49,24 @@ async def report_fault(
     }
     fault_result = db_client.table("pms_faults").insert(fault_data).execute()
     if fault_result.data:
+        fault_id = fault_result.data[0]["id"]
         try:
             ledger_event = build_ledger_event(
                 yacht_id=yacht_id,
                 user_id=user_id,
                 event_type="create",
                 entity_type="fault",
-                entity_id=fault_result.data[0]["id"],
+                entity_id=fault_id,
                 action="report_fault",
                 user_role=user_context.get("role"),
-                change_summary="Fault reported",
+                change_summary=f"Fault reported: {fault_title}",
+                entity_name=fault_title,
+                new_state={
+                    "title": fault_title,
+                    "status": "open",
+                    "severity": severity,
+                    "equipment_id": payload.get("equipment_id"),
+                },
             )
             db_client.table("ledger_events").insert(ledger_event).execute()
         except Exception as ledger_err:
@@ -67,7 +76,7 @@ async def report_fault(
                 logger.warning(f"[Ledger] Failed to record report_fault: {ledger_err}")
         return {
             "status": "success",
-            "fault_id": fault_result.data[0]["id"],
+            "fault_id": fault_id,
             "message": "Fault reported successfully",
         }
     return {
@@ -92,7 +101,7 @@ async def acknowledge_fault(
 
     check = (
         db_client.table("pms_faults")
-        .select("id, status, severity")
+        .select("id, status, severity, title")
         .eq("id", fault_id)
         .eq("yacht_id", yacht_id)
         .single()
@@ -103,6 +112,7 @@ async def acknowledge_fault(
 
     old_status = check.data.get("status", "unknown")
     old_severity = check.data.get("severity", "unknown")
+    entity_name = check.data.get("title") or ""
 
     update_data = {
         "status": "investigating",
@@ -151,7 +161,10 @@ async def acknowledge_fault(
                 entity_id=fault_id,
                 action="acknowledge_fault",
                 user_role=user_context.get("role"),
-                change_summary="Fault acknowledged",
+                change_summary=f"Fault acknowledged — status: {old_status} → investigating",
+                entity_name=entity_name,
+                previous_state={"status": old_status, "severity": old_severity},
+                new_state={"status": "investigating", "severity": "medium"},
             )
             db_client.table("ledger_events").insert(ledger_event).execute()
         except Exception as ledger_err:
@@ -184,7 +197,7 @@ async def resolve_fault(
 
     check = (
         db_client.table("pms_faults")
-        .select("id")
+        .select("id, status, title")
         .eq("id", fault_id)
         .eq("yacht_id", yacht_id)
         .single()
@@ -192,6 +205,10 @@ async def resolve_fault(
     )
     if not check.data:
         raise HTTPException(status_code=404, detail="Fault not found")
+
+    prev_status = check.data.get("status", "unknown")
+    entity_name = check.data.get("title") or ""
+    resolution_notes = payload.get("resolution_notes") or payload.get("note") or ""
 
     now = datetime.now(timezone.utc).isoformat()
     update_data = {
@@ -214,6 +231,9 @@ async def resolve_fault(
     )
     if fault_result.data:
         try:
+            new_state = {"status": "resolved", "resolved_by": user_id}
+            if resolution_notes:
+                new_state["resolution_notes"] = resolution_notes
             ledger_event = build_ledger_event(
                 yacht_id=yacht_id,
                 user_id=user_id,
@@ -222,7 +242,10 @@ async def resolve_fault(
                 entity_id=fault_id,
                 action="resolve_fault",
                 user_role=user_context.get("role"),
-                change_summary="Fault resolved",
+                change_summary=f"Fault resolved — status: {prev_status} → resolved",
+                entity_name=entity_name,
+                previous_state={"status": prev_status},
+                new_state=new_state,
             )
             db_client.table("ledger_events").insert(ledger_event).execute()
         except Exception as ledger_err:
@@ -246,7 +269,7 @@ async def diagnose_fault(
 
     current = (
         db_client.table("pms_faults")
-        .select("id, metadata")
+        .select("id, metadata, title")
         .eq("id", fault_id)
         .eq("yacht_id", yacht_id)
         .single()
@@ -255,8 +278,11 @@ async def diagnose_fault(
     if not current.data:
         raise HTTPException(status_code=404, detail="Fault not found")
 
+    entity_name = current.data.get("title") or ""
+    diagnosis_text = payload.get("diagnosis", "")
+
     metadata = current.data.get("metadata", {}) or {}
-    metadata["diagnosis"] = payload.get("diagnosis", "")
+    metadata["diagnosis"] = diagnosis_text
     metadata["diagnosed_by"] = user_id
     metadata["diagnosed_at"] = datetime.now(timezone.utc).isoformat()
 
@@ -281,12 +307,14 @@ async def diagnose_fault(
             ledger_event = build_ledger_event(
                 yacht_id=yacht_id,
                 user_id=user_id,
-                event_type="status_change",
+                event_type="update",
                 entity_type="fault",
                 entity_id=fault_id,
                 action="diagnose_fault",
                 user_role=user_context.get("role"),
                 change_summary="Fault diagnosed",
+                entity_name=entity_name,
+                new_state={"diagnosis": diagnosis_text, "diagnosed_by": user_id},
             )
             db_client.table("ledger_events").insert(ledger_event).execute()
         except Exception as ledger_err:
@@ -312,7 +340,7 @@ async def close_fault(
 
     check = (
         db_client.table("pms_faults")
-        .select("id, status")
+        .select("id, status, title")
         .eq("id", fault_id)
         .eq("yacht_id", yacht_id)
         .single()
@@ -322,6 +350,7 @@ async def close_fault(
         raise HTTPException(status_code=404, detail="Fault not found")
 
     current_status = check.data.get("status", "open")
+    entity_name = check.data.get("title") or ""
     try:
         validate_state_transition("fault", current_status, "close_fault")
     except InvalidStateTransitionError as e:
@@ -359,7 +388,10 @@ async def close_fault(
                 entity_id=fault_id,
                 action="close_fault",
                 user_role=user_context.get("role"),
-                change_summary="Fault closed",
+                change_summary=f"Fault closed — status: {current_status} → closed",
+                entity_name=entity_name,
+                previous_state={"status": current_status},
+                new_state={"status": "closed"},
             )
             db_client.table("ledger_events").insert(ev).execute()
         except Exception as ledger_err:
@@ -385,7 +417,7 @@ async def update_fault(
 
     check = (
         db_client.table("pms_faults")
-        .select("id")
+        .select("id, title, description, severity, status")
         .eq("id", fault_id)
         .eq("yacht_id", yacht_id)
         .single()
@@ -393,6 +425,9 @@ async def update_fault(
     )
     if not check.data:
         raise HTTPException(status_code=404, detail="Fault not found")
+
+    prev = check.data
+    entity_name = prev.get("title") or ""
 
     update_data = {
         "updated_by": user_id,
@@ -419,6 +454,19 @@ async def update_fault(
     )
     if fault_result.data:
         try:
+            # Compute per-field diffs for change_summary
+            diff_fields = ("title", "description", "severity")
+            changes = []
+            for f in diff_fields:
+                old_val = prev.get(f)
+                new_val = update_data.get(f)
+                if new_val is not None and old_val != new_val:
+                    changes.append(f"{f}: {old_val} → {new_val}")
+            summary = "Fault updated" + (" — " + ", ".join(changes) if changes else "")
+
+            prev_state = {f: prev.get(f) for f in diff_fields}
+            new_state = {f: update_data.get(f, prev.get(f)) for f in diff_fields}
+
             ledger_event = build_ledger_event(
                 yacht_id=yacht_id,
                 user_id=user_id,
@@ -427,7 +475,10 @@ async def update_fault(
                 entity_id=fault_id,
                 action="update_fault",
                 user_role=user_context.get("role"),
-                change_summary="Fault updated",
+                change_summary=summary,
+                entity_name=entity_name,
+                previous_state=prev_state,
+                new_state=new_state,
             )
             db_client.table("ledger_events").insert(ledger_event).execute()
         except Exception as ledger_err:
@@ -453,7 +504,7 @@ async def reopen_fault(
 
     check = (
         db_client.table("pms_faults")
-        .select("id, status")
+        .select("id, status, title")
         .eq("id", fault_id)
         .eq("yacht_id", yacht_id)
         .single()
@@ -463,6 +514,7 @@ async def reopen_fault(
         raise HTTPException(status_code=404, detail="Fault not found")
 
     current_status = check.data.get("status", "open")
+    entity_name = check.data.get("title") or ""
     try:
         validate_state_transition("fault", current_status, "reopen_fault")
     except InvalidStateTransitionError as e:
@@ -502,7 +554,10 @@ async def reopen_fault(
                 entity_id=fault_id,
                 action="reopen_fault",
                 user_role=user_context.get("role"),
-                change_summary="Fault reopened",
+                change_summary=f"Fault reopened — status: {current_status} → open",
+                entity_name=entity_name,
+                previous_state={"status": current_status},
+                new_state={"status": "open"},
             )
             db_client.table("ledger_events").insert(ledger_event).execute()
         except Exception as ledger_err:
@@ -528,7 +583,7 @@ async def mark_fault_false_alarm(
 
     current = (
         db_client.table("pms_faults")
-        .select("id, metadata")
+        .select("id, metadata, title, status")
         .eq("id", fault_id)
         .eq("yacht_id", yacht_id)
         .single()
@@ -536,6 +591,9 @@ async def mark_fault_false_alarm(
     )
     if not current.data:
         raise HTTPException(status_code=404, detail="Fault not found")
+
+    entity_name = current.data.get("title") or ""
+    prev_status = current.data.get("status", "open")
 
     metadata = current.data.get("metadata", {}) or {}
     metadata["false_alarm"] = True
@@ -569,7 +627,10 @@ async def mark_fault_false_alarm(
                 entity_id=fault_id,
                 action="mark_fault_false_alarm",
                 user_role=user_context.get("role"),
-                change_summary="Fault marked as false alarm",
+                change_summary=f"Fault marked as false alarm — status: {prev_status} → closed",
+                entity_name=entity_name,
+                previous_state={"status": prev_status},
+                new_state={"status": "closed", "false_alarm": True},
             )
             db_client.table("ledger_events").insert(ledger_event).execute()
         except Exception as ledger_err:
@@ -710,7 +771,7 @@ async def add_fault_note(
 
     current = (
         db_client.table("pms_faults")
-        .select("id, metadata, severity")
+        .select("id, metadata, severity, title")
         .eq("id", fault_id)
         .eq("yacht_id", yacht_id)
         .single()
@@ -719,6 +780,7 @@ async def add_fault_note(
     if not current.data:
         raise HTTPException(status_code=404, detail="Fault not found")
 
+    entity_name = current.data.get("title") or ""
     metadata = current.data.get("metadata", {}) or {}
     current_severity = current.data.get("severity") or "medium"
     notes = metadata.get("notes", []) or []
@@ -750,6 +812,8 @@ async def add_fault_note(
             action="add_fault_note",
             user_role=user_context.get("role"),
             change_summary="Note added to fault",
+            entity_name=entity_name,
+            new_state={"note_text": note_text, "added_by": user_id},
         )
         db_client.table("ledger_events").insert(ledger_event).execute()
     except Exception as ledger_err:

--- a/apps/api/routes/handlers/ledger_utils.py
+++ b/apps/api/routes/handlers/ledger_utils.py
@@ -20,7 +20,10 @@ def build_ledger_event(
     metadata: dict = None,
     department: str = None,
     actor_name: str = None,
-    event_category: str = "write"
+    event_category: str = "write",
+    entity_name: str = None,
+    new_state: dict = None,
+    previous_state: dict = None,
 ) -> dict:
     """Build a ledger event with correct schema for ledger_events table.
 
@@ -51,6 +54,12 @@ def build_ledger_event(
     if actor_name:
         event_data["actor_name"] = actor_name
     event_data["event_category"] = event_category or "write"
+    if entity_name:
+        event_data["entity_name"] = entity_name
+    if new_state is not None:
+        event_data["new_state"] = new_state
+    if previous_state is not None:
+        event_data["previous_state"] = previous_state
 
     # Generate proof_hash (SHA-256 of event data)
     hash_input = json.dumps({

--- a/apps/api/routes/handlers/work_order_handler.py
+++ b/apps/api/routes/handlers/work_order_handler.py
@@ -35,6 +35,11 @@ async def update_work_order(
 ) -> dict:
     work_order_id = payload.get("work_order_id")
 
+    # Fetch before state
+    prev_result = db_client.table("pms_work_orders").select("id, title, description, priority, status").eq("id", work_order_id).eq("yacht_id", yacht_id).maybe_single().execute()
+    prev = prev_result.data or {}
+    entity_name = prev.get("title") or ""
+
     # Build update data
     update_data = {"updated_by": user_id, "updated_at": datetime.now(timezone.utc).isoformat()}
     if payload.get("description"):
@@ -49,7 +54,28 @@ async def update_work_order(
 
     wo_result = db_client.table("pms_work_orders").update(update_data).eq("id", work_order_id).eq("yacht_id", yacht_id).execute()
     if wo_result.data:
-        return {"status": "success", "message": "Work order updated"}
+        try:
+            diff_fields = ("title", "description", "priority")
+            changes = []
+            for f in diff_fields:
+                old_val = prev.get(f)
+                new_val = update_data.get(f)
+                if new_val is not None and old_val != new_val:
+                    changes.append(f"{f}: {old_val} → {new_val}")
+            summary = "Work order updated" + (" — " + ", ".join(changes) if changes else "")
+            ledger_event = build_ledger_event(
+                yacht_id=yacht_id, user_id=user_id, event_type="update",
+                entity_type="work_order", entity_id=work_order_id, action="update_work_order",
+                user_role=user_context.get("role"), change_summary=summary,
+                entity_name=entity_name,
+                previous_state={f: prev.get(f) for f in diff_fields},
+                new_state={f: update_data.get(f, prev.get(f)) for f in diff_fields},
+            )
+            db_client.table("ledger_events").insert(ledger_event).execute()
+        except Exception as ledger_err:
+            if "204" not in str(ledger_err):
+                logger.warning(f"[Ledger] Failed to record update_work_order: {ledger_err}")
+        return {"status": "success", "message": "Work order updated", "_ledger_written": True}
     else:
         return {"status": "error", "error_code": "UPDATE_FAILED", "message": "Failed to update work order"}
 
@@ -68,6 +94,11 @@ async def assign_work_order(
     work_order_id = payload.get("work_order_id")
     assigned_to = payload.get("assigned_to")
 
+    prev_result = db_client.table("pms_work_orders").select("id, title, assigned_to").eq("id", work_order_id).eq("yacht_id", yacht_id).maybe_single().execute()
+    prev = prev_result.data or {}
+    entity_name = prev.get("title") or ""
+    prev_assigned = prev.get("assigned_to")
+
     update_data = {
         "assigned_to": assigned_to,
         "updated_by": user_id,
@@ -79,7 +110,11 @@ async def assign_work_order(
             ledger_event = build_ledger_event(
                 yacht_id=yacht_id, user_id=user_id, event_type="assignment",
                 entity_type="work_order", entity_id=work_order_id, action="assign_work_order",
-                user_role=user_context.get("role"), change_summary="Work order assigned",
+                user_role=user_context.get("role"),
+                change_summary=f"Work order assigned — assigned_to: {prev_assigned} → {assigned_to}",
+                entity_name=entity_name,
+                previous_state={"assigned_to": prev_assigned},
+                new_state={"assigned_to": assigned_to},
             )
             db_client.table("ledger_events").insert(ledger_event).execute()
         except Exception as ledger_err:
@@ -103,18 +138,27 @@ async def close_work_order(
 ) -> dict:
     work_order_id = payload.get("work_order_id")
 
+    prev_result = db_client.table("pms_work_orders").select("id, title, status").eq("id", work_order_id).eq("yacht_id", yacht_id).maybe_single().execute()
+    prev = prev_result.data or {}
+    entity_name = prev.get("title") or ""
+    prev_status = prev.get("status", "open")
+
     # Note: completed_by has FK to non-existent users table, skip it
     update_data = {
         "status": "completed",
         "completed_at": datetime.now(timezone.utc).isoformat(),
         "updated_at": datetime.now(timezone.utc).isoformat()
     }
-    if payload.get("completion_notes"):
-        update_data["completion_notes"] = payload["completion_notes"]
+    completion_notes = payload.get("completion_notes")
+    if completion_notes:
+        update_data["completion_notes"] = completion_notes
 
     wo_result = db_client.table("pms_work_orders").update(update_data).eq("id", work_order_id).eq("yacht_id", yacht_id).execute()
     if wo_result.data:
         try:
+            new_state = {"status": "completed"}
+            if completion_notes:
+                new_state["completion_notes"] = completion_notes
             ledger_event = build_ledger_event(
                 yacht_id=yacht_id,
                 user_id=user_id,
@@ -123,7 +167,10 @@ async def close_work_order(
                 entity_id=work_order_id,
                 action="close_work_order",
                 user_role=user_context.get("role"),
-                change_summary="Work order closed",
+                change_summary=f"Work order closed — status: {prev_status} → completed",
+                entity_name=entity_name,
+                previous_state={"status": prev_status},
+                new_state=new_state,
             )
             db_client.table("ledger_events").insert(ledger_event).execute()
         except Exception as ledger_err:
@@ -147,13 +194,17 @@ async def add_wo_hours(
 ) -> dict:
     work_order_id = payload.get("work_order_id")
     hours = payload.get("hours", 0)
+    hours_description = payload.get("description", "Work performed")
+
+    wo_result = db_client.table("pms_work_orders").select("id, title").eq("id", work_order_id).eq("yacht_id", yacht_id).maybe_single().execute()
+    entity_name = (wo_result.data or {}).get("title") or ""
 
     # Add to work order notes as hours entry
     # Note: created_by is NOT NULL, use authenticated user_id
     # Note: note_type must be 'general' or 'progress'
     note_data = {
         "work_order_id": work_order_id,
-        "note_text": f"Hours logged: {hours}h - {payload.get('description', 'Work performed')}",
+        "note_text": f"Hours logged: {hours}h - {hours_description}",
         "note_type": "progress",
         "created_by": user_id,
         "created_at": datetime.now(timezone.utc).isoformat()
@@ -170,6 +221,8 @@ async def add_wo_hours(
                 action="add_wo_hours",
                 user_role=user_context.get("role"),
                 change_summary=f"Logged {hours} hours",
+                entity_name=entity_name,
+                new_state={"hours": hours, "description": hours_description},
             )
             db_client.table("ledger_events").insert(ledger_event).execute()
         except Exception as ledger_err:
@@ -267,6 +320,9 @@ async def add_wo_note(
         "created_by": user_id,
         "created_at": datetime.now(timezone.utc).isoformat()
     }
+    wo_result = db_client.table("pms_work_orders").select("id, title").eq("id", work_order_id).eq("yacht_id", yacht_id).maybe_single().execute()
+    entity_name = (wo_result.data or {}).get("title") or ""
+
     note_result = db_client.table("pms_work_order_notes").insert(note_data).execute()
     if note_result.data:
         result = {"status": "success", "message": "Note added to work order"}
@@ -280,6 +336,8 @@ async def add_wo_note(
                 action="add_wo_note",
                 user_role=user_context.get("role"),
                 change_summary="Note added to work order",
+                entity_name=entity_name,
+                new_state={"note_text": note_text, "note_type": note_type, "added_by": user_id},
             )
             db_client.table("ledger_events").insert(ledger_event).execute()
         except Exception as ledger_err:
@@ -305,6 +363,11 @@ async def start_work_order(
 ) -> dict:
     work_order_id = payload.get("work_order_id")
 
+    prev_result = db_client.table("pms_work_orders").select("id, title, status").eq("id", work_order_id).eq("yacht_id", yacht_id).maybe_single().execute()
+    prev = prev_result.data or {}
+    entity_name = prev.get("title") or ""
+    prev_status = prev.get("status", "planned")
+
     # Note: started_at column doesn't exist, just update status
     update_data = {
         "status": "in_progress",
@@ -317,7 +380,11 @@ async def start_work_order(
             ledger_event = build_ledger_event(
                 yacht_id=yacht_id, user_id=user_id, event_type="status_change",
                 entity_type="work_order", entity_id=work_order_id, action="start_work_order",
-                user_role=user_context.get("role"), change_summary="Work order started",
+                user_role=user_context.get("role"),
+                change_summary=f"Work order started — status: {prev_status} → in_progress",
+                entity_name=entity_name,
+                previous_state={"status": prev_status},
+                new_state={"status": "in_progress"},
             )
             db_client.table("ledger_events").insert(ledger_event).execute()
         except Exception as ledger_err:
@@ -341,6 +408,11 @@ async def cancel_work_order(
 ) -> dict:
     work_order_id = payload.get("work_order_id")
 
+    prev_result = db_client.table("pms_work_orders").select("id, title, status").eq("id", work_order_id).eq("yacht_id", yacht_id).maybe_single().execute()
+    prev = prev_result.data or {}
+    entity_name = prev.get("title") or ""
+    prev_status = prev.get("status", "open")
+
     # Note: cancellation columns don't exist, just update status and add note
     update_data = {
         "status": "cancelled",
@@ -353,7 +425,11 @@ async def cancel_work_order(
             ledger_event = build_ledger_event(
                 yacht_id=yacht_id, user_id=user_id, event_type="status_change",
                 entity_type="work_order", entity_id=work_order_id, action="cancel_work_order",
-                user_role=user_context.get("role"), change_summary="Work order cancelled",
+                user_role=user_context.get("role"),
+                change_summary=f"Work order cancelled — status: {prev_status} → cancelled",
+                entity_name=entity_name,
+                previous_state={"status": prev_status},
+                new_state={"status": "cancelled"},
             )
             db_client.table("ledger_events").insert(ledger_event).execute()
         except Exception as ledger_err:
@@ -463,7 +539,25 @@ async def create_work_order(
             # Log audit failure but don't fail the action
             logger.warning(f"Audit log failed for create_work_order (work_order_id={work_order_id}): {audit_err}")
 
-        return {"status": "success", "work_order_id": work_order_id, "message": "Work order created"}
+        try:
+            ledger_event = build_ledger_event(
+                yacht_id=yacht_id, user_id=user_id, event_type="create",
+                entity_type="work_order", entity_id=work_order_id, action="create_work_order",
+                user_role=user_context.get("role"),
+                change_summary=f"Work order created: {title}",
+                entity_name=title,
+                new_state={
+                    "title": title,
+                    "status": "planned",
+                    "priority": wo_data.get("priority"),
+                    "work_order_type": wo_data.get("work_order_type"),
+                },
+            )
+            db_client.table("ledger_events").insert(ledger_event).execute()
+        except Exception as ledger_err:
+            if "204" not in str(ledger_err):
+                logger.warning(f"[Ledger] Failed to record create_work_order: {ledger_err}")
+        return {"status": "success", "work_order_id": work_order_id, "message": "Work order created", "_ledger_written": True}
     else:
         return {"status": "error", "error_code": "INSERT_FAILED", "message": "Failed to create work order"}
 

--- a/apps/api/routes/ledger_routes.py
+++ b/apps/api/routes/ledger_routes.py
@@ -284,6 +284,7 @@ async def record_read_event(
     body = await request.json()
     entity_type = body.get("entity_type", "unknown")
     entity_id   = body.get("entity_id", "")
+    entity_name = body.get("entity_name", "")
     metadata    = body.get("metadata", {})
 
     yacht_id      = resolve_yacht_id(user_context, body.get("yacht_id"))
@@ -298,6 +299,10 @@ async def record_read_event(
 
     try:
         now_iso = datetime.utcnow().isoformat()
+        change_summary = (
+            f"Opened: {entity_name}" if entity_name
+            else f"Opened {entity_type.replace('_', ' ')}"
+        )
         ev = {
             "yacht_id":       str(yacht_id),
             "user_id":        str(user_id),
@@ -309,13 +314,15 @@ async def record_read_event(
             "action":         f"view_{entity_type}",
             "entity_type":    entity_type,
             "entity_id":      str(entity_id),
-            "change_summary": f"Opened {entity_type.replace('_', ' ')}",
+            "change_summary": change_summary,
             "source_context": "microaction",
             "metadata":       metadata,
             "proof_hash":     hashlib.sha256(
                 (f"{yacht_id}{user_id}view{entity_type}{entity_id}{now_iso}").encode()
             ).hexdigest(),
         }
+        if entity_name:
+            ev["entity_name"] = entity_name
         db_client = _get_tenant_client(tenant_alias)
         db_client.table("ledger_events").insert(ev).execute()
         return {"success": True}

--- a/apps/api/routes/p0_actions_routes.py
+++ b/apps/api/routes/p0_actions_routes.py
@@ -1127,7 +1127,17 @@ async def execute_action(
                 if meta:
                     try:
                         from routes.handlers.ledger_utils import build_ledger_event
+                        _ACTION_SUMMARY = {
+                            "add_note": "Note added",
+                            "upload_document": "Document uploaded",
+                            "reorder_part": "Part reorder requested",
+                            "adjust_stock_quantity": "Stock quantity adjusted",
+                            "add_checklist_item": "Checklist item added",
+                            "complete_checklist_item": "Checklist item completed",
+                        }
                         entity_id = payload.get(meta["entity_id_field"]) or yacht_id
+                        _summary = _ACTION_SUMMARY.get(action) or action.replace("_", " ").capitalize()
+                        _entity_name = result.get("entity_name") if isinstance(result, dict) else None
                         ledger_event = build_ledger_event(
                             yacht_id=yacht_id,
                             user_id=user_id,
@@ -1136,6 +1146,8 @@ async def execute_action(
                             entity_id=entity_id,
                             action=action,
                             user_role=user_context.get("role"),
+                            change_summary=_summary,
+                            entity_name=_entity_name,
                         )
                         db_client.table("ledger_events").insert(ledger_event).execute()
                     except Exception as _ledger_err:

--- a/apps/web/src/components/lens-v2/EntityLensPage.tsx
+++ b/apps/web/src/components/lens-v2/EntityLensPage.tsx
@@ -121,7 +121,11 @@ export function EntityLensPage({
 
   const signalCount = signalData?.items?.length ?? 0;
 
-  useReadBeacon(entityType, entityId);
+  useReadBeacon(
+    entityType,
+    entityId,
+    String(lens.entity?.title ?? lens.entity?.name ?? lens.entity?.reference_number ?? pageTitle ?? entityType.replace(/_/g, ' '))
+  );
 
   const handleNavigate = React.useCallback(
     (type: string, id: string) => {

--- a/apps/web/src/hooks/useReadBeacon.ts
+++ b/apps/web/src/hooks/useReadBeacon.ts
@@ -8,6 +8,7 @@ const API_BASE = process.env.NEXT_PUBLIC_API_URL || 'https://pipeline-core.int.c
 export function useReadBeacon(
   entityType: string,
   entityId: string | undefined,
+  entityName?: string,
   metadata?: Record<string, unknown>
 ) {
   const { session } = useAuth();
@@ -24,8 +25,9 @@ export function useReadBeacon(
       body: JSON.stringify({
         entity_type: entityType,
         entity_id: entityId,
+        entity_name: entityName ?? '',
         metadata: metadata ?? {},
       }),
     }).catch(() => { /* intentionally silent */ });
-  }, [entityType, entityId, token]);
+  }, [entityType, entityId, entityName, token]);
 }


### PR DESCRIPTION
## Summary

- Every ledger event now records the human name of the affected entity (e.g. \"Port Engine Overheating\" instead of a UUID)
- Before/after state snapshots captured on all fault and work order write actions
- Change summaries are now descriptive narratives (\"status: open → investigating\") instead of bare action names
- Read-event beacon passes entity title from lens page
- Verifier updated: Name column, before/after diff in Detail column, v1.0

## Files changed

- `apps/api/routes/handlers/ledger_utils.py` — new params: entity_name, new_state, previous_state
- `apps/api/routes/handlers/fault_handler.py` — all 9 write handlers enriched
- `apps/api/routes/handlers/work_order_handler.py` — all write handlers enriched + create_work_order gets ledger write
- `apps/api/routes/ledger_routes.py` — read-event endpoint accepts entity_name
- `apps/api/routes/p0_actions_routes.py` — safety net summary map + entity_name pass-through
- `apps/web/src/hooks/useReadBeacon.ts` — entityName param added
- `apps/web/src/components/lens-v2/EntityLensPage.tsx` — passes entity title to beacon

## DB migration

Applied manually: `ALTER TABLE ledger_events ADD COLUMN IF NOT EXISTS entity_name text`

## Test plan

- [ ] Acknowledge a fault → ledger row has entity_name, previous_state={status:open}, new_state={status:investigating}, change_summary contains the diff
- [ ] Open a fault lens page → ledger row has entity_name from page title, change_summary="Opened: <name>"
- [ ] Create a work order → ledger row has entity_name=title, new_state includes status/priority
- [ ] Generate sealed PDF export, drop on verify.celeste7.ai → Name column shows entity titles, Detail column shows state diffs

🤖 Generated with [Claude Code](https://claude.com/claude-code)