### PR TITLE
fix(handover): countersign role check used non-existent 'hod' role

### DIFF
--- a/apps/api/routes/handover_export_routes.py
+++ b/apps/api/routes/handover_export_routes.py
@@ -835,8 +835,9 @@ async def countersign_export(
     from integrations.supabase import get_tenant_client
     supabase = get_tenant_client(auth['tenant_key_alias'])
 
-    # Verify user is HOD (role comes from auth context, already validated)
-    if auth['role'] not in ["hod", "captain", "manager"]:
+    # Verify user is HOD+ — must match actual DB role values from auth_users_roles
+    # "hod" is not a real DB role — actual values are chief_engineer, chief_officer
+    if auth['role'] not in ["chief_engineer", "chief_officer", "captain", "manager"]:
         raise HTTPException(status_code=403, detail="Only HOD+ can countersign")
 
     # Fetch export


### PR DESCRIPTION
## Bug

The countersign endpoint at `POST /v1/handover/export/{id}/countersign` checked:
```python
if auth['role'] not in ["hod", "captain", "manager"]:
```

`"hod"` is not a real DB role. Actual values in `auth_users_roles` are `chief_engineer` and `chief_officer`. Any chief engineer trying to countersign a handover received a 403.

## Fix
```python
if auth['role'] not in ["chief_engineer", "chief_officer", "captain", "manager"]:
```

## Verified
Captain (`role='captain'`) countersign returns `review_status=complete`. ✓

Identified during LENS_DOMAINS documentation review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)