### PR TITLE
feat(ledger): verifier instructions + export logged to activity feed

### DIFF
--- a/apps/api/routes/ledger_routes.py
+++ b/apps/api/routes/ledger_routes.py
@@ -761,6 +761,21 @@ async def create_ledger_export(
             insert_row["cert_fingerprint"] = sealing_info.cert_fingerprint
         db_client.table("ledger_exports").insert(insert_row).execute()
 
+        # ── Ledger event ── record the export action in the activity log
+        try:
+            db_client.table("ledger_events").insert({
+                "yacht_id":       str(resolved_yid),
+                "user_id":        str(user_id),
+                "event_type":     "mutation",
+                "entity_type":    "ledger_export",
+                "entity_id":      str(export_id),
+                "action":         "export_generated",
+                "change_summary": f"Evidence PDF exported — {len(events)} events ({payload.scope}), {'sealed' if is_sealed else 'unsigned'}",
+                "metadata":       {"event_count": len(events), "scope": payload.scope, "sealed": is_sealed},
+            }).execute()
+        except Exception as _ev_err:
+            logger.warning(f"[Ledger] Export ledger event insert failed: {_ev_err}")
+
         # ── Notify ── fire-and-forget; never blocks the export response
         try:
             db_client.table("ledger_notifications").insert({

--- a/apps/web/src/components/ledger/LedgerPanel.tsx
+++ b/apps/web/src/components/ledger/LedgerPanel.tsx
@@ -395,6 +395,13 @@ export function LedgerPanel({ isOpen, onClose }: LedgerPanelProps) {
                     {exportResult.sealed && <span style={{ marginLeft: 8, fontSize: 10, background: 'var(--mark)', color: 'var(--surface)', padding: '1px 6px', borderRadius: 3 }}>SEALED</span>}
                   </div>
                   <div style={{ fontSize: 11, color: 'var(--txt3)', fontFamily: 'var(--font-mono)' }}>Signed URL expires in 1 hour</div>
+                  <div style={{ fontSize: 11, color: 'var(--txt2)', marginTop: 6, lineHeight: 1.5 }}>
+                    To verify authenticity: download the PDF, then upload it to{' '}
+                    <a href="https://verify.celeste7.ai" target="_blank" rel="noreferrer"
+                      style={{ color: 'var(--mark)', textDecoration: 'none', fontWeight: 600 }}>
+                      verify.celeste7.ai
+                    </a>
+                  </div>
                 </div>
                 <a
                   href={exportResult.url}


### PR DESCRIPTION
## Summary

- **LedgerPanel**: After generating a PDF, the result panel now instructs users to download then upload to [verify.celeste7.ai](https://verify.celeste7.ai) to confirm authenticity — includes a teal hyperlink
- **ledger_routes.py**: Every export now writes a `ledger_events` row (`action: export_generated`) so the action appears in the user's Activity Log with event count, scope, and sealed status

## What it looks like
Result panel now shows:
> Export ready — 1000 events · SEALED
> Signed URL expires in 1 hour
> To verify authenticity: download the PDF, then upload it to **verify.celeste7.ai**

## Ledger entry
The Activity Log will show:
> Evidence PDF exported — 1000 events (department), sealed

🤖 Generated with [Claude Code](https://claude.com/claude-code)