### PR TITLE
feat(certs): complete certificate domain — renew, suspend, revoke, expiry, crew parity

### DIFF
--- a/apps/api/action_router/dispatchers/internal_dispatcher.py
+++ b/apps/api/action_router/dispatchers/internal_dispatcher.py
@@ -419,6 +419,38 @@ async def _cert_supersede_certificate(params: Dict[str, Any]) -> Dict[str, Any]:
     return await fn(**params)
 
 
+async def _cert_renew(params: Dict[str, Any]) -> Dict[str, Any]:
+    handlers = _get_certificate_handlers(get_supabase_client())
+    fn = handlers.get("renew_certificate")
+    if not fn:
+        raise ValueError("renew_certificate handler not registered")
+    return await fn(**params)
+
+
+async def _cert_archive(params: Dict[str, Any]) -> Dict[str, Any]:
+    handlers = _get_certificate_handlers(get_supabase_client())
+    fn = handlers.get("archive_certificate")
+    if not fn:
+        raise ValueError("archive_certificate handler not registered")
+    return await fn(**params)
+
+
+async def _cert_suspend(params: Dict[str, Any]) -> Dict[str, Any]:
+    handlers = _get_certificate_handlers(get_supabase_client())
+    fn = handlers.get("suspend_certificate")
+    if not fn:
+        raise ValueError("suspend_certificate handler not registered")
+    return await fn(**params)
+
+
+async def _cert_revoke(params: Dict[str, Any]) -> Dict[str, Any]:
+    handlers = _get_certificate_handlers(get_supabase_client())
+    fn = handlers.get("revoke_certificate")
+    if not fn:
+        raise ValueError("revoke_certificate handler not registered")
+    return await fn(**params)
+
+
 # ============================================================================
 # DOCUMENT WRAPPERS (bridge to document handlers - Document Lens v2)
 # ============================================================================
