### PR TITLE
fix(warranty-list): include claim_number in domain records API response

### DIFF
--- a/apps/api/routes/vessel_surface_routes.py
+++ b/apps/api/routes/vessel_surface_routes.py
@@ -889,6 +889,20 @@ def _format_record(domain: str, record: dict) -> dict:
             "received_date": record.get("received_date"),
             "meta": f"{record.get('received_by', '')} · {record.get('status', '').upper()}",
         })
+    elif domain == "warranty":
+        claim_number = record.get("claim_number") or f"WC-{str(record.get('id', ''))[:6]}"
+        base.update({
+            "ref": claim_number,
+            "claim_number": claim_number,
+            "title": record.get("title") or claim_number,
+            "status": record.get("status", "draft"),
+            "vendor_name": record.get("vendor_name", ""),
+            "claimed_amount": record.get("claimed_amount"),
+            "currency": record.get("currency"),
+            "warranty_expiry": record.get("warranty_expiry"),
+            "created_at": record.get("created_at"),
+            "meta": f"{(record.get('status') or 'draft').upper()} · {record.get('vendor_name', '')}",
+        })
     else:
         # Generic fallback for other domains
         title_field = next(


### PR DESCRIPTION
## Summary
- Add explicit `warranty` case to `_format_record()` in `vessel_surface_routes.py`
- Previously fell through to generic fallback that set `ref` to UUID prefix, not `claim_number`
- Now maps `claim_number` → `ref` and passes it through so the frontend `warrantyAdapter` can render `entityRef` correctly

## Root cause
`warrantyAdapter` in `warranties/page.tsx` accesses `w.claim_number` to set `entityRef`. The generic `_format_record` fallback did not include `claim_number` in the API response, so every list row showed `—` instead of `WC-TEST-001`.

## Test impact  
Fixes T3-WAR-02, T3-WAR-03a/b/c, T3-WAR-BTN-01, T3-WAR-BTN-04, T3-WAR-FIELDS-01, T3-WAR-FIELDS-02.

🤖 Generated with [Claude Code](https://claude.com/claude-code)