@@ -3917,9 +3949,9 @@ INTERNAL_HANDLERS: Dict[str, Any] = {
     "delete_work_order": _soft_delete_entity,
     "archive_fault": _soft_delete_entity,
     "delete_fault": _soft_delete_entity,
-    "archive_certificate": _soft_delete_entity,
-    "suspend_certificate": _soft_delete_entity,
-    "revoke_certificate": _soft_delete_entity,
+    "archive_certificate": _cert_archive,
+    "suspend_certificate": _cert_suspend,
+    "revoke_certificate": _cert_revoke,
     "archive_part": _soft_delete_entity,
     "delete_part": _soft_delete_entity,
     "cancel_po": _soft_delete_entity,
@@ -3935,7 +3967,7 @@ INTERNAL_HANDLERS: Dict[str, Any] = {
     # =========================================================================
     # Task 5: Stub Handlers (not yet implemented)
     # =========================================================================
-    "renew_certificate": _not_yet_implemented,
+    "renew_certificate": _cert_renew,
     "reorder_part": _part_add_to_shopping_list,
     "confirm_receiving": _recv_accept,
     "convert_to_po": _convert_to_po,

--- a/apps/api/action_router/ledger_metadata.py
+++ b/apps/api/action_router/ledger_metadata.py
@@ -64,9 +64,10 @@ ACTION_METADATA: dict = {
 
     # ── Certificates ─────────────────────────────────────────────────────────
     "add_certificate_note":              {"event_type": "update",        "entity_type": "certificate",   "entity_id_field": "certificate_id"},
-    "archive_certificate":               {"event_type": "update",        "entity_type": "certificate",   "entity_id_field": "certificate_id"},
-    "revoke_certificate":                {"event_type": "status_change", "entity_type": "certificate",   "entity_id_field": "certificate_id"},
-    "suspend_certificate":               {"event_type": "status_change", "entity_type": "certificate",   "entity_id_field": "certificate_id"},
+    "archive_certificate":               {"event_type": "update",        "entity_type": "certificate",   "entity_id_field": "entity_id"},
+    "renew_certificate":                 {"event_type": "create",        "entity_type": "certificate",   "entity_id_field": "certificate_id"},
+    "revoke_certificate":                {"event_type": "status_change", "entity_type": "certificate",   "entity_id_field": "entity_id"},
+    "suspend_certificate":               {"event_type": "status_change", "entity_type": "certificate",   "entity_id_field": "entity_id"},
 
     # ── Parts / Inventory ────────────────────────────────────────────────────
     "add_part_note":                     {"event_type": "update",        "entity_type": "part",          "entity_id_field": "part_id"},

--- a/apps/api/action_router/registry.py
+++ b/apps/api/action_router/registry.py
@@ -2550,7 +2550,7 @@ ACTION_REGISTRY: Dict[str, ActionDefinition] = {
         handler_type=HandlerType.INTERNAL,
         method="POST",
         allowed_roles=["chief_engineer", "captain", "manager"],
-        required_fields=["yacht_id", "equipment_id", "note_text"],
+        required_fields=["yacht_id", "certificate_id", "note_text"],
         domain="certificates",
         variant=ActionVariant.MUTATE,
     ),
@@ -3463,10 +3463,13 @@ ACTION_REGISTRY: Dict[str, ActionDefinition] = {
         endpoint="/v1/actions/execute",
         handler_type=HandlerType.INTERNAL,
         method="POST",
-        allowed_roles=["chief_engineer", "chief_officer", "captain", "manager"],
-        required_fields=["yacht_id", "entity_id"],
+        allowed_roles=["captain", "manager"],
+        required_fields=["yacht_id", "entity_id", "reason"],
         domain="certificates",
         variant=ActionVariant.SIGNED,
+        field_metadata={
+            "reason": {"name": "reason", "type": "text-area", "label": "Reason for suspension", "placeholder": "State the reason this certificate is being suspended..."},
+        },
     ),
 
     "revoke_certificate": ActionDefinition(
@@ -3475,10 +3478,13 @@ ACTION_REGISTRY: Dict[str, ActionDefinition] = {
         endpoint="/v1/actions/execute",
         handler_type=HandlerType.INTERNAL,
         method="POST",
-        allowed_roles=["chief_engineer", "chief_officer", "captain", "manager"],
-        required_fields=["yacht_id", "entity_id"],
+        allowed_roles=["captain", "manager"],
+        required_fields=["yacht_id", "entity_id", "reason"],
         domain="certificates",
         variant=ActionVariant.SIGNED,
+        field_metadata={
+            "reason": {"name": "reason", "type": "text-area", "label": "Reason for revocation", "placeholder": "State the reason this certificate is being revoked..."},
+        },
     ),
 
     "archive_part": ActionDefinition(
@@ -3624,9 +3630,15 @@ ACTION_REGISTRY: Dict[str, ActionDefinition] = {
         handler_type=HandlerType.INTERNAL,
         method="POST",
         allowed_roles=["chief_engineer", "captain", "manager"],
-        required_fields=["yacht_id", "certificate_id"],
+        required_fields=["yacht_id", "certificate_id", "new_issue_date", "new_expiry_date"],
         domain="certificates",
         variant=ActionVariant.MUTATE,
+        field_metadata={
+            "new_issue_date": {"name": "new_issue_date", "type": "date", "label": "New Issue Date", "placeholder": "YYYY-MM-DD"},
+            "new_expiry_date": {"name": "new_expiry_date", "type": "date", "label": "New Expiry Date", "placeholder": "YYYY-MM-DD"},
+            "new_certificate_number": {"name": "new_certificate_number", "type": "text", "label": "New Certificate Number (optional)", "placeholder": "e.g. ISM-2026-001"},
+            "new_issuing_authority": {"name": "new_issuing_authority", "type": "text", "label": "Issuing Authority (if changed)", "placeholder": "e.g. DNV GL"},
+        },
     ),
 
     "reorder_part": ActionDefinition(

--- a/apps/api/handlers/certificate_handlers.py
+++ b/apps/api/handlers/certificate_handlers.py
@@ -1158,6 +1158,8 @@ def _supersede_certificate_adapter(handlers: CertificateHandlers):
             "is_signed": True,
         }
 
+    return _fn
+
 
 def _resolve_cert_domain(db, yacht_id: str, cert_id: str) -> tuple:
     """

--- a/apps/api/handlers/certificate_handlers.py
+++ b/apps/api/handlers/certificate_handlers.py
@@ -1162,12 +1162,17 @@ def _supersede_certificate_adapter(handlers: CertificateHandlers):
 def _resolve_cert_domain(db, yacht_id: str, cert_id: str) -> tuple:
     """
     Auto-detect which table a certificate belongs to.
-    Returns (table_name, row_data) or raises ValueError if not found.
+    Returns (domain, table_key, row_data) or raises ValueError if not found.
+
+    Uses .execute() with limit(1) instead of maybe_single() because
+    maybe_single() returns None (not a response object) when no row matches
+    in this supabase client version, causing AttributeError on .data access.
     """
     for domain, table_key in [("vessel", "vessel_certificates"), ("crew", "crew_certificates")]:
-        result = db.table(get_table(table_key)).select("*").eq("yacht_id", yacht_id).eq("id", cert_id).maybe_single().execute()
-        if result.data:
-            return domain, table_key, result.data
+        result = db.table(get_table(table_key)).select("*").eq("yacht_id", yacht_id).eq("id", cert_id).limit(1).execute()
+        rows = getattr(result, "data", None) or []
+        if rows:
+            return domain, table_key, rows[0]
     raise ValueError(f"Certificate {cert_id} not found or access denied")
 
 

--- a/apps/api/handlers/certificate_handlers.py
+++ b/apps/api/handlers/certificate_handlers.py
@@ -105,6 +105,12 @@ class CertificateHandlers:
             status_filter = params.get("status")
             cert_type_filter = params.get("certificate_type")
 
+            # Refresh expired status before listing (lazy expiry evaluation)
+            try:
+                self.db.rpc("refresh_certificate_expiry", {"p_yacht_id": yacht_id}).execute()
+            except Exception:
+                pass
+
             # Build query
             query = self.db.table(get_table("vessel_certificates")).select(
                 map_vessel_certificate_select(),
@@ -180,6 +186,12 @@ class CertificateHandlers:
             limit = params.get("limit", 50)
             person_filter = params.get("person_name")
             cert_type_filter = params.get("certificate_type")
+
+            # Refresh expired status before listing (lazy expiry evaluation)
+            try:
+                self.db.rpc("refresh_certificate_expiry", {"p_yacht_id": yacht_id}).execute()
+            except Exception:
+                pass
 
             # Build query
             query = self.db.table(get_table("crew_certificates")).select(
@@ -652,6 +664,9 @@ def get_certificate_handlers(supabase_client) -> Dict[str, callable]:
     """Get certificate handler functions for registration."""
     handlers = CertificateHandlers(supabase_client)
 
+    _suspend = _change_certificate_status_adapter("suspended")(handlers)
+    _revoke = _change_certificate_status_adapter("revoked")(handlers)
+
     return {
         # READ handlers
         "list_vessel_certificates": handlers.list_vessel_certificates,
@@ -666,6 +681,10 @@ def get_certificate_handlers(supabase_client) -> Dict[str, callable]:
         "update_certificate": _update_certificate_adapter(handlers),
         "link_document_to_certificate": _link_document_to_certificate_adapter(handlers),
         "supersede_certificate": _supersede_certificate_adapter(handlers),
+        "renew_certificate": _renew_certificate_adapter(handlers),
+        "suspend_certificate": _suspend,
+        "revoke_certificate": _revoke,
+        "archive_certificate": _archive_certificate_adapter(handlers),
     }
 
 
@@ -1138,5 +1157,237 @@ def _supersede_certificate_adapter(handlers: CertificateHandlers):
             "reason": reason,
             "is_signed": True,
         }
+
+
+def _resolve_cert_domain(db, yacht_id: str, cert_id: str) -> tuple:
+    """
+    Auto-detect which table a certificate belongs to.
+    Returns (table_name, row_data) or raises ValueError if not found.
+    """
+    for domain, table_key in [("vessel", "vessel_certificates"), ("crew", "crew_certificates")]:
+        result = db.table(get_table(table_key)).select("*").eq("yacht_id", yacht_id).eq("id", cert_id).maybe_single().execute()
+        if result.data:
+            return domain, table_key, result.data
+    raise ValueError(f"Certificate {cert_id} not found or access denied")
+
+
+def _renew_certificate_adapter(handlers: "CertificateHandlers"):
+    async def _fn(**params):
+        """
+        Renew a certificate: mark old as superseded, create new with updated dates.
+
+        Expected params:
+        - yacht_id (str)
+        - user_id (str)
+        - certificate_id (str) — the certificate being renewed
+        - new_issue_date (str, ISO date)
+        - new_expiry_date (str, ISO date)
+        - new_certificate_number (str, optional)
+        - new_issuing_authority (str, optional)
+        """
+        db = handlers.db
+        yacht_id = params["yacht_id"]
+        user_id = params["user_id"]
+        cert_id = params["certificate_id"]
+        new_issue_date = params.get("new_issue_date")
+        new_expiry_date = params.get("new_expiry_date")
+
+        if not new_issue_date or not new_expiry_date:
+            raise ValueError("new_issue_date and new_expiry_date are required")
+        if new_expiry_date <= new_issue_date:
+            raise ValueError("new_expiry_date must be after new_issue_date")
+
+        domain, table_key, old_cert = _resolve_cert_domain(db, yacht_id, cert_id)
+        table = get_table(table_key)
+
+        if old_cert.get("status") in ("superseded", "revoked"):
+            raise ValueError(f"Cannot renew a certificate with status '{old_cert.get('status')}'")
+
+        now = datetime.now(timezone.utc).isoformat()
+
+        # Build new cert payload — copy all non-date fields from old cert
+        exclude = {"id", "created_at", "updated_at", "status", "deleted_at", "deleted_by",
+                   "issue_date", "expiry_date", "certificate_number", "issuing_authority",
+                   "last_survey_date", "next_survey_due", "is_seed", "source_id",
+                   "imported_at", "import_session_id"}
+        new_payload = {k: v for k, v in old_cert.items() if k not in exclude and v is not None}
+        new_payload.update({
+            "yacht_id": yacht_id,
+            "status": "valid",
+            "issue_date": new_issue_date,
+            "expiry_date": new_expiry_date,
+            "certificate_number": params.get("new_certificate_number") or old_cert.get("certificate_number"),
+            "issuing_authority": params.get("new_issuing_authority") or old_cert.get("issuing_authority"),
+            "source": "manual",
+            "is_seed": False,
+            "created_at": now,
+            "properties": {
+                **(old_cert.get("properties") or {}),
+                "renews": cert_id,
+                "renewed_at": now,
+            },
+        })
+        if domain == "vessel":
+            new_payload["last_survey_date"] = params.get("new_last_survey_date")
+            new_payload["next_survey_due"] = params.get("new_next_survey_due")
+
+        ins = db.table(table).insert(new_payload).execute()
+        new_id = (ins.data or [{}])[0].get("id")
+        if not new_id:
+            raise ValueError("Renewal insert did not return id")
+
+        # Mark old cert as superseded
+        db.table(table).update({
+            "status": "superseded",
+            "properties": {
+                **(old_cert.get("properties") or {}),
+                "superseded_at": now,
+                "superseded_by_renewal": new_id,
+            },
+        }).eq("yacht_id", yacht_id).eq("id", cert_id).execute()
+
+        # Audit log
+        try:
+            db.table("pms_audit_log").insert({
+                "yacht_id": yacht_id,
+                "entity_type": "certificate",
+                "entity_id": cert_id,
+                "action": "renew_certificate",
+                "user_id": user_id,
+                "old_values": {"status": old_cert.get("status"), "expiry_date": old_cert.get("expiry_date")},
+                "new_values": {"status": "superseded", "renewed_by": new_id, "new_expiry_date": new_expiry_date},
+                "signature": {},
+                "metadata": {"source": "certificate_lens", "domain": domain, "new_certificate_id": new_id},
+                "created_at": now,
+            }).execute()
+        except Exception:
+            pass
+
+        return {
+            "status": "success",
+            "renewed_certificate_id": new_id,
+            "superseded_certificate_id": cert_id,
+            "new_expiry_date": new_expiry_date,
+        }
+
+    return _fn
+
+
+def _change_certificate_status_adapter(new_status: str):
+    """
+    Factory that returns a handler for suspend/revoke — both are status-change operations.
+    new_status: 'suspended' | 'revoked'
+    """
+    def _make(handlers: "CertificateHandlers"):
+        async def _fn(**params):
+            db = handlers.db
+            yacht_id = params["yacht_id"]
+            user_id = params["user_id"]
+            # entity_id is the canonical key from the action router for archive/suspend/revoke
+            cert_id = params.get("entity_id") or params.get("certificate_id")
+            reason = params.get("reason", "")
+            signature = params.get("signature", {})
+
+            if not cert_id:
+                raise ValueError("entity_id (certificate id) is required")
+
+            domain, table_key, old_cert = _resolve_cert_domain(db, yacht_id, cert_id)
+            table = get_table(table_key)
+
+            current_status = old_cert.get("status")
+            if current_status in ("superseded", "revoked"):
+                raise ValueError(f"Cannot change status of a certificate in terminal state '{current_status}'")
+            if current_status == new_status:
+                raise ValueError(f"Certificate is already '{new_status}'")
+
+            now = datetime.now(timezone.utc).isoformat()
+            db.table(table).update({
+                "status": new_status,
+                "properties": {
+                    **(old_cert.get("properties") or {}),
+                    f"{new_status}_at": now,
+                    f"{new_status}_by": user_id,
+                    f"{new_status}_reason": reason,
+                },
+            }).eq("yacht_id", yacht_id).eq("id", cert_id).execute()
+
+            try:
+                db.table("pms_audit_log").insert({
+                    "yacht_id": yacht_id,
+                    "entity_type": "certificate",
+                    "entity_id": cert_id,
+                    "action": f"{new_status}_certificate",
+                    "user_id": user_id,
+                    "old_values": {"status": current_status},
+                    "new_values": {"status": new_status, "reason": reason},
+                    "signature": signature if signature else {},
+                    "metadata": {"source": "certificate_lens", "domain": domain, "is_signed_action": bool(signature)},
+                    "created_at": now,
+                }).execute()
+            except Exception:
+                pass
+
+            return {
+                "status": "success",
+                "certificate_id": cert_id,
+                "new_status": new_status,
+                "reason": reason,
+            }
+
+        return _fn
+    return _make
+
+
+def _archive_certificate_adapter(handlers: "CertificateHandlers"):
+    async def _fn(**params):
+        """
+        Archive a certificate (soft-delete). Works for both vessel and crew.
+
+        Expected params:
+        - yacht_id (str)
+        - user_id (str)
+        - entity_id (str) — the certificate UUID
+        """
+        db = handlers.db
+        yacht_id = params["yacht_id"]
+        user_id = params["user_id"]
+        cert_id = params.get("entity_id") or params.get("certificate_id")
+        signature = params.get("signature", {})
+
+        if not cert_id:
+            raise ValueError("entity_id (certificate id) is required")
+
+        domain, table_key, old_cert = _resolve_cert_domain(db, yacht_id, cert_id)
+        table = get_table(table_key)
+
+        now = datetime.now(timezone.utc).isoformat()
+        db.table(table).update({
+            "deleted_at": now,
+            "deleted_by": user_id,
+        }).eq("yacht_id", yacht_id).eq("id", cert_id).execute()
+
+        try:
+            db.table("pms_audit_log").insert({
+                "yacht_id": yacht_id,
+                "entity_type": "certificate",
+                "entity_id": cert_id,
+                "action": "archive_certificate",
+                "user_id": user_id,
+                "old_values": {"deleted_at": None},
+                "new_values": {"deleted_at": now},
+                "signature": signature if signature else {},
+                "metadata": {"source": "certificate_lens", "domain": domain},
+                "created_at": now,
+            }).execute()
+        except Exception:
+            pass
+
+        return {
+            "status": "success",
+            "certificate_id": cert_id,
+            "archived_at": now,
+        }
+
+    return _fn
 
     return _fn

--- a/apps/api/routes/handlers/certificate_handler.py
+++ b/apps/api/routes/handlers/certificate_handler.py
@@ -33,13 +33,16 @@ def _enforce_rbac(action: str, user_context: dict) -> None:
 
 
 async def _delegate(action_name: str, db_client: Client, payload: dict,
-                    yacht_id: str, user_id: str, user_context: dict) -> dict:
+                    yacht_id: str, user_id: str, user_context: dict,
+                    context: dict = None) -> dict:
     from handlers.certificate_handlers import get_certificate_handlers
     handlers = get_certificate_handlers(db_client)
     fn = handlers.get(action_name)
     if not fn:
         raise HTTPException(501, detail=f"'{action_name}' not registered in certificate_handlers")
-    return await fn(**{"yacht_id": yacht_id, "user_id": user_id, **payload})
+    # Merge context (contains entity_id/certificate_id) + payload into params
+    merged = {"yacht_id": yacht_id, "user_id": user_id, **(context or {}), **payload}
+    return await fn(**merged)
 
 
 async def create_vessel_certificate(payload, context, yacht_id, user_id, user_context, db_client):
@@ -54,7 +57,7 @@ async def create_crew_certificate(payload, context, yacht_id, user_id, user_cont
 
 async def update_certificate(payload, context, yacht_id, user_id, user_context, db_client):
     _enforce_rbac("update_certificate", user_context)
-    return await _delegate("update_certificate", db_client, payload, yacht_id, user_id, user_context)
+    return await _delegate("update_certificate", db_client, payload, yacht_id, user_id, user_context, context)
 
 
 async def link_document_to_certificate(payload, context, yacht_id, user_id, user_context, db_client):
@@ -68,14 +71,14 @@ async def link_document_to_certificate(payload, context, yacht_id, user_id, user
         dm = None
     if not getattr(dm, "data", None):
         raise HTTPException(404, detail="document_id not found")
-    return await _delegate("link_document_to_certificate", db_client, payload, yacht_id, user_id, user_context)
+    return await _delegate("link_document_to_certificate", db_client, payload, yacht_id, user_id, user_context, context)
 
 
 async def supersede_certificate(payload, context, yacht_id, user_id, user_context, db_client):
     _enforce_rbac("supersede_certificate", user_context)
     if not payload.get("signature"):
         raise HTTPException(400, detail="signature payload required for supersede (signed action)")
-    return await _delegate("supersede_certificate", db_client, payload, yacht_id, user_id, user_context)
+    return await _delegate("supersede_certificate", db_client, payload, yacht_id, user_id, user_context, context)
 
 
 HANDLERS: dict = {

--- a/apps/api/routes/handlers/certificate_handler.py
+++ b/apps/api/routes/handlers/certificate_handler.py
@@ -1,15 +1,12 @@
 """
-Certificate Action Handlers
+Certificate Action Handlers — Phase 4 native.
 
-Migrated from p0_actions_routes.py elif blocks (Phase 4, Task 5).
-Handler contract: see handlers/__init__.py header.
-Do NOT call get_tenant_supabase_client — db_client is pre-constructed by dispatcher.
+These handlers take priority over the internal_adapter shim in routes/handlers/__init__.py.
+Only Phase 4 native handlers live here. All other certificate actions (renew, archive,
+suspend, revoke, add_note) are handled by internal_adapter → internal_dispatcher → certificate_handlers.
 
-Block 1 (L2557-2562): add_certificate, renew_certificate, add_service_contract, record_contract_claim
-    — BLOCKED: pms_certificates / pms_service_contracts tables do not exist.
-Block 2 (L4897-4959): create_vessel_certificate, create_crew_certificate, update_certificate,
-    link_document_to_certificate, supersede_certificate
-    — Delegates to handlers.certificate_handlers.CertificateHandlers via get_certificate_handlers().
+Routing priority (from __init__.py):
+    CERT_HANDLERS (this file) > ADAPTER_HANDLERS (internal_adapter)
 """
 import logging
 
@@ -18,202 +15,74 @@ from supabase import Client
 
 logger = logging.getLogger(__name__)
 
-# RBAC mapping for Certificate Lens v2 actions (from original elif block L4902-4908)
-_CERT_V2_ALLOWED_ROLES = {
+_ALLOWED_ROLES: dict = {
     "create_vessel_certificate": ["chief_engineer", "captain", "manager"],
-    "create_crew_certificate": ["chief_engineer", "captain", "manager"],
-    "update_certificate": ["chief_engineer", "captain", "manager"],
+    "create_crew_certificate":   ["chief_engineer", "captain", "manager"],
+    "update_certificate":        ["chief_engineer", "captain", "manager"],
     "link_document_to_certificate": ["chief_engineer", "captain", "manager"],
-    "supersede_certificate": ["captain", "manager"],
+    "supersede_certificate":     ["captain", "manager"],
 }
 
 
-# ============================================================================
-# BLOCKED ACTIONS (L2557-2562) — tables do not exist yet
-# ============================================================================
-
-async def add_certificate(
-    payload: dict,
-    context: dict,
-    yacht_id: str,
-    user_id: str,
-    user_context: dict,
-    db_client: Client,
-) -> dict:
-    raise HTTPException(
-        status_code=501,
-        detail="Action 'add_certificate' BLOCKED: pms_certificates/pms_service_contracts tables do not exist."
-    )
+def _enforce_rbac(action: str, user_context: dict) -> None:
+    role = user_context.get("role", "")
+    allowed = _ALLOWED_ROLES.get(action, [])
+    if role not in allowed:
+        logger.warning(f"[RLS] Role '{role}' denied for '{action}'. Allowed: {allowed}")
+        raise HTTPException(403, detail=f"Role '{role}' not authorised for '{action}'")
 
 
-async def renew_certificate(
-    payload: dict,
-    context: dict,
-    yacht_id: str,
-    user_id: str,
-    user_context: dict,
-    db_client: Client,
-) -> dict:
-    raise HTTPException(
-        status_code=501,
-        detail="Action 'renew_certificate' BLOCKED: pms_certificates/pms_service_contracts tables do not exist."
-    )
-
-
-async def add_service_contract(
-    payload: dict,
-    context: dict,
-    yacht_id: str,
-    user_id: str,
-    user_context: dict,
-    db_client: Client,
-) -> dict:
-    raise HTTPException(
-        status_code=501,
-        detail="Action 'add_service_contract' BLOCKED: pms_certificates/pms_service_contracts tables do not exist."
-    )
-
-
-async def record_contract_claim(
-    payload: dict,
-    context: dict,
-    yacht_id: str,
-    user_id: str,
-    user_context: dict,
-    db_client: Client,
-) -> dict:
-    raise HTTPException(
-        status_code=501,
-        detail="Action 'record_contract_claim' BLOCKED: pms_certificates/pms_service_contracts tables do not exist."
-    )
-
-
-# ============================================================================
-# CERT LENS V2 ACTIONS (L4897-4959) — delegate to handlers.certificate_handlers
-# ============================================================================
-
-async def _delegate_to_cert_handler(
-    action_name: str,
-    db_client: Client,
-    payload: dict,
-    yacht_id: str,
-    user_id: str,
-    user_context: dict,
-) -> dict:
-    """Single factory call shared by all cert v2 delegate functions."""
+async def _delegate(action_name: str, db_client: Client, payload: dict,
+                    yacht_id: str, user_id: str, user_context: dict) -> dict:
     from handlers.certificate_handlers import get_certificate_handlers
-    cert_handlers = get_certificate_handlers(db_client)
-    handler_fn = cert_handlers.get(action_name)
-    if not handler_fn:
-        raise HTTPException(status_code=501, detail=f"Certificate action '{action_name}' not implemented")
-    handler_params = {"yacht_id": yacht_id, "user_id": user_id, **payload}
-    return await handler_fn(**handler_params)
+    handlers = get_certificate_handlers(db_client)
+    fn = handlers.get(action_name)
+    if not fn:
+        raise HTTPException(501, detail=f"'{action_name}' not registered in certificate_handlers")
+    return await fn(**{"yacht_id": yacht_id, "user_id": user_id, **payload})
 
 
-async def create_vessel_certificate(
-    payload: dict,
-    context: dict,
-    yacht_id: str,
-    user_id: str,
-    user_context: dict,
-    db_client: Client,
-) -> dict:
-    _enforce_cert_rbac("create_vessel_certificate", user_context)
-    return await _delegate_to_cert_handler("create_vessel_certificate", db_client, payload, yacht_id, user_id, user_context)
+async def create_vessel_certificate(payload, context, yacht_id, user_id, user_context, db_client):
+    _enforce_rbac("create_vessel_certificate", user_context)
+    return await _delegate("create_vessel_certificate", db_client, payload, yacht_id, user_id, user_context)
 
 
-async def create_crew_certificate(
-    payload: dict,
-    context: dict,
-    yacht_id: str,
-    user_id: str,
-    user_context: dict,
-    db_client: Client,
-) -> dict:
-    _enforce_cert_rbac("create_crew_certificate", user_context)
-    return await _delegate_to_cert_handler("create_crew_certificate", db_client, payload, yacht_id, user_id, user_context)
+async def create_crew_certificate(payload, context, yacht_id, user_id, user_context, db_client):
+    _enforce_rbac("create_crew_certificate", user_context)
+    return await _delegate("create_crew_certificate", db_client, payload, yacht_id, user_id, user_context)
 
 
-async def update_certificate(
-    payload: dict,
-    context: dict,
-    yacht_id: str,
-    user_id: str,
-    user_context: dict,
-    db_client: Client,
-) -> dict:
-    _enforce_cert_rbac("update_certificate", user_context)
-    return await _delegate_to_cert_handler("update_certificate", db_client, payload, yacht_id, user_id, user_context)
+async def update_certificate(payload, context, yacht_id, user_id, user_context, db_client):
+    _enforce_rbac("update_certificate", user_context)
+    return await _delegate("update_certificate", db_client, payload, yacht_id, user_id, user_context)
 
 
-async def link_document_to_certificate(
-    payload: dict,
-    context: dict,
-    yacht_id: str,
-    user_id: str,
-    user_context: dict,
-    db_client: Client,
-) -> dict:
-    _enforce_cert_rbac("link_document_to_certificate", user_context)
-    # Defensive validation: ensure document exists (from original L4944-4953)
+async def link_document_to_certificate(payload, context, yacht_id, user_id, user_context, db_client):
+    _enforce_rbac("link_document_to_certificate", user_context)
     doc_id = payload.get("document_id")
     if not doc_id:
-        raise HTTPException(status_code=400, detail="document_id is required")
+        raise HTTPException(400, detail="document_id is required")
     try:
         dm = db_client.table("doc_metadata").select("id").eq("id", doc_id).maybe_single().execute()
     except Exception:
         dm = None
-    if not getattr(dm, 'data', None):
-        raise HTTPException(status_code=404, detail="document_id not found")
+    if not getattr(dm, "data", None):
+        raise HTTPException(404, detail="document_id not found")
+    return await _delegate("link_document_to_certificate", db_client, payload, yacht_id, user_id, user_context)
 
-    return await _delegate_to_cert_handler("link_document_to_certificate", db_client, payload, yacht_id, user_id, user_context)
 
-
-async def supersede_certificate(
-    payload: dict,
-    context: dict,
-    yacht_id: str,
-    user_id: str,
-    user_context: dict,
-    db_client: Client,
-) -> dict:
-    _enforce_cert_rbac("supersede_certificate", user_context)
-    # Signature required (from original L4957-4958)
+async def supersede_certificate(payload, context, yacht_id, user_id, user_context, db_client):
+    _enforce_rbac("supersede_certificate", user_context)
     if not payload.get("signature"):
-        raise HTTPException(status_code=400, detail="signature payload is required for supersede action")
-
-    return await _delegate_to_cert_handler("supersede_certificate", db_client, payload, yacht_id, user_id, user_context)
-
-
-# ============================================================================
-# HELPERS
-# ============================================================================
-
-def _enforce_cert_rbac(action: str, user_context: dict) -> None:
-    """Check RBAC for cert v2 actions. Raises HTTPException(403) if denied."""
-    user_role = user_context.get("role", "")
-    allowed_roles = _CERT_V2_ALLOWED_ROLES.get(action, [])
-    if user_role not in allowed_roles:
-        logger.warning(f"[RLS] Role '{user_role}' denied for action '{action}'. Allowed: {allowed_roles}")
-        raise HTTPException(
-            status_code=403,
-            detail=f"Role '{user_role}' is not authorized to perform action '{action}'"
-        )
+        raise HTTPException(400, detail="signature payload required for supersede (signed action)")
+    return await _delegate("supersede_certificate", db_client, payload, yacht_id, user_id, user_context)
 
 
-# ============================================================================
-# HANDLER REGISTRY
-# ============================================================================
 HANDLERS: dict = {
-    # Blocked legacy actions (501)
-    "add_certificate": add_certificate,
-    "renew_certificate": renew_certificate,
-    "add_service_contract": add_service_contract,
-    "record_contract_claim": record_contract_claim,
-    # Certificate Lens v2 actions (delegate)
-    "create_vessel_certificate": create_vessel_certificate,
-    "create_crew_certificate": create_crew_certificate,
-    "update_certificate": update_certificate,
+    "create_vessel_certificate":    create_vessel_certificate,
+    "create_crew_certificate":      create_crew_certificate,
+    "update_certificate":           update_certificate,
     "link_document_to_certificate": link_document_to_certificate,
-    "supersede_certificate": supersede_certificate,
+    "supersede_certificate":        supersede_certificate,
+    # renew, archive, suspend, revoke, add_note handled by internal_adapter → internal_dispatcher
 }

--- a/apps/api/routes/handlers/internal_adapter.py
+++ b/apps/api/routes/handlers/internal_adapter.py
@@ -77,6 +77,7 @@ def _make_adapter(action_id: str) -> Callable:
 _ACTIONS_TO_ADAPT = [
     "accept_receiving",
     "add_certificate_note",
+    "renew_certificate",
     "add_document_comment",
     "add_document_note",
     "add_entity_link",

--- a/apps/api/routes/p0_actions_routes.py
+++ b/apps/api/routes/p0_actions_routes.py
@@ -637,6 +637,14 @@ _WARRANTY_ACTIONS = frozenset({
     "add_warranty_note",
 })
 
+_CERT_ACTIONS = frozenset({
+    "create_vessel_certificate", "create_crew_certificate",
+    "update_certificate", "link_document_to_certificate",
+    "supersede_certificate", "renew_certificate",
+    "suspend_certificate", "revoke_certificate",
+    "archive_certificate", "add_certificate_note",
+})
+
 
 def resolve_entity_context(action: str, context: dict) -> dict:
     """
@@ -671,6 +679,8 @@ def resolve_entity_context(action: str, context: dict) -> dict:
             ctx.setdefault("handover_id", entity_id)
         elif action in _WARRANTY_ACTIONS:
             ctx.setdefault("warranty_id", entity_id)
+        elif action in _CERT_ACTIONS:
+            ctx.setdefault("certificate_id", entity_id)
 
     return ctx
 
@@ -893,9 +903,11 @@ async def execute_action(
     }
 
     if action in REQUIRED_FIELDS:
-        missing = [f for f in REQUIRED_FIELDS[action] if not payload.get(f)]
+        # Merge context + payload: context holds entity_id/certificate_id, payload holds user fields
+        merged_for_check = {**request.context, **payload}
+        missing = [f for f in REQUIRED_FIELDS[action] if not merged_for_check.get(f)]
         # Allow task_description OR description for add_worklist_task
-        if action == "add_worklist_task" and not payload.get("task_description") and payload.get("description"):
+        if action == "add_worklist_task" and not merged_for_check.get("task_description") and merged_for_check.get("description"):
             missing = [f for f in missing if f != "task_description"]
         if missing:
             raise HTTPException(

--- a/apps/api/tests/cert_binary_tests.py
+++ b/apps/api/tests/cert_binary_tests.py
@@ -1,0 +1,302 @@
+"""
+Certificate domain — binary verification tests.
+Each test: setup → call → query DB → PASS or FAIL (no middle ground).
+"""
+import asyncio
+import sys
+import uuid
+from datetime import datetime, timezone, date, timedelta
+
+# Wire the tenant supabase client directly with service key
+TENANT_URL = "https://vzsohavtuotocgrfkfyd.supabase.co"
+TENANT_KEY = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InZ6c29oYXZ0dW90b2NncmZrZnlkIiwicm9sZSI6InNlcnZpY2Vfcm9sZSIsImlhdCI6MTc2MzU5Mjg3NSwiZXhwIjoyMDc5MTY4ODc1fQ.fC7eC_4xGnCHIebPzfaJ18pFMPKgImE7BuN0I3A-pSY"
+YACHT_ID  = "85fe1119-b04c-41ac-80f1-829d23322598"
+USER_ID   = "00000000-0000-0000-0000-000000000001"  # synthetic test user
+
+from supabase import create_client
+db = create_client(TENANT_URL, TENANT_KEY)
+
+sys.path.insert(0, '/Users/celeste7/Documents/CLOUD_PMS/apps/api')
+from handlers.certificate_handlers import get_certificate_handlers
+handlers = get_certificate_handlers(db)
+
+results = []
+
+def record(name, passed, evidence):
+    mark = "PASS" if passed else "FAIL"
+    results.append((name, passed, evidence))
+    print(f"  [{mark}] {name}")
+    if not passed:
+        print(f"         Evidence: {evidence}")
+
+
+# ─── HELPERS ────────────────────────────────────────────────────────────────
+
+def make_vessel_cert(extra=None):
+    """Insert a test vessel cert, return its id."""
+    payload = {
+        "yacht_id": YACHT_ID,
+        "certificate_type": "TEST",
+        "certificate_name": f"Test Cert {uuid.uuid4().hex[:8]}",
+        "issuing_authority": "Test Authority",
+        "issue_date": "2025-01-01",
+        "expiry_date": "2026-01-01",
+        "status": "valid",
+        "source": "manual",
+        "is_seed": False,
+    }
+    if extra:
+        payload.update(extra)
+    r = db.table("pms_vessel_certificates").insert(payload).execute()
+    return r.data[0]["id"]
+
+def make_crew_cert(extra=None):
+    """Insert a test crew cert, return its id."""
+    payload = {
+        "yacht_id": YACHT_ID,
+        "person_name": f"Test Crew {uuid.uuid4().hex[:6]}",
+        "certificate_type": "TEST_CREW",
+        "issuing_authority": "Test Authority",
+        "issue_date": "2025-01-01",
+        "expiry_date": "2026-01-01",
+        "status": "valid",
+    }
+    if extra:
+        payload.update(extra)
+    r = db.table("pms_crew_certificates").insert(payload).execute()
+    return r.data[0]["id"]
+
+def get_vessel(cert_id):
+    return db.table("pms_vessel_certificates").select("*").eq("id", cert_id).maybe_single().execute().data
+
+def get_crew(cert_id):
+    return db.table("pms_crew_certificates").select("*").eq("id", cert_id).maybe_single().execute().data
+
+def get_notes_for_cert(cert_id):
+    return db.table("pms_notes").select("*").eq("certificate_id", cert_id).execute().data
+
+def get_audit(cert_id):
+    return db.table("pms_audit_log").select("*").eq("entity_id", cert_id).execute().data
+
+def cleanup(*ids_and_tables):
+    """Delete test rows."""
+    for table, id_ in ids_and_tables:
+        try:
+            db.table(table).delete().eq("id", id_).execute()
+        except Exception:
+            pass
+
+
+# ─── TEST 1: renew_certificate ──────────────────────────────────────────────
+print("\nT1: renew_certificate")
+old_id = make_vessel_cert()
+try:
+    result = asyncio.run(handlers["renew_certificate"](
+        yacht_id=YACHT_ID,
+        user_id=USER_ID,
+        certificate_id=old_id,
+        new_issue_date="2026-02-01",
+        new_expiry_date="2027-02-01",
+    ))
+    new_id = result.get("renewed_certificate_id")
+    # Verify 1: old cert is now superseded
+    old_row = get_vessel(old_id)
+    record("T1a: old cert status = superseded",
+           old_row and old_row["status"] == "superseded",
+           f"status={old_row and old_row['status']}")
+    # Verify 2: new cert exists with correct expiry
+    new_row = get_vessel(new_id) if new_id else None
+    record("T1b: new cert exists with new_expiry_date",
+           new_row and new_row["expiry_date"] == "2027-02-01" and new_row["status"] == "valid",
+           f"new_row={new_row}")
+    # Verify 3: audit log written
+    audit = get_audit(old_id)
+    record("T1c: audit log entry written",
+           any(a["action"] == "renew_certificate" for a in audit),
+           f"audit_actions={[a['action'] for a in audit]}")
+    cleanup(("pms_vessel_certificates", old_id), ("pms_vessel_certificates", new_id))
+except Exception as e:
+    record("T1: renew_certificate raised exception", False, str(e))
+    cleanup(("pms_vessel_certificates", old_id))
+
+
+# ─── TEST 2: suspend_certificate (vessel) ───────────────────────────────────
+print("\nT2: suspend_certificate (vessel)")
+cert_id = make_vessel_cert()
+try:
+    asyncio.run(handlers["suspend_certificate"](
+        yacht_id=YACHT_ID,
+        user_id=USER_ID,
+        entity_id=cert_id,
+        reason="Test suspension",
+        signature={"signer": USER_ID, "method": "test"},
+    ))
+    row = get_vessel(cert_id)
+    record("T2a: vessel cert status = suspended",
+           row and row["status"] == "suspended",
+           f"status={row and row['status']}")
+    audit = get_audit(cert_id)
+    record("T2b: audit log written",
+           any(a["action"] == "suspended_certificate" for a in audit),
+           f"audit_actions={[a['action'] for a in audit]}")
+    cleanup(("pms_vessel_certificates", cert_id))
+except Exception as e:
+    record("T2: suspend raised exception", False, str(e))
+    cleanup(("pms_vessel_certificates", cert_id))
+
+
+# ─── TEST 3: revoke_certificate (crew) ──────────────────────────────────────
+print("\nT3: revoke_certificate (crew cert)")
+crew_id = make_crew_cert()
+try:
+    asyncio.run(handlers["revoke_certificate"](
+        yacht_id=YACHT_ID,
+        user_id=USER_ID,
+        entity_id=crew_id,
+        reason="Test revocation",
+        signature={"signer": USER_ID, "method": "test"},
+    ))
+    row = get_crew(crew_id)
+    record("T3a: crew cert status = revoked",
+           row and row["status"] == "revoked",
+           f"status={row and row['status']}")
+    audit = get_audit(crew_id)
+    record("T3b: audit log written",
+           any(a["action"] == "revoked_certificate" for a in audit),
+           f"audit_actions={[a['action'] for a in audit]}")
+    cleanup(("pms_crew_certificates", crew_id))
+except Exception as e:
+    record("T3: revoke raised exception", False, str(e))
+    cleanup(("pms_crew_certificates", crew_id))
+
+
+# ─── TEST 4: archive_certificate — vessel ───────────────────────────────────
+print("\nT4: archive_certificate (vessel)")
+cert_id = make_vessel_cert()
+try:
+    asyncio.run(handlers["archive_certificate"](
+        yacht_id=YACHT_ID,
+        user_id=USER_ID,
+        entity_id=cert_id,
+    ))
+    row = get_vessel(cert_id)
+    record("T4a: vessel cert deleted_at is set",
+           row and row.get("deleted_at") is not None,
+           f"deleted_at={row and row.get('deleted_at')}")
+    # Verify it does NOT appear in v_certificates_enriched
+    view_row = db.table("v_certificates_enriched").select("id").eq("id", cert_id).execute().data
+    record("T4b: archived cert absent from v_certificates_enriched",
+           len(view_row) == 0,
+           f"view returned {len(view_row)} rows")
+    cleanup(("pms_vessel_certificates", cert_id))
+except Exception as e:
+    record("T4: archive vessel raised exception", False, str(e))
+    cleanup(("pms_vessel_certificates", cert_id))
+
+
+# ─── TEST 5: archive_certificate — crew ─────────────────────────────────────
+print("\nT5: archive_certificate (crew)")
+crew_id = make_crew_cert()
+try:
+    asyncio.run(handlers["archive_certificate"](
+        yacht_id=YACHT_ID,
+        user_id=USER_ID,
+        entity_id=crew_id,
+    ))
+    row = get_crew(crew_id)
+    record("T5a: crew cert deleted_at is set",
+           row and row.get("deleted_at") is not None,
+           f"deleted_at={row and row.get('deleted_at')}")
+    view_row = db.table("v_certificates_enriched").select("id").eq("id", crew_id).execute().data
+    record("T5b: archived crew cert absent from view",
+           len(view_row) == 0,
+           f"view returned {len(view_row)} rows")
+    cleanup(("pms_crew_certificates", crew_id))
+except Exception as e:
+    record("T5: archive crew raised exception", False, str(e))
+    cleanup(("pms_crew_certificates", crew_id))
+
+
+# ─── TEST 6: add_certificate_note ───────────────────────────────────────────
+print("\nT6: add_certificate_note")
+cert_id = make_vessel_cert()
+try:
+    from action_router.dispatchers.internal_dispatcher import add_note
+    asyncio.run(add_note({
+        "yacht_id": YACHT_ID,
+        "user_id": USER_ID,
+        "certificate_id": cert_id,
+        "note_text": "Binary verification test note",
+    }))
+    notes = get_notes_for_cert(cert_id)
+    record("T6a: note row exists with certificate_id set",
+           len(notes) == 1 and notes[0]["certificate_id"] == cert_id,
+           f"notes={notes}")
+    record("T6b: note text is correct",
+           len(notes) == 1 and notes[0]["text"] == "Binary verification test note",
+           f"text={notes[0]['text'] if notes else None}")
+    for n in notes:
+        db.table("pms_notes").delete().eq("id", n["id"]).execute()
+    cleanup(("pms_vessel_certificates", cert_id))
+except Exception as e:
+    record("T6: add_note raised exception", False, str(e))
+    cleanup(("pms_vessel_certificates", cert_id))
+
+
+# ─── TEST 7: refresh_certificate_expiry ─────────────────────────────────────
+print("\nT7: refresh_certificate_expiry")
+expired_id = make_vessel_cert({"expiry_date": "2020-01-01", "status": "valid"})
+expired_crew_id = make_crew_cert({"expiry_date": "2020-01-01", "status": "valid"})
+try:
+    db.rpc("refresh_certificate_expiry", {"p_yacht_id": YACHT_ID}).execute()
+    vessel_row = get_vessel(expired_id)
+    crew_row = get_crew(expired_crew_id)
+    record("T7a: past-expiry vessel cert status flipped to expired",
+           vessel_row and vessel_row["status"] == "expired",
+           f"status={vessel_row and vessel_row['status']}")
+    record("T7b: past-expiry crew cert status flipped to expired",
+           crew_row and crew_row["status"] == "expired",
+           f"status={crew_row and crew_row['status']}")
+    cleanup(("pms_vessel_certificates", expired_id), ("pms_crew_certificates", expired_crew_id))
+except Exception as e:
+    record("T7: refresh_certificate_expiry raised exception", False, str(e))
+    cleanup(("pms_vessel_certificates", expired_id), ("pms_crew_certificates", expired_crew_id))
+
+
+# ─── TEST 8: renew blocked on superseded cert ───────────────────────────────
+print("\nT8: renew rejected on superseded cert (guard)")
+cert_id = make_vessel_cert({"status": "superseded"})
+try:
+    asyncio.run(handlers["renew_certificate"](
+        yacht_id=YACHT_ID,
+        user_id=USER_ID,
+        certificate_id=cert_id,
+        new_issue_date="2026-01-01",
+        new_expiry_date="2027-01-01",
+    ))
+    record("T8: renew on superseded should have raised ValueError", False, "No exception raised")
+except ValueError as e:
+    record("T8: renew correctly rejected on superseded cert", True, str(e))
+except Exception as e:
+    record("T8: wrong exception type raised", False, str(e))
+finally:
+    cleanup(("pms_vessel_certificates", cert_id))
+
+
+# ─── SUMMARY ────────────────────────────────────────────────────────────────
+total = len(results)
+passed = sum(1 for _, p, _ in results if p)
+failed = total - passed
+
+print(f"\n{'='*60}")
+print(f"RESULTS: {passed}/{total} PASS  |  {failed}/{total} FAIL")
+print(f"{'='*60}")
+if failed:
+    print("\nFAILED TESTS:")
+    for name, ok, ev in results:
+        if not ok:
+            print(f"  FAIL  {name}")
+            print(f"        {ev}")
+    sys.exit(1)
+else:
+    print("ALL PASS — binary verified against live tenant DB.")

--- a/apps/web/src/components/lens-v2/actions/AttachmentUploadModal.tsx
+++ b/apps/web/src/components/lens-v2/actions/AttachmentUploadModal.tsx
@@ -1,11 +1,23 @@
 'use client';
 
 /**
- * WarrantyUploadModal — Warranty lens file upload action modal
+ * AttachmentUploadModal — Generic file upload modal for any entity lens.
  *
- * Uploads a document directly to Supabase storage bucket `pms-warranty-documents`,
- * then inserts a row to `pms_attachments`. Uses design system tokens exclusively.
- * Shows loading state during upload, handles errors via Toast.
+ * Uploads directly to the specified Supabase storage bucket, then inserts
+ * a row to pms_attachments. Reusable across all entity types.
+ *
+ * Usage:
+ *   <AttachmentUploadModal
+ *     open={open}
+ *     onClose={onClose}
+ *     entityType="warranty"
+ *     entityId={id}
+ *     bucket="pms-warranty-documents"
+ *     category="claim_document"
+ *     yachtId={yachtId}
+ *     userId={userId}
+ *     onComplete={refetch}
+ *   />
  */
 
 import * as React from 'react';
@@ -56,10 +68,16 @@ function sanitizeFilename(name: string): string {
 // Types
 // ---------------------------------------------------------------------------
 
-export interface WarrantyUploadModalProps {
+export interface AttachmentUploadModalProps {
   open: boolean;
   onClose: () => void;
+  /** Entity type written to pms_attachments.entity_type */
+  entityType: string;
   entityId: string;
+  /** Supabase storage bucket name */
+  bucket: string;
+  /** pms_attachments.category value */
+  category: string;
   yachtId: string;
   userId: string;
   onComplete: () => void;
@@ -69,20 +87,17 @@ export interface WarrantyUploadModalProps {
 // Component
 // ---------------------------------------------------------------------------
 
-/**
- * WarrantyUploadModal
- *
- * Modal overlay for uploading a document to a warranty claim.
- * Escape key dismisses. Cancel clears file selection.
- */
-export function WarrantyUploadModal({
+export function AttachmentUploadModal({
   open,
   onClose,
+  entityType,
   entityId,
+  bucket,
+  category,
   yachtId,
   userId,
   onComplete,
-}: WarrantyUploadModalProps) {
+}: AttachmentUploadModalProps) {
   const [file, setFile] = React.useState<File | null>(null);
   const [loading, setLoading] = React.useState(false);
   const [toast, setToast] = React.useState<{ type: 'success' | 'error'; message: string } | null>(null);
@@ -129,12 +144,12 @@ export function WarrantyUploadModal({
 
     setLoading(true);
     try {
-      // Build storage path
-      const path = `warranty/${entityId}/${Date.now()}-${sanitizeFilename(file.name)}`;
+      // Build storage path: {entityType}/{entityId}/{timestamp}-{filename}
+      const path = `${entityType}/${entityId}/${Date.now()}-${sanitizeFilename(file.name)}`;
 
       // Upload to Supabase storage
       const { error: uploadError } = await supabase.storage
-        .from('pms-warranty-documents')
+        .from(bucket)
         .upload(path, file, { contentType: file.type });
 
       if (uploadError) {
@@ -146,20 +161,20 @@ export function WarrantyUploadModal({
       const { error: insertError } = await supabase
         .from('pms_attachments')
         .insert({
-          entity_type: 'warranty',
+          entity_type: entityType,
           entity_id: entityId,
-          storage_bucket: 'pms-warranty-documents',
+          storage_bucket: bucket,
           storage_path: path,
           filename: file.name,
           mime_type: file.type,
           file_size: file.size,
-          category: 'claim_document',
+          category,
           uploaded_by: userId,
           yacht_id: yachtId,
         });
 
       if (insertError) {
-        // File is uploaded but metadata insert failed — partial state, still close
+        // File uploaded but metadata insert failed — partial state, still trigger refetch
         setToast({ type: 'error', message: insertError.message ?? 'Failed to save attachment record' });
         setTimeout(() => {
           onComplete();
@@ -193,45 +208,41 @@ export function WarrantyUploadModal({
       <div
         role="dialog"
         aria-modal="true"
-        aria-labelledby="warranty-upload-title"
+        aria-labelledby="attachment-upload-title"
         className={cn(
           'fixed left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2',
           'z-modal',
-          // Surface tokens
           'bg-surface-elevated border border-surface-border',
-          // Shape
           'rounded-lg shadow-modal',
-          // Width
           'w-full max-w-md mx-4'
         )}
       >
         {/* Header */}
         <div className="px-6 pt-6 pb-4 border-b border-surface-border">
           <h2
-            id="warranty-upload-title"
+            id="attachment-upload-title"
             className="text-heading text-txt-primary"
           >
             Upload Document
           </h2>
           <p className="mt-1 text-label text-txt-secondary">
-            Attach a file to this warranty claim.
+            Attach a file to this record.
           </p>
         </div>
 
         {/* Form */}
         <form onSubmit={handleUpload}>
           <div className="px-6 py-4 space-y-3">
-            {/* File input */}
             <div>
               <label
-                htmlFor="warranty-file-input"
+                htmlFor="attachment-file-input"
                 className="block text-label text-txt-primary mb-2"
               >
                 Select File
               </label>
               <input
                 ref={inputRef}
-                id="warranty-file-input"
+                id="attachment-file-input"
                 type="file"
                 accept={ACCEPTED_MIME_TYPES}
                 onChange={handleFileChange}
@@ -249,7 +260,6 @@ export function WarrantyUploadModal({
               />
             </div>
 
-            {/* File info / error */}
             {file && (
               <div className="space-y-1">
                 <p className="text-label text-txt-secondary truncate">
@@ -265,27 +275,18 @@ export function WarrantyUploadModal({
             )}
           </div>
 
-          {/* Footer buttons */}
+          {/* Footer */}
           <div className="px-6 pb-6 flex justify-end gap-3">
-            <GhostButton
-              type="button"
-              onClick={handleCancel}
-              disabled={loading}
-            >
+            <GhostButton type="button" onClick={handleCancel} disabled={loading}>
               Cancel
             </GhostButton>
-            <PrimaryButton
-              type="submit"
-              disabled={!canUpload}
-              aria-busy={loading}
-            >
+            <PrimaryButton type="submit" disabled={!canUpload} aria-busy={loading}>
               {loading ? 'Uploading…' : 'Upload'}
             </PrimaryButton>
           </div>
         </form>
       </div>
 
-      {/* Toast notification */}
       {toast && (
         <Toast
           type={toast.type}

--- a/apps/web/src/components/lens-v2/entity/CertificateContent.tsx
+++ b/apps/web/src/components/lens-v2/entity/CertificateContent.tsx
@@ -204,9 +204,9 @@ export function CertificateContent() {
   const primaryDisabled = renewAction?.disabled ?? false;
   const primaryDisabledReason = renewAction?.disabled_reason;
 
-  const handlePrimary = React.useCallback(async () => {
-    await executeAction('renew_certificate', {});
-  }, [executeAction]);
+  const handlePrimary = React.useCallback(() => {
+    if (renewAction) openActionPopup(renewAction as any);
+  }, [renewAction]);
 
   const SPECIAL_HANDLERS: Record<string, () => void> = {};
   const DANGER_ACTIONS = new Set(['suspend_certificate', 'archive_certificate', 'revoke_certificate']);

--- a/apps/web/src/components/lens-v2/entity/WarrantyContent.tsx
+++ b/apps/web/src/components/lens-v2/entity/WarrantyContent.tsx
@@ -37,7 +37,7 @@ import {
 } from '../sections';
 import { ActionPopup, type ActionPopupField } from '../ActionPopup';
 import { AddNoteModal } from '@/components/lens-v2/actions/AddNoteModal';
-import { WarrantyUploadModal } from '@/components/lens-v2/actions/WarrantyUploadModal';
+import { AttachmentUploadModal } from '@/components/lens-v2/actions/AttachmentUploadModal';
 import { useAuth } from '@/hooks/useAuth';
 
 // ─── Helpers ───
@@ -390,10 +390,13 @@ export function WarrantyContent() {
         </ScrollReveal>
       )}
 
-      <WarrantyUploadModal
+      <AttachmentUploadModal
         open={uploadModalOpen}
         onClose={() => setUploadModalOpen(false)}
+        entityType="warranty"
         entityId={entityId}
+        bucket="pms-warranty-documents"
+        category="claim_document"
         yachtId={(entity?.yacht_id as string) ?? user?.yachtId ?? ''}
         userId={user?.id ?? ''}
         onComplete={() => { refetch(); }}

--- a/docs/CLICKTHROUGH_CHECKLIST.md
+++ b/docs/CLICKTHROUGH_CHECKLIST.md
@@ -1,0 +1,493 @@
+# CelesteOS Cloud PMS — Definitive Clickthrough Checklist
+
+**Purpose:** Exhaustive test of every page, every button, every action, every signature flow, every workflow journey. Verify the FULL round trip: click → modal → fill → submit → API call → DB insert → UI update.
+
+**How to use:**
+1. Open site + browser DevTools (Console tab + Network tab)
+2. Test 4 times — once per role (Crew, HOD, Captain, Fleet Manager)
+3. For every action: fill the form, SUBMIT, check Network for POST status, check Console for errors, check UI for result
+4. Mark: PASS (full round trip works) / FAIL (broken) / 403 (permission denied) / STUB (returns NOT_IMPLEMENTED)
+5. Paste any console error text in the Console column
+
+**Date:**  
+**Environment:** (local / staging / production)  
+**Browser:**
+
+---
+
+## TEST ACCOUNTS
+
+| Role | Account Email | Password | Notes |
+|------|-------------|----------|-------|
+| **Crew** (deckhand/steward) | | | Lowest privilege. Many mutations should 403. |
+| **HOD** (chief_engineer) | | | Engineering dept. Can sign handovers, manage WOs. Cannot: adjust stock, decommission, archive. |
+| **Captain** | | | Full access. SIGNED actions require PIN. Sees all departments in ledger. |
+| **Fleet Manager** | | | Multi-vessel. Test vessel switching. Full access + fleet view. |
+
+---
+
+## ROLE PERMISSION MATRIX
+
+**R = Allowed | X = Expect 403 | S = Signed (PIN required) | — = N/A**
+
+| Action | Crew | HOD | Captain | Fleet Mgr |
+|--------|------|-----|---------|-----------|
+| View any entity (read) | R | R | R | R |
+| report_fault | R | R | R | R |
+| add_fault_note | R | R | R | R |
+| add_wo_note | R | R | R | R |
+| add_equipment_note | R | R | R | R |
+| add_part_note | R | R | R | R |
+| add_po_note | R | R | R | R |
+| add_document_note | R | R | R | R |
+| add_warranty_note | R | R | R | R |
+| flag_equipment_attention | R | R | R | R |
+| upsert_hours_of_rest | R | R | R | R |
+| investigate_fault | X | R | R | R |
+| resolve_fault | X | R | R | R |
+| close_fault | X | R | R | R |
+| create_work_order | X | R | R | R |
+| start_work_order | X | R | R | R |
+| close_work_order | X | R | R | R |
+| add_wo_part | X | R | R | R |
+| add_wo_hours | X | R | R | R |
+| reassign_work_order | X | R | R | R |
+| create_work_order_for_equipment | X | R | R | R |
+| sign_handover | X | R | R | R |
+| add_to_handover | X | R | R | R |
+| cancel_po | X | R | R | R |
+| upload_document | X | R | R | R |
+| accept_receiving | X | R | R | R |
+| approve_shopping_list_item | X | R | R | R |
+| reject_shopping_list_item | X | R | R | R |
+| archive_fault | X | X | S | S |
+| archive_work_order | X | X | S | S |
+| decommission_equipment | X | X | S | S |
+| archive_handover | X | X | S | S |
+| adjust_stock_quantity | X | X | S | S |
+| write_off_part | X | X | S | S |
+
+**NOTE: Frontend shows ALL buttons to ALL roles.** Backend enforces via 403. If crew clicks "Archive" they'll see a 403 — the button shouldn't be visible but is. Log these as UX bugs.
+
+---
+
+## PART 1: NAVIGATION & SHELL
+
+### 1.1 Login & Auth
+
+| # | Action | Expected | Crew | HOD | Capt | Fleet | Console |
+|---|--------|----------|------|-----|------|-------|---------|
+| 1.1 | Enter valid credentials, Sign In | Redirect to `/` | | | | | |
+| 1.2 | Enter invalid credentials | Error message, no redirect | | | | | |
+| 1.3 | Forgot Password (if exists) | Reset email sent | | | | | |
+| 1.4 | Sign Out (hamburger menu) | `supabase.auth.signOut()`, redirect `/login` | | | | | |
+
+### 1.2 Sidebar Navigation (test every item loads)
+
+| # | Item | URL | Crew | HOD | Capt | Fleet | Console |
+|---|------|-----|------|-----|------|-------|---------|
+| 1.5 | Vessel Surface | `/` | | | | | |
+| 1.6 | Work Orders | `/work-orders` | | | | | |
+| 1.7 | Faults | `/faults` | | | | | |
+| 1.8 | Equipment | `/equipment` | | | | | |
+| 1.9 | Handover | `/handover-export` | | | | | |
+| 1.10 | Hours of Rest | `/hours-of-rest` | | | | | |
+| 1.11 | Email | `/email` | | | | | |
+| 1.12 | Parts / Inventory | `/inventory` | | | | | |
+| 1.13 | Shopping List | `/shopping-list` | | | | | |
+| 1.14 | Purchase Orders | `/purchasing` | | | | | |
+| 1.15 | Receiving | `/receiving` | | | | | |
+| 1.16 | Certificates | `/certificates` | | | | | |
+| 1.17 | Documents | `/documents` | | | | | |
+| 1.18 | Warranties | `/warranties` | | | | | |
+
+### 1.3 Topbar & Global Actions
+
+| # | Action | Expected | Crew | HOD | Capt | Fleet | Console |
+|---|--------|----------|------|-----|------|-------|---------|
+| 1.19 | Click search bar | Search overlay opens | | | | | |
+| 1.20 | Press Cmd+K | Search overlay opens | | | | | |
+| 1.21 | Type query, press Enter | Results grouped by entity type | | | | | |
+| 1.22 | Click a search result | Navigate to entity detail, overlay closes | | | | | |
+| 1.23 | Press Esc in search | Overlay closes | | | | | |
+| 1.24 | Hamburger > Activity Log | Ledger panel opens (right drawer, 480px) | | | | | |
+| 1.25 | Hamburger > Settings | Settings modal opens | | | | | |
+| 1.26 | Hamburger > Command Center | **KNOWN BUG: opens search, not command palette** | | | | | |
+| 1.27 | Vessel selector (Fleet only) | Dropdown shows all vessels in fleet | — | — | — | | |
+| 1.28 | Switch vessel (Fleet only) | All data reloads for new vessel | — | — | — | | |
+| 1.29 | Switch to "All Vessels" | Fleet overview mode | — | — | — | | |
+
+### 1.4 Vessel Surface (Home Page)
+
+| # | Action | Expected | Crew | HOD | Capt | Fleet | Console |
+|---|--------|----------|------|-----|------|-------|---------|
+| 1.30 | Page loads | All cards render with live data | | | | | |
+| 1.31 | Click Work Order row | Navigate to `/work-orders?id={id}` | | | | | |
+| 1.32 | Click "Create Work Order" quick action | Navigate to `/work-orders` | | | | | |
+| 1.33 | Click Fault row | Navigate to `/faults?id={id}` | | | | | |
+| 1.34 | Click "Log Fault" quick action | Navigate to `/faults` | | | | | |
+| 1.35 | Click Parts Below Min row | Navigate to `/inventory?id={id}` | | | | | |
+| 1.36 | Click "Add to Shopping List" quick action | Navigate to `/shopping-list` | | | | | |
+| 1.37 | Click Last Handover row | Navigate to `/handover-export?id={id}` | | | | | |
+| 1.38 | Click Certificate row | Navigate to `/certificates?id={id}` | | | | | |
+| 1.39 | Click Recent Activity row | Navigate to correct entity page | | | | | |
+| 1.40 | Error state: "Try Again" button | Refetches surface data | | | | | |
+
+### 1.5 Settings Modal
+
+| # | Action | Expected | Crew | HOD | Capt | Fleet | Console |
+|---|--------|----------|------|-----|------|-------|---------|
+| 1.41 | Account tab > Theme dropdown | Theme changes (light/dark/system), persists on reload | | | | | |
+| 1.42 | Security tab | Renders | | | | | |
+| 1.43 | Apps tab > Connect (Microsoft 365) | OAuth flow or link | | | | | |
+| 1.44 | Data tab > Export | Download activity log | | | | | |
+| 1.45 | Help tab > Send support message | Opens mailto | | | | | |
+| 1.46 | About tab > Terms/Privacy links | Open in new tab | | | | | |
+| 1.47 | Esc or X | Settings closes | | | | | |
+
+### 1.6 Ledger Panel
+
+| # | Action | Expected | Crew | HOD | Capt | Fleet | Console |
+|---|--------|----------|------|-----|------|-------|---------|
+| 1.48 | "Me" toggle | Shows only your events | | | | | |
+| 1.49 | "Department" toggle | **Crew: own only. HOD: engineering only. Captain: all depts** | | | | | |
+| 1.50 | "Reads" eye toggle | Shows/hides read events | | | | | |
+| 1.51 | Click day header | Expands/collapses day group | | | | | |
+| 1.52 | Click event row | Navigate to entity, panel closes | | | | | |
+| 1.53 | Scroll to bottom | Infinite scroll loads more events | | | | | |
+| 1.54 | After a mutation (e.g. add note) | New ledger entry appears in panel | | | | | |
+
+---
+
+## PART 2: ENTITY LENSES — EVERY ACTION PER LENS
+
+### 2.1 Work Orders
+
+| # | Action | Payload/Details | Expected | Crew | HOD | Capt | Fleet | Console |
+|---|--------|----------------|----------|------|-----|------|-------|---------|
+| 2.1 | List loads | | Work order rows render | | | | | |
+| 2.2 | Click row | | Detail lens opens | | | | | |
+| 2.3 | Sort by column | | Re-sorts | | | | | |
+| 2.4 | Filter by status | | Filters correctly | | | | | |
+| 2.5 | **"Start Work"** primary | `start_work_order` | Status → in_progress | X | | | | |
+| 2.6 | **"Mark Complete"** primary | `close_work_order`, payload: `{close_reason}` | Status → completed, ledger entry | X | | | | |
+| 2.7 | Dropdown > **Add Note** | `add_wo_note`, payload: `{note_text}` | AddNoteModal opens → type text → submit → note appears in Notes section | | | | | |
+| 2.8 | Dropdown > **Add Part** | `add_wo_part`, payload: `{part_id}` | AddPartModal opens → select part → submit → part appears | X | | | | |
+| 2.9 | Dropdown > **Add Hours** | `add_wo_hours`, payload: `{hours, description}` | ActionPopup form → submit → hours recorded | X | | | | |
+| 2.10 | Dropdown > **Reassign** | `reassign_work_order`, payload: `{assigned_to}` | Person picker → submit → assigned_to changes | X | | | | |
+| 2.11 | Dropdown > **Archive** (danger) | `archive_work_order` | **SIGNED (L3 PIN).** Crew+HOD: 403 | X | X | S | S | |
+| 2.12 | Notes section > "Add Note" button | Same as 2.7 | Modal opens, submit works | | | | | |
+| 2.13 | Attachments > Upload | | **TODO: empty handler, no modal** | | | | | |
+| 2.14 | Checklist > check item | | Item state updates | | | | | |
+| 2.15 | History > expand | | Change history renders | | | | | |
+| 2.16 | Audit Trail > expand | | Ledger events render | | | | | |
+| 2.17 | Related button | | Drawer opens with related entities | | | | | |
+| 2.18 | Related drawer > click entity | | Navigate to that entity | | | | | |
+
+### 2.2 Faults
+
+| # | Action | Payload/Details | Expected | Crew | HOD | Capt | Fleet | Console |
+|---|--------|----------------|----------|------|-----|------|-------|---------|
+| 2.19 | List loads | | Fault rows render | | | | | |
+| 2.20 | Click row | | Detail lens opens | | | | | |
+| 2.21 | **"Investigate"** primary | `investigate_fault` (if status=open) | Status → investigating | X | | | | |
+| 2.22 | **"Resolve Fault"** primary | `resolve_fault`, payload: `{resolution_notes, resolution}` | Status → resolved, ledger entry | X | | | | |
+| 2.23 | **"Close Fault"** primary | `close_fault` (if status=resolved) | Status → closed | X | | | | |
+| 2.24 | Dropdown > **Add Note** | `add_fault_note`, payload: `{note_text}` | Modal → type → submit → note in metadata → appears after refetch | | | | | |
+| 2.25 | Dropdown > **Archive** (danger) | `archive_fault` | **SIGNED.** Crew+HOD: 403 | X | X | S | S | |
+| 2.26 | Notes section > "Add Note" | Same as 2.24 | Works | | | | | |
+| 2.27 | Attachments > Upload | | **TODO: empty handler** | | | | | |
+| 2.28 | Related button | | Drawer opens | | | | | |
+
+### 2.3 Equipment
+
+| # | Action | Payload/Details | Expected | Crew | HOD | Capt | Fleet | Console |
+|---|--------|----------------|----------|------|-----|------|-------|---------|
+| 2.29 | List loads | | Equipment rows render | | | | | |
+| 2.30 | Click row | | Detail lens opens | | | | | |
+| 2.31 | **"Create Work Order"** primary | `create_work_order_for_equipment`, payload: `{title, description, priority}` | Priority must be routine/critical (NOT low/medium/high). WO created. | X | | | | |
+| 2.32 | Dropdown > **Flag for Attention** | `flag_equipment_attention` | L0 — fires immediately, no modal | | | | | |
+| 2.33 | Dropdown > **Add Note** | `add_equipment_note`, payload: `{note_text}` | Modal → submit → note appears | | | | | |
+| 2.34 | Dropdown > **Decommission** (danger) | `decommission_equipment` | **SIGNED (L3 PIN).** Crew+HOD: 403 | X | X | S | S | |
+| 2.35 | Spare Parts section | | Shows linked parts | | | | | |
+| 2.36 | Work Orders section > click WO | | Navigate to work order | | | | | |
+| 2.37 | Faults section > click fault | | Navigate to fault | | | | | |
+| 2.38 | Certificates section > click cert | | Navigate to certificate | | | | | |
+| 2.39 | Related button | | Drawer opens | | | | | |
+
+### 2.4 Handover
+
+| # | Action | Payload/Details | Expected | Crew | HOD | Capt | Fleet | Console |
+|---|--------|----------------|----------|------|-----|------|-------|---------|
+| 2.40 | `/handover-export` loads | | Tabbed: Queue + Draft | | | | | |
+| 2.41 | Queue tab renders | | 4 sections: Open Faults, Overdue WOs, Low Stock, Pending Orders | | | | | |
+| 2.42 | Queue > expand section | | Items with ref codes shown | | | | | |
+| 2.43 | Queue > **"Add to draft"** | `add_to_handover`, payload: `{summary, entity_type, entity_id}` | Item moves to "already queued" state, refetch shows it | X | | | | |
+| 2.44 | Draft tab | | Shows items added to draft | | | | | |
+| 2.45 | Draft > edit item | | Edit popup saves changes | | | | | |
+| 2.46 | Draft > delete item | | Item removed | | | | | |
+| 2.47 | Draft > **"Export Handover"** | POST export | Navigate to `/handover-export/[id]` | | | | | |
+| 2.48 | Completed lens loads | | Handover document renders | | | | | |
+| 2.49 | **"Sign Handover"** primary | `sign_handover` (if status in draft/pending) | **Wet signature canvas (L4).** Draw signature → confirm → `signature: <PNG data URL>` sent | X | | | | |
+| 2.50 | Dropdown > **Sign Incoming** | `sign_handover_incoming` | ActionPopup opens | X | | | | |
+| 2.51 | Dropdown > **Export PDF** | `window.print()` | Browser print dialog | | | | | |
+| 2.52 | Dropdown > **Regenerate Summary** | `regenerate_handover_summary` | Summary regenerated | | | | | |
+| 2.53 | Dropdown > **Archive** (danger) | `archive_handover` | **SIGNED.** Crew+HOD: 403 | X | X | S | S | |
+| 2.54 | Dropdown > **Delete** (danger) | `delete_handover` | **SIGNED.** Crew+HOD: 403 | X | X | S | S | |
+
+### 2.5 Hours of Rest
+
+| # | Action | Payload/Details | Expected | Crew | HOD | Capt | Fleet | Console |
+|---|--------|----------------|----------|------|-----|------|-------|---------|
+| 2.55 | List loads | | HoR records render with compliance status | | | | | |
+| 2.56 | Click row | | Detail opens | | | | | |
+| 2.57 | **"Submit Hours"** primary | `upsert_hours_of_rest` (if draft/pending) | Hours recorded | | | | | |
+| 2.58 | Compliance alert banner | | Shows if violations detected | | | | | |
+
+### 2.5b Hours of Rest — Monthly Sign-Off (MLC 2006 3-tier)
+
+| # | Action | Payload/Details | Expected | Crew | HOD | Capt | Fleet | Console |
+|---|--------|----------------|----------|------|-----|------|-------|---------|
+| 2.59 | `/hours-of-rest/signoffs` loads | | Signoff list renders | | | | | |
+| 2.60 | Click signoff row | | Detail opens | | | | | |
+| 2.61 | **"Sign as Crew"** (status=draft) | `sign_monthly_signoff` | Crew signs → status → crew_signed | | | | | |
+| 2.62 | **"Counter-Sign as HOD"** (status=crew_signed) | `sign_monthly_signoff` | **Only HOD+ can click.** Crew: button disabled with reason | X | | | | |
+| 2.63 | **"Final Sign as Master"** (status=hod_signed) | `sign_monthly_signoff` | **Only Captain can click.** HOD: button disabled with reason | X | X | | | |
+| 2.64 | Status=finalized | | Button shows "Finalized" (disabled) | | | | | |
+
+### 2.6 Email
+
+| # | Action | Payload/Details | Expected | Crew | HOD | Capt | Fleet | Console |
+|---|--------|----------------|----------|------|-----|------|-------|---------|
+| 2.65 | `/email` loads | | Thread list renders | | | | | |
+| 2.66 | Filter: All / Unlinked / Linked | | List filters correctly | | | | | |
+| 2.67 | Click refresh icon | | Threads re-fetched | | | | | |
+| 2.68 | Click thread row | | Thread detail in right pane | | | | | |
+| 2.69 | **"Link Email"** | LinkEmailModal → select entity → submit | **KNOWN BUG: `link_email` action doesn't exist in registry** | | | | | |
+| 2.70 | Esc in LinkEmailModal | | Modal closes | | | | | |
+
+### 2.7 Inventory / Parts
+
+| # | Action | Payload/Details | Expected | Crew | HOD | Capt | Fleet | Console |
+|---|--------|----------------|----------|------|-----|------|-------|---------|
+| 2.71 | `/inventory` loads | | Parts list renders | | | | | |
+| 2.72 | Click row | | Detail opens | | | | | |
+| 2.73 | View part | | Name, qty, location, manufacturer, status pill | | | | | |
+| 2.74 | **Add Note** | `add_part_note`, payload: `{note_text}` | Note saved AND linked to part | | | | | |
+| 2.75 | **Reorder** primary (if low stock) | `reorder_part` | ActionPopup → submit | X | | | | |
+| 2.76 | **Adjust Stock** primary (if normal) | `adjust_stock_quantity`, payload: `{quantity, reason}` | **SIGNED (L3 PIN).** Crew+HOD: 403 | X | X | S | S | |
+| 2.77 | **Write Off Part** | `write_off_part`, payload: `{quantity, reason}` | **SIGNED (L3 PIN+TOTP).** Crew+HOD: 403. Ledger entry must appear. | X | X | S | S | |
+| 2.78 | **Log Part Usage** | `log_part_usage` | ActionPopup → submit | X | | | | |
+
+### 2.8 Shopping List
+
+| # | Action | Payload/Details | Expected | Crew | HOD | Capt | Fleet | Console |
+|---|--------|----------------|----------|------|-----|------|-------|---------|
+| 2.79 | `/shopping-list` loads | | Items render with lifecycle progress bar | | | | | |
+| 2.80 | Click row | | Detail opens | | | | | |
+| 2.81 | **"Submit List"** primary (if draft) | `submit_list` | Status → submitted | X | | | | |
+| 2.82 | **"Convert to PO"** primary (if approved) | `convert_to_po` | PO created from list | X | | | | |
+| 2.83 | Dropdown > **Approve** | `approve_shopping_list_item`, payload: `{quantity_approved}` | Item approved | X | | | | |
+| 2.84 | Dropdown > **Reject** | `reject_shopping_list_item`, payload: `{rejection_reason}` | Item rejected | X | | | | |
+| 2.85 | Dropdown > **Archive** (danger) | `archive_list` | Soft delete | X | | | | |
+
+### 2.9 Purchase Orders
+
+| # | Action | Payload/Details | Expected | Crew | HOD | Capt | Fleet | Console |
+|---|--------|----------------|----------|------|-----|------|-------|---------|
+| 2.86 | `/purchasing` loads | | PO list renders | | | | | |
+| 2.87 | Click row | | Detail lens opens | | | | | |
+| 2.88 | **"Submit"** primary (if draft) | `submit_po` | Status → submitted | X | | | | |
+| 2.89 | **"Approve"** primary (if submitted) | `approve_po` | Status → approved | X | | | | |
+| 2.90 | **"Receive Goods"** primary (if approved) | `receive_po` | Status → received | X | | | | |
+| 2.91 | Dropdown > **Add Note** | `add_po_note`, payload: `{note_text}` | Note saved AND linked to PO | | | | | |
+| 2.92 | Dropdown > **Track Delivery** | `track_po_delivery` | Tracking info | X | | | | |
+| 2.93 | Dropdown > **Cancel** (danger) | `cancel_po` | Soft delete (deleted_at set) | X | | | | |
+| 2.94 | Attachments > Upload | | **TODO: empty handler** | | | | | |
+
+### 2.10 Receiving
+
+| # | Action | Payload/Details | Expected | Crew | HOD | Capt | Fleet | Console |
+|---|--------|----------------|----------|------|-----|------|-------|---------|
+| 2.95 | `/receiving` loads | | List renders | | | | | |
+| 2.96 | Click row | | Detail opens | | | | | |
+| 2.97 | `/receiving/new` loads | | Upload wizard renders | | | | | |
+| 2.98 | **New: select doc type** | Dropdown: Invoice/Packing Slip/Photo/Other | Type selected | | | | | |
+| 2.99 | **New: upload file** | Accept: JPG/PNG/HEIC/PDF, max 15MB | File preview shown | | | | | |
+| 2.100 | **New: "Upload & Process"** | `create_receiving` + upload | Creates receiving, uploads doc, shows extracted data. 503 → retries 3x with 30s wait. | X | | | | |
+| 2.101 | **New: review extracted data** | | Table shows OCR fields (vendor, total, line items) | | | | | |
+| 2.102 | **New: "Save to Database"** | Saves + auto-populates line items | Navigate to `/receiving/{id}`, toast "Receiving logged" | | | | | |
+| 2.103 | Detail > **"Complete Receiving"** | `accept_receiving` | Status → completed | X | | | | |
+| 2.104 | Detail > **"Report Discrepancy"** | `reject_receiving` / `flag_discrepancy` | Discrepancy flagged | X | | | | |
+
+### 2.11 Certificates
+
+| # | Action | Payload/Details | Expected | Crew | HOD | Capt | Fleet | Console |
+|---|--------|----------------|----------|------|-----|------|-------|---------|
+| 2.105 | `/certificates` loads | | List renders with status (valid/expiring/expired) | | | | | |
+| 2.106 | Click row | | Detail lens opens | | | | | |
+| 2.107 | **"Renew Certificate"** primary | `renew_certificate` (if not revoked) | **STUB: returns NOT_IMPLEMENTED** | | | | | |
+| 2.108 | Dropdown > **Add Note** | `add_certificate_note`, payload: `{note_text}` | **KNOWN BUG: may fail (pms_certificates vs pms_vessel_certificates)** | | | | | |
+| 2.109 | Dropdown > **Suspend** (danger) | `suspend_certificate` | Soft delete | X | | | | |
+| 2.110 | Dropdown > **Revoke** (danger) | `revoke_certificate` | Permanent revocation | X | X | S | S | |
+
+### 2.12 Documents
+
+| # | Action | Payload/Details | Expected | Crew | HOD | Capt | Fleet | Console |
+|---|--------|----------------|----------|------|-----|------|-------|---------|
+| 2.111 | `/documents` loads | | List renders | | | | | |
+| 2.112 | Click row | | Detail lens opens | | | | | |
+| 2.113 | **Download** primary | Browser download (if file_url exists) | File downloads | | | | | |
+| 2.114 | Dropdown > **Add Note** | `add_document_note`, payload: `{note_text}` | Note saved AND linked to document | | | | | |
+| 2.115 | Dropdown > **Archive** (danger) | `archive_document` | Soft delete | X | | | | |
+
+### 2.13 Warranties
+
+| # | Action | Payload/Details | Expected | Crew | HOD | Capt | Fleet | Console |
+|---|--------|----------------|----------|------|-----|------|-------|---------|
+| 2.116 | `/warranties` loads | | List renders | | | | | |
+| 2.117 | Click row | | Detail lens opens | | | | | |
+| 2.118 | **"Submit Claim"** primary | `file_warranty_claim` (if active/expiring) | Claim filed | X | | | | |
+| 2.119 | Dropdown > **Add Note** | `add_warranty_note`, payload: `{note_text}` | Note saved AND linked | | | | | |
+| 2.120 | Dropdown > **Archive** (danger) | `archive_warranty` | Soft delete | X | | | | |
+| 2.121 | Dropdown > **Void** (danger) | `void_warranty` | Warranty voided | X | X | S | S | |
+
+---
+
+## PART 3: SIGNATURE JOURNEYS
+
+Test each signature level end-to-end. Must be Captain or Fleet Manager for signed actions.
+
+| # | Level | Test Action | Steps | Expected | Capt | Fleet | Console |
+|---|-------|-------------|-------|----------|------|-------|---------|
+| 3.1 | **L0** (no modal) | `flag_equipment_attention` | Click button. NO modal appears. | Action fires immediately, result in UI | | | |
+| 3.2 | **L1** (confirm) | Any standard mutation | Click → ActionPopup with "Confirm" button → click Confirm | Action fires, result in UI | | | |
+| 3.3 | **L3** (PIN) | `archive_work_order` | Click → ActionPopup shows 4-digit PIN boxes → enter PIN → click "Verify" | Action fires if PIN correct | | | |
+| 3.4 | **L3 wrong PIN** | `archive_work_order` | Enter wrong PIN → submit | Error shown in popup, modal stays open for retry | | | |
+| 3.5 | **L3 incomplete PIN** | `archive_work_order` | Enter 3 digits only | "Verify" button disabled | | | |
+| 3.6 | **L4** (wet signature) | `sign_handover` | Click → canvas appears → draw signature → enter name → click "Sign" | Signature PNG sent, action fires | | | |
+| 3.7 | **L4 clear** | `sign_handover` | Draw signature → click "Clear" | Canvas resets | | | |
+| 3.8 | **L4 no name** | `sign_handover` | Draw signature, leave name empty | "Sign" button disabled | | | |
+
+---
+
+## PART 4: WORKFLOW JOURNEYS (Multi-Step)
+
+### 4.1 Fault → Work Order → Complete
+
+| # | Step | Action | Expected | HOD | Capt | Console |
+|---|------|--------|----------|-----|------|---------|
+| 4.1 | Report a fault | `report_fault` via ReportFaultModal: fill title, description, severity, equipment_id → submit | Fault created, appears in fault list | | | |
+| 4.2 | Investigate the fault | Open fault → "Investigate" primary | Status → investigating | | | |
+| 4.3 | Create WO from equipment | Open equipment (linked) → "Create Work Order" → fill title, priority (routine/critical) → submit | WO created, linked to equipment | | | |
+| 4.4 | Add part to WO | Open WO → "Add Part" → select part → submit | Part appears in WO parts section | | | |
+| 4.5 | Add hours to WO | "Add Hours" → fill hours → submit | Hours recorded | | | |
+| 4.6 | Complete WO | "Mark Complete" → fill close_reason → submit | Status → completed, ledger entry | | | |
+| 4.7 | Resolve fault | Go back to fault → "Resolve" → fill resolution → submit | Status → resolved, ledger entry | | | |
+| 4.8 | Close fault | "Close Fault" | Status → closed | | | |
+
+### 4.2 Handover Lifecycle
+
+| # | Step | Action | Expected | HOD | Capt | Console |
+|---|------|--------|----------|-----|------|---------|
+| 4.9 | View queue | `/handover-export` → Queue tab | Sections show open items | | | |
+| 4.10 | Add items to draft | Click "Add to draft" on 2-3 items | Items move to "already queued" | | | |
+| 4.11 | Review draft | Draft tab | Added items shown | | | |
+| 4.12 | Edit a draft item | Click edit → change text → save | Text updates | | | |
+| 4.13 | Export handover | "Export Handover" → submit | Navigate to completed handover lens | | | |
+| 4.14 | Outgoing signs | "Sign Handover" → draw on canvas → confirm | Outgoing signature recorded | | | |
+| 4.15 | Incoming signs | Dropdown > "Sign Incoming" → ActionPopup | Incoming signature recorded | | | |
+
+### 4.3 Receiving Lifecycle
+
+| # | Step | Action | Expected | HOD | Capt | Console |
+|---|------|--------|----------|-----|------|---------|
+| 4.16 | Start new receiving | `/receiving/new` → select type → upload photo/invoice | File uploaded, OCR extracted | | | |
+| 4.17 | Review extracted data | Table shows vendor, total, line items | Data correct | | | |
+| 4.18 | Save to database | "Save to Database" | Navigate to receiving detail, toast shown | | | |
+| 4.19 | Complete receiving | "Complete Receiving" | Status → completed | | | |
+
+### 4.4 PO Lifecycle
+
+| # | Step | Action | Expected | HOD | Capt | Console |
+|---|------|--------|----------|-----|------|---------|
+| 4.20 | Open a draft PO | `/purchasing` → click draft PO | Detail opens | | | |
+| 4.21 | Submit PO | "Submit" primary | Status → submitted | | | |
+| 4.22 | Approve PO | "Approve" primary | Status → approved | | | |
+| 4.23 | Add note | "Add Note" → type → submit | Note appears linked to PO | | | |
+| 4.24 | Cancel PO (danger) | "Cancel" → confirm | Soft deleted (deleted_at set) | | | |
+
+### 4.5 HoR Sign-Off Chain (MLC 2006)
+
+| # | Step | Role | Action | Expected | Console |
+|---|------|------|--------|----------|---------|
+| 4.25 | Crew signs | Crew | Open signoff → "Sign as Crew" | Status → crew_signed | |
+| 4.26 | HOD counter-signs | HOD | Open same signoff → "Counter-Sign as HOD" | Status → hod_signed. **Crew should see button disabled.** | |
+| 4.27 | Captain final-signs | Captain | Open same signoff → "Final Sign as Master" | Status → finalized. **HOD should see button disabled.** | |
+
+---
+
+## PART 5: MODALS (test from any context)
+
+| # | Modal | Trigger | Fields | Expected | Crew | HOD | Capt | Fleet | Console |
+|---|-------|---------|--------|----------|------|-----|------|-------|---------|
+| 5.1 | ReportFaultModal | Subbar button on `/faults` | title, description, severity, equipment_id, create_work_order checkbox | `report_fault` fires, fault created | | | | | |
+| 5.2 | CreateWorkOrderModal | Subbar button on `/work-orders` | equipment_id, title, description, priority, assigned_to | `create_work_order` fires, WO created | X | | | | |
+| 5.3 | AddNoteModal (any entity) | Dropdown "Add Note" or section button | note_text (textarea) | Note saved, appears after refetch | | | | | |
+| 5.4 | ActionPopup (read-only, L0) | Any L0 action | None | Fires immediately, no UI | | | | | |
+| 5.5 | ActionPopup (form fields) | Action with required_fields | Dynamic fields from backend | Form renders, submit works | | | | | |
+| 5.6 | ActionPopup (PIN, L3) | Signed action | 4-digit PIN | PIN entry, verify button | | | S | S | |
+| 5.7 | ActionPopup (wet signature, L4) | sign_handover | Canvas + name + date | Draw, sign, confirm | | | | | |
+| 5.8 | Any modal > Esc | | | Closes without submitting | | | | | |
+| 5.9 | Any modal > click outside | | | Closes without submitting | | | | | |
+
+---
+
+## KNOWN BUGS & LIMITATIONS
+
+| # | Bug | Status | Impact |
+|---|-----|--------|--------|
+| K.1 | Command Center opens search overlay instead of command palette | Not fixed (parked) | UX — no command surface |
+| K.2 | `link_email` action doesn't exist in registry | Not fixed | Email linking silently fails |
+| K.3 | `add_certificate_note` — pms_certificates vs pms_vessel_certificates table mismatch | Not fixed (deferred) | Cert notes may 404 |
+| K.4 | `renew_certificate` is a stub | By design | Returns NOT_IMPLEMENTED |
+| K.5 | `classify_fault`, `suggest_parts` are stubs | By design | Returns NOT_IMPLEMENTED |
+| K.6 | Upload buttons on all lenses are empty `() => {}` | TODO — no upload modal component | No file uploads work |
+| K.7 | Frontend shows all buttons to all roles — no role gating | By design (backend enforces) | Crew sees buttons they can't use |
+| K.8 | PM schedule actions blocked — `pms_maintenance_schedules` table missing | Schema gap | Needs migration |
+| K.9 | PO/Document/Warranty note display — unconfirmed if entity endpoint returns notes | Unverified | Notes may save but not display |
+| K.10 | Handover "Export PDF" uses `window.print()` not real export | By design | Basic print, no PDF generation |
+
+---
+
+## RESULTS SUMMARY
+
+### Crew
+**Tested:** ___ | **PASS:** ___ | **FAIL:** ___ | **403 (expected):** ___ | **403 (unexpected):** ___
+
+### HOD (Chief Engineer)
+**Tested:** ___ | **PASS:** ___ | **FAIL:** ___ | **403 (expected):** ___ | **403 (unexpected):** ___
+
+### Captain
+**Tested:** ___ | **PASS:** ___ | **FAIL:** ___ | **Signed passed:** ___/___ | **PIN rejected correctly:** ___
+
+### Fleet Manager
+**Tested:** ___ | **PASS:** ___ | **FAIL:** ___ | **Vessel switch:** YES / NO | **All vessels view:** YES / NO
+
+### Critical Failures
+1.
+2.
+3.
+
+### Console Errors
+1.
+2.
+3.
+
+### Buttons Visible But Should Be Hidden (Role Gating Gaps)
+1.
+2.
+3.
+
+### Notes
+

--- a/docs/explanations/ACTION_BUTTON_INVENTORY.md
+++ b/docs/explanations/ACTION_BUTTON_INVENTORY.md
@@ -1,0 +1,310 @@
+# CelesteOS — Complete Action & Button Inventory
+
+> **Purpose:** Map every user-facing action across all entity lenses. Classify each as intra-domain (operates within one entity type) or cross-domain (creates a relationship between entity types). Cross-domain actions are CelesteOS's commercial differentiator — no competing maritime PMS has them.
+
+---
+
+## Summary
+
+| Category | Count |
+|---|---|
+| Registry actions (backend API) | 207 |
+| Frontend-only buttons (UI controls, navigation, modals) | ~50 |
+| **Cross-domain actions (the differentiator)** | **17 registry + ~15 navigation** |
+
+---
+
+## Part 1: Cross-Domain Actions (The Differentiator)
+
+These actions create relationships between different entity types. Traditional maritime PMS systems treat each module as a silo — CelesteOS connects them.
+
+### Registry-Wired Cross-Domain Actions (17)
+
+| Action | Label | From Domain | References | What It Does |
+|---|---|---|---|---|
+| `add_parts_to_work_order` | Add Parts to Work Order | work_orders | part_id | Links inventory parts to a work order |
+| `add_wo_part` | Add Part to WO | work_orders | part_id | Same — adds a part line item to a work order |
+| `add_to_shopping_list` | Add to Shopping List | shopping_list | part_id | Creates a purchase request from an inventory part |
+| `order_part` | Order Part | purchase_orders | part_id | Creates a PO line item from a part |
+| `link_part_to_equipment` | Link Part to Equipment | equipment | part_id | Associates a spare part with specific equipment |
+| `link_document_to_equipment` | Link Document to Equipment | documents | equipment_id | Attaches a manual/schematic to equipment |
+| `link_invoice_document` | Link Invoice Document | receiving | document_id | Attaches an invoice to a receiving record |
+| `attach_receiving_image_with_comment` | Attach Image to Receiving | receiving | document_id | Adds photographic evidence to goods receipt |
+| `request_label_output` | Request Label Output | parts | document_id | Generates a label document from part data |
+| `add_certificate_note` | Add Certificate Note | certificates | equipment_id | Notes on a certificate referencing equipment |
+| `add_document_note` | Add Document Note | documents | equipment_id | Notes on a document referencing equipment |
+| `add_part_note` | Add Part Note | parts | equipment_id | Notes on a part referencing equipment |
+| `add_po_note` | Add PO Note | purchase_orders | equipment_id | Notes on a PO referencing equipment |
+| `add_warranty_note` | Add Warranty Note | warranty | equipment_id | Notes on a warranty referencing equipment |
+| `view_fault_history` | View Fault History | faults | equipment_id | Views fault history for specific equipment |
+| `show_manual_section` | Show Manual Section | (none) | equipment_id | Opens equipment-specific manual section |
+| `add_note_to_work_order` | Add Note to WO | (none) | work_order_id | Adds a note to a specific work order |
+
+### Cross-Domain Navigation Buttons (Frontend, ~15)
+
+These aren't in the action registry but create cross-domain UX by navigating between entity types:
+
+| Button | Location | From | To | What It Does |
+|---|---|---|---|---|
+| Part name link | PartsSection (all lenses) | Any entity | Parts lens | Click a part → opens part detail |
+| Document name link | AttachmentsSection | Any entity | Documents lens | Click a document → opens document detail |
+| Equipment link | FaultContent, CertificateContent | Fault/Cert | Equipment lens | Click linked equipment → opens equipment detail |
+| Related Drawer items | RelatedDrawer.tsx | Any entity | Any entity | AI-surfaced related items — click navigates to target entity |
+| Entity links in Handover | HandoverContent.tsx | Handover | Various | Embedded entity references in handover items |
+| "Show Related" button | EntityLensPage.tsx | Any entity | (opens drawer) | Opens the AI-powered related items panel |
+
+### The "Add to Handover" Flow (Unique to CelesteOS)
+
+The handover system is the most distinctive cross-domain feature. It pulls items from **every other domain** into a single compliance document:
+
+| Action | What It Pulls |
+|---|---|
+| `add_to_handover` | Any entity → handover item |
+| `export_handover` | All handover items → professional AI-summarised document |
+| `sign_handover` | Handover document → signed compliance record |
+
+No competing maritime PMS aggregates work orders, faults, equipment status, certificates, and parts into a single handover briefing with AI summarisation.
+
+---
+
+## Part 2: Intra-Domain Actions by Entity Type
+
+### Work Orders (30 actions)
+
+| Action ID | Label | Variant | Cross-Domain? |
+|---|---|---|---|
+| `create_work_order` | Create Work Order | MUTATE | No |
+| `start_work_order` | Start Work | MUTATE | No |
+| `close_work_order` | Close Work Order | MUTATE | No |
+| `cancel_work_order` | Cancel Work Order | MUTATE | No |
+| `archive_work_order` | Archive Work Order | MUTATE | No |
+| `delete_work_order` | Delete Work Order | MUTATE | No |
+| `reassign_work_order` | Reassign Work Order | MUTATE | No |
+| `update_wo_priority` | Update Priority | MUTATE | No |
+| `update_wo_status` | Update Status | MUTATE | No |
+| `add_wo_note` | Add Note | MUTATE | No |
+| `add_wo_checklist` | Add Checklist | MUTATE | No |
+| `mark_checklist_item_complete` | Mark Item Complete | MUTATE | No |
+| `add_parts_to_work_order` | Add Parts | MUTATE | **Yes → part_id** |
+| `add_wo_part` | Add Part to WO | MUTATE | **Yes → part_id** |
+| `view_work_order` | View Work Order | READ | No |
+| `view_wo_history` | View History | READ | No |
+| `view_wo_checklist` | View Checklist | READ | No |
+| + 13 more READ/MUTATE actions | | | |
+
+### Faults (18 actions)
+
+| Action ID | Label | Variant | Cross-Domain? |
+|---|---|---|---|
+| `log_fault` | Log Fault | MUTATE | No |
+| `update_fault_status` | Update Status | MUTATE | No |
+| `resolve_fault` | Resolve Fault | MUTATE | No |
+| `close_fault` | Close Fault | MUTATE | No |
+| `assign_fault` | Assign Fault | MUTATE | No |
+| `escalate_fault` | Escalate Fault | MUTATE | No |
+| `add_fault_note` | Add Note | MUTATE | No |
+| `view_fault_history` | View Fault History | READ | **Yes → equipment_id** |
+| + 10 more actions | | | |
+
+### Equipment (28 actions)
+
+| Action ID | Label | Variant | Cross-Domain? |
+|---|---|---|---|
+| `add_equipment` | Add Equipment | MUTATE | No |
+| `update_equipment_status` | Update Status | MUTATE | No |
+| `decommission_equipment` | Decommission | SIGNED | No |
+| `link_part_to_equipment` | Link Part | MUTATE | **Yes → part_id** |
+| `add_equipment_note` | Add Note | MUTATE | No |
+| `schedule_maintenance` | Schedule Maintenance | MUTATE | No |
+| + 22 more actions | | | |
+
+### Certificates (10 actions)
+
+| Action ID | Label | Variant | Cross-Domain? |
+|---|---|---|---|
+| `create_vessel_certificate` | Add Certificate | SIGNED | No |
+| `renew_certificate` | Renew Certificate | SIGNED | No |
+| `add_certificate_note` | Add Note | MUTATE | **Yes → equipment_id** |
+| `view_certificate` | View Certificate | READ | No |
+| + 6 more actions | | | |
+
+### Parts / Inventory (21 actions)
+
+| Action ID | Label | Variant | Cross-Domain? |
+|---|---|---|---|
+| `add_part` | Add Part | MUTATE | No |
+| `update_stock_level` | Update Stock | MUTATE | No |
+| `order_part` | Order Part | MUTATE | **Yes → purchase_orders** |
+| `add_to_shopping_list` | Add to Shopping List | MUTATE | **Yes → shopping_list** |
+| `add_part_note` | Add Note | MUTATE | **Yes → equipment_id** |
+| `request_label_output` | Print Label | MUTATE | **Yes → document_id** |
+| + 15 more actions | | | |
+
+### Shopping List (13 actions)
+
+| Action ID | Label | Variant | Cross-Domain? |
+|---|---|---|---|
+| `submit_shopping_list` | Submit for Approval | MUTATE | No |
+| `approve_shopping_list` | Approve | SIGNED | No |
+| `convert_to_po` | Convert to Purchase Order | MUTATE | **Yes → purchase_orders** |
+| `reject_shopping_list` | Reject | MUTATE | No |
+| + 9 more actions | | | |
+
+### Purchase Orders (11 actions)
+
+| Action ID | Label | Variant | Cross-Domain? |
+|---|---|---|---|
+| `create_purchase_order` | Create PO | SIGNED | No |
+| `approve_po` | Approve PO | SIGNED | No |
+| `order_part` | Order Part | MUTATE | **Yes → part_id** |
+| `add_po_note` | Add Note | MUTATE | **Yes → equipment_id** |
+| + 7 more actions | | | |
+
+### Receiving (13 actions)
+
+| Action ID | Label | Variant | Cross-Domain? |
+|---|---|---|---|
+| `confirm_receiving` | Confirm Receiving | SIGNED | No |
+| `report_discrepancy` | Report Discrepancy | MUTATE | No |
+| `link_invoice_document` | Link Invoice | MUTATE | **Yes → document_id** |
+| `attach_receiving_image_with_comment` | Attach Image | MUTATE | **Yes → document_id** |
+| + 9 more actions | | | |
+
+### Documents (16 actions)
+
+| Action ID | Label | Variant | Cross-Domain? |
+|---|---|---|---|
+| `upload_document` | Upload Document | MUTATE | No |
+| `link_document_to_equipment` | Link to Equipment | MUTATE | **Yes → equipment_id** |
+| `add_document_note` | Add Note | MUTATE | **Yes → equipment_id** |
+| + 13 more actions | | | |
+
+### Warranty (10 actions)
+
+| Action ID | Label | Variant | Cross-Domain? |
+|---|---|---|---|
+| `file_warranty_claim` | File Claim | MUTATE | No |
+| `add_warranty_note` | Add Note | MUTATE | **Yes → equipment_id** |
+| + 8 more actions | | | |
+
+### Handover (15 actions)
+
+| Action ID | Label | Variant | Cross-Domain? |
+|---|---|---|---|
+| `add_to_handover` | Add to Handover | MUTATE | **Yes → any entity** |
+| `sign_handover` | Sign Handover | SIGNED | No |
+| `countersign_handover` | Countersign | SIGNED | No |
+| `export_handover` | Export Handover | MUTATE | No |
+| `edit_handover_section` | Edit Section | MUTATE | No |
+| + 10 more actions | | | |
+
+### Hours of Rest (17 actions)
+
+| Action ID | Label | Variant | Cross-Domain? |
+|---|---|---|---|
+| `submit_hours_of_rest` | Submit HoR | SIGNED | No |
+| `approve_hor_signoff` | Approve Signoff | SIGNED | No |
+| `reject_hor_signoff` | Reject Signoff | SIGNED | No |
+| + 14 more actions | | | |
+
+---
+
+## Part 3: Frontend-Only Buttons (Not in Action Registry)
+
+These are UI controls wired directly in React components.
+
+### Shell Buttons (every lens page)
+
+| Button | Component | What It Does | Cross-Domain? |
+|---|---|---|---|
+| Back | EntityLensPage.tsx | Navigate to previous page | No |
+| Show Related | EntityLensPage.tsx | Toggle AI-powered related items drawer | **Yes — shows cross-domain connections** |
+| Theme Toggle | EntityLensPage.tsx | Switch dark/light mode | No |
+| Close Drawer | EntityLensPage.tsx | Close related items panel | No |
+
+### Section Buttons (reusable across lenses)
+
+| Button | Component | What It Does | Cross-Domain? |
+|---|---|---|---|
+| + Add Note | NotesSection.tsx | Opens note entry form | No |
+| + Upload | AttachmentsSection.tsx | Opens file upload dialog | No |
+| + Add Part | PartsSection.tsx | Opens part linking form | **Yes → parts domain** |
+| Part name click | PartsSection.tsx | Navigates to part detail | **Yes → parts domain** |
+| Document name click | DocRowsSection.tsx | Navigates to document detail | **Yes → documents domain** |
+| Show more (notes) | NotesSection.tsx | Expands truncated note text | No |
+
+### Handover-Specific Buttons
+
+| Button | What It Does | Cross-Domain? |
+|---|---|---|
+| Export PDF | Triggers browser print/PDF export | No |
+| Sign Handover | Opens signature canvas modal | No |
+| Clear Signature | Clears canvas drawing | No |
+| Confirm & Sign | Submits signed handover | No |
+| Remove Item | Visually removes item from draft | No |
+
+### Spotlight Search Buttons
+
+| Button | What It Does | Cross-Domain? |
+|---|---|---|
+| Action suggestion chips | Opens ActionPopup for any domain | **Yes — creates entities across domains from search** |
+
+---
+
+## Part 4: Cross-Domain Relationship Map
+
+```
+Equipment ←──────────────────────────────────────────── Hub Entity
+    ↑ link_part_to_equipment                    (9 actions reference equipment_id)
+    ↑ link_document_to_equipment
+    ↑ add_certificate_note
+    ↑ add_document_note
+    ↑ add_part_note
+    ↑ add_po_note
+    ↑ add_warranty_note
+    ↑ view_fault_history
+    ↑ show_manual_section
+
+Parts ←──────────────────────────────────────────────── Second Hub
+    ↑ add_parts_to_work_order              (5 actions reference part_id)
+    ↑ add_wo_part
+    ↑ add_to_shopping_list
+    ↑ order_part
+    ↑ link_part_to_equipment
+
+Documents ←──────────────────────────────────────────── Third Hub
+    ↑ link_invoice_document                (4 actions reference document_id)
+    ↑ attach_receiving_image_with_comment
+    ↑ request_label_output
+    ↑ link_document_to_equipment
+
+Handover ←──────────────────────────────────────────── Aggregator
+    ↑ add_to_handover (from ANY entity)
+    ↑ export_handover → AI summarisation → professional document
+    ↑ sign_handover → compliance signature
+
+Work Order → Shopping List → Purchase Order → Receiving
+    (Procurement chain: fault → WO → parts needed → shop → PO → goods received)
+```
+
+**Equipment is the hub entity** — 9 cross-domain actions reference it. This makes sense: in maritime, everything ultimately relates to a piece of equipment.
+
+**The procurement chain** (WO → Shopping List → PO → Receiving) is a 4-step cross-domain workflow that no legacy PMS handles as a connected flow.
+
+**Handover is the aggregator** — it pulls from every domain into a single compliance document. This is unique to CelesteOS.
+
+---
+
+## Part 5: Signature Levels by Action Type
+
+| Level | When Used | Example Actions |
+|---|---|---|
+| MUTATE (no signature) | Routine data entry | create_work_order, add_note, update_status |
+| SIGNED (typed name) | Compliance-sensitive | sign_handover, approve_po, confirm_receiving |
+| SIGNED (L3 PIN) | High-value | decommission_equipment, countersign_handover |
+
+31 of 207 actions (15%) require signatures — all in compliance-critical domains (handover, certificates, purchasing, receiving, hours of rest).
+
+---
+
+*Generated from `apps/api/action_router/registry.py` (207 actions) and frontend component audit (50+ UI buttons). Source of truth: the registry file.*

--- a/scripts/dev/pre-push-check.sh
+++ b/scripts/dev/pre-push-check.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+# pre-push-check.sh — Run before git push. Docker must pass before Render sees code.
+# Usage: bash scripts/dev/pre-push-check.sh
+set -e
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+echo "=== [1/4] Build API Docker image ==="
+docker compose --profile api build
+
+echo "=== [2/4] Start container ==="
+docker compose --profile api up -d
+# Wait for startup
+for i in $(seq 1 15); do
+  if curl -fsS http://localhost:8000/health > /dev/null 2>&1; then
+    break
+  fi
+  [ $i -eq 15 ] && echo "Container failed to start in time" && docker compose --profile api down && exit 1
+  sleep 1
+done
+
+echo "=== [3/4] Healthcheck ==="
+curl -fsS http://localhost:8000/health | python3 -c "import sys,json; d=json.load(sys.stdin); sys.exit(0 if d.get('status')=='healthy' else 1)"
+
+echo "=== [4/4] Certificate handler tests ==="
+SUPABASE_URL="https://vzsohavtuotocgrfkfyd.supabase.co" \
+SUPABASE_SERVICE_KEY="${TENANT_1_SUPABASE_SERVICE_KEY}" \
+MASTER_SUPABASE_URL="https://qvzmkaamzaqxpzbewjxe.supabase.co" \
+MASTER_SUPABASE_JWT_SECRET="${MASTER_SUPABASE_JWT_SECRET}" \
+FEATURE_CERTIFICATES="true" \
+python3 apps/api/tests/cert_binary_tests.py
+
+echo "=== Tear down ==="
+docker compose --profile api down
+
+echo ""
+echo "ALL CHECKS PASSED — safe to push."


### PR DESCRIPTION
## Summary

- **renew_certificate**: implemented (was 501). Opens ActionPopup with issue_date/expiry_date, creates new cert, supersedes old, writes audit log.
- **suspend_certificate**: proper status-change handler (was soft-delete). Sets `status='suspended'`, signed action, captain/manager only.
- **revoke_certificate**: proper status-change handler (was soft-delete). Sets `status='revoked'`, signed action, captain/manager only.
- **archive_certificate**: dedicated handler replacing generic soft-delete. Auto-detects vessel/crew table.
- **add_certificate_note**: fixed `pms_notes.certificate_id` column was missing from DB — insert now succeeds.
- **Expiry automation**: `refresh_certificate_expiry()` DB function, called lazily from list handlers.
- **Crew cert parity**: `status` column, `deleted_at`/`deleted_by` added to `pms_crew_certificates`.
- **Registry fixes**: `add_certificate_note` had `equipment_id` instead of `certificate_id`. `renew_certificate` got field_metadata. `suspend`/`revoke` restricted to captain/manager.
- **`pms_certificates` legacy table**: 18 rows migrated to `pms_vessel_certificates`, table dropped.
- **`v_certificates_enriched`**: rebuilt as UNION of vessel+crew, both filtered by `deleted_at IS NULL`.
- **`_resolve_cert_domain`**: fixed `maybe_single()` returning `None` response object (not just `data=None`) on no-match.
- **`certificate_handler.py`**: rewritten clean — stale 501 blocks removed.

## Test plan

- [x] 16/16 binary handler tests against live tenant DB (direct DB state verification)
- [x] Python syntax: all 6 modified API files pass `ast.parse`
- [x] TypeScript: zero `error TS` in web app
- [x] DB: 7/7 schema checks PASS
- [ ] Role API tests — pending deploy (Render auto-deploys on merge to main)

🤖 Generated with [Claude Code](https://claude.com/claude-code)