### PR TITLE
docs(lens-domains): complete domain READMEs — handover, certificates, HoR, warranty

### DIFF
--- a/docs/explanations/LENS_DOMAINS/certificates.md
+++ b/docs/explanations/LENS_DOMAINS/certificates.md
@@ -1,0 +1,649 @@
+# Certificates Domain — Complete Engineer Reference
+
+**Written:** 2026-04-14  
+**Author:** CERTIFICATE01  
+**Status:** Current as of PR #525 merged to main  
+**Scope:** Everything about the certificate domain — DB, API, action router, ledger, frontend, cross-domain wiring, bugs, limitations, flow.
+
+---
+
+## What certificates actually are
+
+A certificate in the maritime context is not a document. It is a **dated legal obligation** issued by an external authority (flag state, classification society, port state control). If it lapses, the vessel cannot legally operate. An inspector can detain the vessel. The insurer can void coverage.
+
+The certificate system is therefore not a filing cabinet. It is a **compliance countdown clock with a tamper-evident evidence trail**.
+
+There are two distinct certificate types in this system:
+
+- **Vessel certificates** — issued to the vessel itself. ISM, ISPS, SOLAS, MLC, CLASS, FLAG, LOAD_LINE, MARPOL, IOPP, TONNAGE, IOPP, MANNING, REGISTRATION. Cover the ship's right to operate under specific regulations.
+- **Crew certificates** — issued to individual seafarers. STCW, ENG1, COC (Certificate of Competency), GMDSS, BST (Basic Safety Training), MEDICAL_CARE. Cover the seafarer's qualifications.
+
+Both live in the same UI page but separate DB tables.
+
+---
+
+## The three database tables
+
+All tables live in the **TENANT Supabase** (`vzsohavtuotocgrfkfyd`), not the MASTER.
+
+### `pms_vessel_certificates`
+
+The primary vessel certificate store. 371 rows in production (338 seed, 33 real as of 2026-04-14).
+
+```
+id                uuid         PK
+yacht_id          uuid         FK → yacht_registry(id) ON DELETE CASCADE
+certificate_type  text         NOT NULL  (uppercase, e.g. "ISM", "CLASS", "FLAG")
+certificate_name  text         NOT NULL  (e.g. "ISM Safety Management Certificate")
+certificate_number text                  unique per yacht+type
+issuing_authority text         NOT NULL  (e.g. "DNV GL", "Flag State")
+issue_date        date
+expiry_date       date
+last_survey_date  date                   vessel-specific — survey window start
+next_survey_due   date                   vessel-specific — survey window end
+status            text         NOT NULL  DEFAULT 'valid'
+                               ENUM: valid | expired | superseded | suspended | revoked
+document_id       uuid         FK → doc_metadata(id) ON DELETE SET NULL
+properties        jsonb        DEFAULT '{}'  — stores supersede reason, cascade metadata
+created_at        timestamptz  NOT NULL
+deleted_at        timestamptz             soft-delete field
+deleted_by        uuid                    soft-delete actor (no FK — plain UUID)
+source            text         DEFAULT 'manual'  — 'manual' | 'imported'
+source_id         text                   external ID if imported
+imported_at       timestamptz
+import_session_id uuid         FK → import_sessions(id)
+is_seed           boolean      DEFAULT true  — seed data flag, NOT shown in UI
+```
+
+**Critical:** `is_seed = true` records are filtered out by the view. 338 of 353 rows are seed data. Only 15+ are real.
+
+**Triggers:**
+- `trg_certificates_cache_invalidate` — fires on INSERT/UPDATE, invalidates F1 cache for the `certificate` entity type.
+
+**Indexes:** `yacht_id`, `status`, `certificate_type`, `expiry_date`, `next_survey_due`, `document_id`, `import_session_id`.
+
+### `pms_crew_certificates`
+
+Crew / seafarer certificate store. 38 rows in production.
+
+```
+id                uuid         PK
+yacht_id          uuid         FK → yacht_registry(id) ON DELETE CASCADE
+person_node_id    uuid         FK → search_graph_nodes(id) ON DELETE SET NULL  (nullable)
+person_name       text         NOT NULL  — free text, not FK to crew table
+certificate_type  text         NOT NULL  (e.g. "STCW Basic Safety Training")
+certificate_number text
+issuing_authority text
+issue_date        date
+expiry_date       date
+document_id       uuid         FK → doc_metadata(id) ON DELETE SET NULL
+properties        jsonb        DEFAULT '{}'
+created_at        timestamptz  NOT NULL
+source            text         DEFAULT 'manual'
+source_id         text
+imported_at       timestamptz
+import_session_id uuid         FK → import_sessions(id)
+status            text         NOT NULL  DEFAULT 'valid'
+                               ENUM: valid | expired | revoked | suspended
+deleted_at        timestamptz             added 2026-04-14
+deleted_by        uuid                    added 2026-04-14 (no FK constraint — matches vessel pattern)
+```
+
+**Key difference from vessel:** No `last_survey_date`, `next_survey_due`, `is_seed`. No `certificate_name` (cert type IS the name for crew). No `deleted_by` FK constraint.
+
+**Important:** `person_name` is a free text field. It does NOT FK to any crew/person table. This means if a crew member's name changes in the crew system, their certificates stay linked by name string only. Known limitation.
+
+### `pms_certificates` (DROPPED)
+
+Legacy 18-row table. Migrated into `pms_vessel_certificates` (is_seed=false) and dropped on 2026-04-14. **Do not reference this table anywhere.** If you see it in old code, that code is stale.
+
+---
+
+## The unified view: `v_certificates_enriched`
+
+The frontend page does NOT query the raw tables. It queries this view:
+
+```sql
+CREATE VIEW v_certificates_enriched AS
+  SELECT
+    id, yacht_id,
+    UPPER(certificate_type) AS certificate_type,  -- normalises case inconsistency
+    certificate_name, certificate_number, issuing_authority,
+    issue_date, expiry_date, last_survey_date, next_survey_due,
+    status, document_id, properties, created_at, deleted_at,
+    source, import_session_id, is_seed,
+    'vessel' AS domain,
+    NULL::uuid AS person_node_id,
+    NULL::text AS person_name
+  FROM pms_vessel_certificates
+  WHERE is_seed = false AND deleted_at IS NULL
+
+  UNION ALL
+
+  SELECT
+    id, yacht_id,
+    UPPER(certificate_type) AS certificate_type,
+    certificate_type AS certificate_name,   -- crew: type IS the name
+    certificate_number, issuing_authority,
+    issue_date, expiry_date,
+    NULL::date AS last_survey_date,         -- vessel-only field
+    NULL::date AS next_survey_due,          -- vessel-only field
+    status, document_id, properties, created_at, deleted_at,
+    source, import_session_id,
+    false AS is_seed,
+    'crew' AS domain,                       -- discriminator column
+    person_node_id, person_name
+  FROM pms_crew_certificates
+  WHERE deleted_at IS NULL;
+```
+
+**The `domain` column is critical.** It tells the frontend and adapter which table the cert came from. Without it, you cannot safely route mutations.
+
+**RLS:** The view inherits RLS from the underlying tables. Authenticated users can only see certs for their `yacht_id`.
+
+---
+
+## Expiry automation: `refresh_certificate_expiry()`
+
+```sql
+CREATE FUNCTION refresh_certificate_expiry(p_yacht_id uuid) RETURNS void
+```
+
+This DB function:
+1. Finds all `pms_vessel_certificates` for the yacht with `status = 'valid'` and `expiry_date < CURRENT_DATE`
+2. Updates them to `status = 'expired'`
+3. Writes a `status_change` ledger event for each flip, `source_context = 'system'`
+4. Does the same for `pms_crew_certificates`
+
+**When it runs:** Called lazily at the start of `list_vessel_certificates` and `list_crew_certificates` handlers. Every time a user opens the certificates list, expired statuses are corrected. There is no nightly cron. If nobody views the page, statuses drift — a known limitation.
+
+**Why lazy:** No `pg_cron` available in Supabase on this plan. Chosen over a Render-side scheduled endpoint to avoid an extra network hop.
+
+---
+
+## File map — exact names and locations
+
+```
+BACKEND (apps/api/)
+│
+├── handlers/
+│   └── certificate_handlers.py          ← MAIN LOGIC FILE. CertificateHandlers class.
+│                                           All 14 registered handlers.
+│                                           _renew_certificate_adapter
+│                                           _change_certificate_status_adapter (factory for suspend/revoke)
+│                                           _archive_certificate_adapter
+│                                           _resolve_cert_domain (auto-detects vessel/crew table)
+│                                           _ledger_read (view event writer)
+│                                           get_certificate_handlers(supabase_client) → dict
+│
+├── routes/
+│   ├── certificate_routes.py            ← REST GET endpoints only.
+│   │                                      GET /api/v1/certificates/vessel
+│   │                                      GET /api/v1/certificates/crew
+│   │                                      GET /api/v1/certificates/expiring
+│   │                                      GET /api/v1/certificates/{id}
+│   │                                      GET /api/v1/certificates/{id}/history
+│   │                                      POST /api/v1/certificates/debug/pipeline-test (dev only)
+│   │
+│   └── handlers/
+│       ├── certificate_phase4_handler.py ← Phase 4 route SHIM. 5 native handlers only:
+│       │                                   create_vessel, create_crew, update,
+│       │                                   link_document, supersede.
+│       │                                   All other cert actions go via internal_adapter.
+│       │                                   ⚠️ READ THE BANNER AT TOP before adding anything here.
+│       │
+│       ├── internal_adapter.py          ← Migration shim. Routes legacy actions to
+│       │                                   INTERNAL_HANDLERS in internal_dispatcher.
+│       │                                   cert actions in _ACTIONS_TO_ADAPT:
+│       │                                   renew, archive, suspend, revoke, add_note
+│       │
+│       └── __init__.py                  ← Assembles all HANDLERS dicts. CERT_HANDLERS
+│                                           takes priority over ADAPTER_HANDLERS.
+│
+├── action_router/
+│   ├── registry.py                      ← All 10 certificate action definitions.
+│   │                                      allowed_roles, required_fields, field_metadata.
+│   │                                      Lines ~1570 (supersede), ~2546 (add_note),
+│   │                                      ~3448 (archive/suspend/revoke), ~3626 (renew),
+│   │                                      ~1544 (create_vessel/crew), ~1561 (update/link)
+│   │
+│   ├── ledger_metadata.py               ← Maps all 10 cert actions to ledger event_type.
+│   │                                      Used by p0_actions_routes safety net.
+│   │
+│   └── dispatchers/
+│       └── internal_dispatcher.py       ← INTERNAL_HANDLERS dict.
+│                                           _cert_renew, _cert_archive, _cert_suspend,
+│                                           _cert_revoke wrappers.
+│                                           _cert_supersede_certificate (legacy wrapper)
+│                                           All at lines 368–451.
+│
+├── routes/
+│   └── p0_actions_routes.py             ← Handles POST /v1/actions/execute.
+│                                           Contains Phase B ledger safety net.
+│                                           _CERT_ACTIONS frozenset — maps entity_id → certificate_id.
+│                                           REQUIRED_FIELDS dict — validated from merged context+payload.
+│
+└── tests/
+    ├── cert_binary_tests.py             ← 16-test binary suite. Each test verifies
+    │                                      exact DB row state. No mocks.
+    │                                      Run: python3 tests/cert_binary_tests.py
+    │
+    └── handlers/
+        └── test_remaining_handlers.py   ← Unit tests for certificate_phase4_handler.py.
+                                            Imports from routes.handlers.certificate_phase4_handler.
+
+FRONTEND (apps/web/src/)
+│
+├── app/
+│   └── certificates/
+│       └── page.tsx                     ← The /certificates page.
+│                                           FilteredEntityList → v_certificates_enriched
+│                                           Filters: domain (vessel/crew), status
+│                                           Adapter: certAdapter — routes crew/vessel
+│                                           EntityDetailOverlay → CertificateContent
+│
+└── components/
+    └── lens-v2/
+        └── entity/
+            └── CertificateContent.tsx   ← The detail lens. 442 lines.
+                                            Sections: Identity → Holder Certs →
+                                            Coverage → Equipment → Renewal History →
+                                            Audit Trail → Related Certs → Notes →
+                                            Attachments
+                                            Primary action: renew (opens ActionPopup)
+                                            Secondary: suspend, revoke, archive, add_note
+                                            DANGER_ACTIONS: suspend, archive, revoke
+```
+
+---
+
+## How a read works (full flow)
+
+```
+User opens /certificates
+        ↓
+page.tsx — FilteredEntityList queries Supabase directly
+        ↓ (client-side, uses MASTER JWT + Supabase anon key)
+v_certificates_enriched view
+        ↓
+Returns domain='vessel'|'crew' per row
+        ↓
+certAdapter maps domain → title, type, entityRef
+        ↓
+User clicks a cert → EntityDetailOverlay opens
+        ↓
+EntityLensPage fetches /v1/entity/certificate/{id}
+        ↓
+entity_routes.py → certificate_handlers.get_certificate_details()
+        ↓
+handler calls _ledger_read() [view event to ledger_events]
+        ↓
+handler reads pms_vessel_certificates OR pms_crew_certificates
+        ↓
+returns CertificateContent data shape
+        ↓
+CertificateContent.tsx renders all sections
+```
+
+**IMPORTANT:** The list page queries Supabase DIRECTLY from the browser using the anon key + RLS. The detail view goes through the Render API. These are different auth paths.
+
+---
+
+## How a mutation works (full flow)
+
+Example: captain clicks "Renew Certificate"
+
+```
+CertificateContent.tsx
+        ↓
+handlePrimary() → openActionPopup(renewAction)
+        ↓
+ActionPopup renders fields: new_issue_date, new_expiry_date
+        ↓
+User fills form → submits
+        ↓
+executeAction('renew_certificate', {new_issue_date, new_expiry_date})
+        ↓
+POST /v1/actions/execute {action, context:{yacht_id, entity_id, certificate_id}, payload}
+        ↓
+p0_actions_routes.py
+  1. Role check (registry allowed_roles: chief_engineer, captain, manager)
+  2. REQUIRED_FIELDS check (merged context + payload)
+  3. _CERT_ACTIONS mapping: entity_id → certificate_id
+  4. validate_action_payload()
+  5. RLS entity validation
+  6. Routes to HANDLERS["renew_certificate"]
+        ↓
+HANDLERS lookup order:
+  certificate_phase4_handler.py HANDLERS → not found (renew not in Phase 4)
+  internal_adapter HANDLERS → found (renew is in _ACTIONS_TO_ADAPT)
+        ↓
+internal_adapter calls INTERNAL_HANDLERS["renew_certificate"]
+        ↓
+_cert_renew() in internal_dispatcher.py
+        ↓
+get_certificate_handlers(db).get("renew_certificate")
+        ↓
+_renew_certificate_adapter() in certificate_handlers.py
+  1. _resolve_cert_domain() — finds which table the cert is in
+  2. Validates not superseded/revoked
+  3. Inserts new cert (copy old fields, new dates)
+  4. Updates old cert status → 'superseded'
+  5. Writes pms_audit_log entry
+  6. Returns {status, renewed_certificate_id, superseded_certificate_id}
+        ↓
+p0_actions_routes Phase B ledger safety net
+  ACTION_METADATA["renew_certificate"] → event_type='create'
+  Inserts to ledger_events
+        ↓
+Frontend: onSuccess → refetch entity → CertificateContent re-renders
+```
+
+---
+
+## The 10 certificate actions
+
+| action_id | Layer | Roles | Notes |
+|---|---|---|---|
+| `create_vessel_certificate` | Phase 4 shim → handlers | chief_engineer, captain, manager | |
+| `create_crew_certificate` | Phase 4 shim → handlers | chief_engineer, captain, manager | |
+| `update_certificate` | Phase 4 shim → handlers | chief_engineer, captain, manager | Blocked on superseded/revoked |
+| `link_document_to_certificate` | Phase 4 shim → handlers | chief_engineer, captain, manager | Validates doc_id exists first |
+| `supersede_certificate` | Phase 4 shim → handlers | captain, manager | **SIGNED** — requires full signature payload |
+| `renew_certificate` | internal_adapter → dispatcher | chief_engineer, captain, manager | Creates new cert, supersedes old |
+| `suspend_certificate` | internal_adapter → dispatcher | captain, manager only | Sets status='suspended', SIGNED |
+| `revoke_certificate` | internal_adapter → dispatcher | captain, manager only | Sets status='revoked', SIGNED |
+| `archive_certificate` | internal_adapter → dispatcher | captain, manager | Soft-delete, both tables |
+| `add_certificate_note` | internal_adapter → dispatcher | chief_engineer, captain, manager | Writes to pms_notes.certificate_id |
+
+### Adding a new certificate action — required steps
+
+1. Add `ActionDefinition` to `registry.py` with `domain="certificates"`
+2. Add handler function in `handlers/certificate_handlers.py`, register in `get_certificate_handlers()`
+3. Add `_cert_*` wrapper in `action_router/dispatchers/internal_dispatcher.py`
+4. Add to `INTERNAL_HANDLERS` dict in same file
+5. Add to `_ACTIONS_TO_ADAPT` in `routes/handlers/internal_adapter.py`
+6. Add to `ACTION_METADATA` in `action_router/ledger_metadata.py`
+7. Do NOT add to `certificate_phase4_handler.py` unless it is a Phase 4 native handler
+
+---
+
+## Certificate status lifecycle
+
+```
+         ┌──────────┐
+         │  valid   │◄──────── (renewed cert starts here)
+         └────┬─────┘
+              │
+    ┌─────────┼──────────┬──────────┐
+    ▼         ▼          ▼          ▼
+expired   superseded  suspended  revoked
+              │
+         (terminal)
+```
+
+- **valid** → expired (auto, via `refresh_certificate_expiry`)
+- **valid** → superseded (via `supersede_certificate` SIGNED action — old cert when renewed)
+- **valid** → suspended (via `suspend_certificate` SIGNED — captain/manager only)
+- **valid** → revoked (via `revoke_certificate` SIGNED — captain/manager only)
+- **expired** → valid (via `renew_certificate` — creates new cert, old becomes superseded)
+- **superseded** → terminal. Cannot be changed.
+- **revoked** → terminal. Cannot be changed.
+
+Status check constraints:
+- `pms_vessel_certificates`: `valid | expired | superseded | suspended | revoked`
+- `pms_crew_certificates`: `valid | expired | revoked | suspended`
+
+---
+
+## Ledger coverage — what gets logged and how
+
+Every certificate operation is logged. No exceptions.
+
+### Mutations (via ACTION_METADATA safety net in p0_actions_routes)
+
+```
+create_vessel_certificate  → event_type: create
+create_crew_certificate    → event_type: create
+update_certificate         → event_type: update
+link_document_to_certificate → event_type: update
+supersede_certificate      → event_type: status_change
+renew_certificate          → event_type: create
+suspend_certificate        → event_type: status_change
+revoke_certificate         → event_type: status_change
+archive_certificate        → event_type: update
+add_certificate_note       → event_type: update
+```
+
+The safety net fires after every successful handler execution where `result["_ledger_written"]` is falsy. Fire-and-forget — never blocks the mutation response.
+
+### Reads (via `_ledger_read()` in CertificateHandlers)
+
+```
+list_vessel_certificates   → event_type: view
+list_crew_certificates     → event_type: view
+get_certificate_details    → event_type: view
+view_certificate_history   → event_type: view
+find_expiring_certificates → event_type: view
+```
+
+Written synchronously inside each handler. Fire-and-forget — never blocks the read response. `user_id` and `user_role` come from params injected by `certificate_routes.py`.
+
+### Expiry automation
+
+```
+refresh_certificate_expiry() → event_type: status_change, source_context: system
+user_id: 00000000-0000-0000-0000-000000000000 (sentinel for system actor)
+```
+
+### What is NOT logged
+
+- **Import pipeline** — `import_service.py` writes directly to the DB tables, bypasses the action router and ledger safety net. Imported certs have no ledger trace. This is intentional (imports are considered externally audited at source).
+
+---
+
+## Cross-domain interactions
+
+### With work orders
+**Currently:** None. A cert renewal does not automatically create a work order.
+**Gap:** In real vessel ops, renewing an ISM cert requires booking a class surveyor — that's a work order. No bridge exists. Future: `renew_certificate` could optionally create a linked work order.
+
+### With the ledger
+**Current:** All 10 mutations + 5 reads + expiry automation write to `ledger_events`. Full coverage. The `proof_hash` chain on ledger_events provides tamper-evidence.
+
+### With documents (`doc_metadata`)
+**Current:** `link_document_to_certificate` attaches a single doc to a cert. `document_id` is a single FK — one cert can only have one directly linked document.
+**Gap:** Multi-document support doesn't exist. Certificate PDFs are stored as attachments via `pms_attachments` (uploaded via the Attachments section in the lens), not via `document_id`.
+
+### With the handover system
+**Current:** None. Certificate register is not includable in a handover export.
+**Gap:** Real-world handovers include a cert register. Not wired.
+
+### With notifications
+**Current:** None. No expiry warnings are pushed to any user.
+**Gap:** 90-day, 30-day, 7-day expiry notifications would be standard maritime practice. Not built.
+
+### With the import pipeline (`import_service.py`)
+**Current:** Certs can be imported from CSV. `source = 'imported'`, `import_session_id` is set. The import writes directly to `pms_vessel_certificates` and `pms_crew_certificates` bypassing the action router.
+**Ledger gap:** No ledger entry is written for imported certs.
+
+### With `pms_audit_log`
+**Current:** All mutation handlers in `certificate_handlers.py` write to `pms_audit_log` directly, in addition to the ledger safety net writing to `ledger_events`. This is double-logging — `pms_audit_log` is the handler-level audit, `ledger_events` is the router-level ledger.
+**Why both:** `pms_audit_log` includes `old_values`/`new_values` diffs which `ledger_events` does not currently populate. They serve different purposes.
+
+---
+
+## The `_resolve_cert_domain` function
+
+This is one of the most important utility functions in the domain. It auto-detects which table a certificate belongs to without requiring the caller to specify.
+
+```python
+def _resolve_cert_domain(db, yacht_id: str, cert_id: str) -> tuple:
+    for domain, table_key in [("vessel", "vessel_certificates"), ("crew", "crew_certificates")]:
+        result = db.table(get_table(table_key)).select("*")
+                   .eq("yacht_id", yacht_id).eq("id", cert_id)
+                   .limit(1).execute()
+        rows = getattr(result, "data", None) or []
+        if rows:
+            return domain, table_key, rows[0]
+    raise ValueError(f"Certificate {cert_id} not found or access denied")
+```
+
+**Why `.limit(1)` not `.maybe_single()`:** `maybe_single()` in this version of the Supabase Python client returns `None` (the whole response object, not just the data) when no row matches. Accessing `.data` on `None` raises `AttributeError`. `.limit(1)` returns a list response, empty list if no match. This bug was caught by binary tests.
+
+---
+
+## Known bugs found and fixed (2026-04-14)
+
+| Bug | File | Symptom | Fix |
+|---|---|---|---|
+| `_supersede_certificate_adapter` missing `return _fn` | `handlers/certificate_handlers.py` | supersede always returned 501 "not registered" | Added `return _fn` after inner function definition |
+| `maybe_single()` returns `None` response on no-match | `handlers/certificate_handlers.py` | `_resolve_cert_domain` raised `AttributeError: 'NoneType' has no attribute 'data'` | Switched to `.limit(1)` + `getattr(result, "data", None) or []` |
+| `_delegate()` didn't pass context | `routes/handlers/certificate_phase4_handler.py` | `supersede_certificate` raised `KeyError: 'certificate_id'` | Added `context` param to `_delegate`, merged into params |
+| No `_CERT_ACTIONS` in `resolve_entity_context` | `routes/p0_actions_routes.py` | `entity_id` from EntityLensPage never mapped to `certificate_id` for cert actions | Added `_CERT_ACTIONS` frozenset + mapping |
+| REQUIRED_FIELDS check payload-only | `routes/p0_actions_routes.py` | False 400 on supersede (cert_id in context, not payload) | Changed to `{**request.context, **payload}` for the check |
+| `pms_notes` had no `certificate_id` column | DB | `add_certificate_note` silently failed — insert threw column-not-found | Added `certificate_id uuid FK → pms_vessel_certificates(id)` |
+| `pms_crew_certificates` had no `status` column | DB | Crew cert health was computed-only, never stored | Added `status text NOT NULL DEFAULT 'valid'` with check constraint |
+| `pms_crew_certificates` had no `deleted_at`/`deleted_by` | DB | Archive on crew certs failed | Added both columns (no FK on `deleted_by`, matching vessel pattern) |
+| 5 cert actions missing from `ACTION_METADATA` | `action_router/ledger_metadata.py` | create_vessel, create_crew, update, link_doc, supersede wrote no ledger events | Added all 5 |
+| Read operations wrote no ledger events | `handlers/certificate_handlers.py` | Compliance gap — views were invisible | Added `_ledger_read()` helper, called in all 5 read handlers |
+| `maybe_single()` in `link_document_to_certificate` | `handlers/certificate_handlers.py` | Same AttributeError as above | Fixed with `.limit(1)` pattern |
+
+---
+
+## Known limitations
+
+### No chief_engineer test user exists
+The test user table claims `captain.tenant@alex-short.com` has role `chief_engineer`. In the TENANT DB (`auth_users_roles`), they actually have role `captain`. There is no test user with `chief_engineer` role in the system. Role gating for chief_engineer is verified only through registry inspection + binary handler tests, not via a real JWT.
+
+### Crew cert `person_name` is free text
+No FK to any crew/person record. If someone renames a crew member in the crew system, their certificates remain linked only by name string. Searching by crew member does a `ilike` pattern match on `person_name`.
+
+### Single document per cert
+`document_id` is a single FK. If a cert has multiple associated PDFs (e.g., original + renewal letter + survey report), only one can be linked via `document_id`. Additional files go in the Attachments section via `pms_attachments`, which is not searched or filtered.
+
+### No multi-cert supersede chain UI
+The `properties.supersedes` and `properties.renews` fields track the chain, but the frontend `Renewal History` section only shows the `pms_audit_log` entries — not a visual chain of cert → superseded → superseded by → new cert.
+
+### Expiry is lazy-evaluated
+`refresh_certificate_expiry()` only runs when a list endpoint is called. If nobody views the page, certs past expiry date stay `status='valid'` in the DB indefinitely. There is no background job.
+
+### Import pipeline has no ledger trail
+Certs ingested from Seahub CSV or other import sources arrive silently — no `ledger_events` row is written. The `import_session_id` column tracks the batch, but not at ledger level.
+
+### Feature flag dependency
+All certificate API routes (`/api/v1/certificates/*`) check `FEATURE_CERTIFICATES=true` env var. If this is not set on Render, every read endpoint returns 404. The action router path (`/v1/actions/execute`) does not check this flag — mutations work regardless. This asymmetry is a known inconsistency.
+
+### No notifications
+No 90/30/7-day expiry warnings are sent to any user. No assignment field exists per certificate to know who is responsible for renewal.
+
+### Certificate type case inconsistency
+Historical data in `pms_vessel_certificates` has mixed case types: `class`, `CLASS`, `safety`, `SOLAS`. The view normalises to UPPERCASE via `UPPER(certificate_type)`. New inserts should always be uppercase. The handlers do not enforce this on create — only the view normalises on read.
+
+---
+
+## Things I wish I knew at the start
+
+**1. There are three routing layers and they interact in a specific priority order.**
+When `/v1/actions/execute` receives a cert action, it hits `p0_actions_routes.py`, which consults the unified `HANDLERS` dict. That dict is assembled in `routes/handlers/__init__.py` with this priority: `CERT_HANDLERS` (certificate_phase4_handler.py) takes precedence over `ADAPTER_HANDLERS` (internal_adapter.py). If a cert action is in `CERT_HANDLERS`, it goes there. If not, it falls through to the adapter which routes to `INTERNAL_HANDLERS` in `internal_dispatcher.py`.
+
+**2. The Phase 4 shim (`certificate_phase4_handler.py`) handles exactly 5 actions.**
+All others (renew, archive, suspend, revoke, add_note) go through the adapter path. Adding a new action to the shim when it should go in the dispatcher causes it to work for the Phase 4 path but fail on the action router path. The banner at the top of `certificate_phase4_handler.py` explains this.
+
+**3. `maybe_single()` in this Supabase Python client is broken.**
+When no row matches, it returns `None` for the whole response object, not a response object with `data=None`. Any code that does `result = ...maybe_single().execute(); if result.data:` will raise `AttributeError: 'NoneType' object has no attribute 'data'` when the cert is not in that table. Always use `.limit(1)` + `getattr(result, "data", None) or []`.
+
+**4. The frontend queries the view directly, not the API, for the list.**
+`FilteredEntityList` uses the Supabase client directly (browser-side, anon key + RLS) to query `v_certificates_enriched`. The detail view goes through the Render API. These are different auth paths. This matters when debugging 404s vs empty lists.
+
+**5. `is_seed = true` hides 338 of 353 vessel cert rows.**
+The view filters `WHERE is_seed = false`. If the list is empty, this is usually why. The seed data is there but hidden. Any cert you create via the UI will have `is_seed = false`.
+
+**6. The ledger safety net only fires on mutations via p0_actions_routes.**
+Read operations via GET endpoints (`/api/v1/certificates/*`) do not go through the safety net. They write to the ledger only because `_ledger_read()` was explicitly added to each handler. If you add a new read handler, you must also add a `_ledger_read()` call.
+
+**7. `entity_id` from the frontend context is NOT automatically `certificate_id`.**
+The EntityLensPage sends `entity_id` in the context. For most domains (fault, work order, equipment) the `resolve_entity_context()` function in `p0_actions_routes.py` maps this to the domain-specific key. For certificates, `_CERT_ACTIONS` frozenset handles this mapping to `certificate_id`. If you add a new cert action and forget to add it to `_CERT_ACTIONS`, the action will fail with MISSING_REQUIRED_FIELD.
+
+**8. `supersede_certificate` requires a complete signature payload.**
+Not just `{"signature": {}}` — the router validates that these four keys are present: `signed_at`, `user_id`, `role_at_signing`, `signature_type`. Any test that sends a minimal signature will get 400 from the router, not 403.
+
+**9. The test user roles are NOT what the test table says.**
+`captain.tenant@alex-short.com` appears to be `chief_engineer` in documentation but is actually `captain` in the TENANT DB `auth_users_roles` table. The action router resolves role from TENANT DB, not from the MASTER DB `user_accounts` table. Always check `auth_users_roles` directly to know what role a user actually has.
+
+**10. `deleted_by` has no FK constraint on crew certs.**
+I added it without a FK initially (matching the vessel cert pattern where `deleted_by` also has no FK). Then I made the mistake of adding `REFERENCES auth.users(id)`. This caused test failures when the synthetic test user UUID didn't exist in `auth.users`. The correct pattern — matching vessel certs — is a plain UUID with no FK constraint.
+
+---
+
+## Running the binary tests
+
+The 16-test binary suite hits the live tenant DB. Each test verifies exact DB row state — no mocks.
+
+```bash
+cd /Users/celeste7/Documents/CLOUD_PMS/apps/api
+
+SUPABASE_URL="https://vzsohavtuotocgrfkfyd.supabase.co" \
+SUPABASE_SERVICE_KEY="<from /Documents/Cloud_PMS/env/env vars.md>" \
+MASTER_SUPABASE_URL="https://qvzmkaamzaqxpzbewjxe.supabase.co" \
+MASTER_SUPABASE_JWT_SECRET="<from env vars.md>" \
+FEATURE_CERTIFICATES="true" \
+python3 tests/cert_binary_tests.py
+```
+
+Expected output: `RESULTS: 16/16 PASS | 0/16 FAIL`
+
+The pre-push Docker check also runs these:
+
+```bash
+bash scripts/dev/pre-push-check.sh
+```
+
+---
+
+## Role permissions quick reference
+
+| Action | crew | chief_engineer | captain | manager |
+|---|---|---|---|---|
+| View list | ✓ | ✓ | ✓ | ✓ |
+| View detail | ✓ | ✓ | ✓ | ✓ |
+| View history | ✓ | ✓ | ✓ | ✓ |
+| Create vessel cert | ✗ | ✓ | ✓ | ✓ |
+| Create crew cert | ✗ | ✓ | ✓ | ✓ |
+| Update cert | ✗ | ✓ | ✓ | ✓ |
+| Renew cert | ✗ | ✓ | ✓ | ✓ |
+| Link document | ✗ | ✓ | ✓ | ✓ |
+| Add note | ✗ | ✓ | ✓ | ✓ |
+| Supersede (SIGNED) | ✗ | ✗ | ✓ | ✓ |
+| Suspend (SIGNED) | ✗ | ✗ | ✓ | ✓ |
+| Revoke (SIGNED) | ✗ | ✗ | ✓ | ✓ |
+| Archive | ✗ | ✗ | ✓ | ✓ |
+| Delete (hard) | ✗ | ✗ | ✗ | ✓ |
+
+SIGNED actions require a signature payload with: `signed_at`, `user_id`, `role_at_signing`, `signature_type`.
+
+---
+
+## Environment variables
+
+All from `/Users/celeste7/Documents/Cloud_PMS/env/env vars.md`
+
+| Variable | Used by | Purpose |
+|---|---|---|
+| `FEATURE_CERTIFICATES` | Render + Docker | Gates all `/api/v1/certificates/*` GET endpoints. Must be `true`. Does NOT gate mutation endpoints via action router. |
+| `SUPABASE_URL` | Render API | Tenant DB URL (`vzsohavtuotocgrfkfyd`) |
+| `SUPABASE_SERVICE_KEY` | Render API | Bypasses RLS for service operations |
+| `MASTER_SUPABASE_URL` | Render API | Master DB URL (`qvzmkaamzaqxpzbewjxe`) for auth |
+| `MASTER_SUPABASE_JWT_SECRET` | Render API | JWT verification |
+
+The frontend (`apps/web`) uses the Supabase anon key + RLS for direct DB queries (the list view). No additional env vars needed for cert reads.
+
+---
+
+## PR history (this domain)
+
+| PR | What | Status |
+|---|---|---|
+| #522 | Complete cert domain — renew/suspend/revoke/expiry/crew parity, 4 pre-existing bugs fixed, Docker pre-push check | Merged |
+| #524 | Cert ledger reads + ACTION_METADATA gaps (opened separately, landed in #525) | Merged via #525 |
+| #525 | Full package: cert+ledger+HoR+handover — all domains on one branch | Merged to main 2026-04-14T16:08Z |

--- a/docs/explanations/LENS_DOMAINS/handover.md
+++ b/docs/explanations/LENS_DOMAINS/handover.md
@@ -1,0 +1,726 @@
+# Handover — Complete Feature Explanation
+
+**Written by:** HANDOVER01 (2026-04-14)  
+**For:** Any new engineer, agent, or worker picking up this feature  
+**Repo:** `Cloud_PMS` — `shortalex12333/Cloud_PMS`  
+**Scope:** Everything about the handover feature — frontend, backend, DB, microservice, ledger, bugs, traps, limitations
+
+---
+
+## 1. What This Feature Is (Plain English)
+
+When a crew member finishes their rotation on a yacht and someone new comes on board, there needs to be a formal knowledge transfer. Traditionally this is a Word document written at 10pm on the last night, with no structure, no accountability, and no links to actual records.
+
+CelesteOS replaces that. Throughout the rotation, crew members tap a button ("Add to Handover") on any fault, work order, equipment record, or part to queue it. When it's time to hand over, one click assembles everything into a professional, structured, LLM-processed document. The outgoing crew signs it. The HOD (Head of Department) reviews and countersigns. The incoming crew receives it and signs to acknowledge. The ledger records the whole chain permanently.
+
+Every role generates their own handover — deckhand, stew, engineer, captain. Each scoped to their department.
+
+---
+
+## 2. The User Journey (Step by Step)
+
+### Step 1 — Tagging items (throughout the rotation)
+- Crew member is on a fault lens, work order lens, or parts page
+- Clicks "Add to Handover" action button
+- A popup appears — summary is **pre-filled** from the entity data (no typing required)
+- Category auto-set: fault → `urgent`, part → `fyi`, etc.
+- One tap confirm → item lands in `handover_items` table
+- **Critical items** immediately trigger a ledger notification to all HOD-level users on the vessel
+
+### Step 2 — Viewing draft items
+- Navigate to `/handover-export`
+- Two tabs: **Queue** (auto-detected candidates) and **Draft Items** (things already added)
+- Queue shows: Open Faults / Overdue Work Orders / Low Stock Parts / Pending Purchase Orders
+- Each queue row has `+ Add` button — tapping it runs the same add_to_handover action
+- Draft Items tab shows all `handover_items` for this user, grouped by day (Today expanded)
+- Click any item → popup to Edit / Delete
+- Click "Add Note" → create a freetext note (not linked to any entity)
+
+### Step 3 — Generating the export
+- Click "Export" button in Draft Items tab
+- Frontend POSTs to `POST /v1/handover/export` on Render API
+- Render fetches all the user's pending handover_items
+- Render calls the **handover-export microservice** (separate service at `handover-export.onrender.com`)
+- Microservice runs LLM pipeline: classify → group → merge → render Jinja2 HTML
+- Returns professional HTML document + structured sections JSON
+- Render writes: `handover_entries`, `handover_drafts`, `handover_draft_sections`, `handover_draft_items`, `handover_exports` to TENANT DB
+- Ledger event fires → HOD notified to review
+- User is redirected to `/handover-export/{export_id}`
+
+### Step 4 — Reviewing and signing
+- User sees generated document at `/handover-export/{export_id}`
+- Document is editable while `review_status = 'pending_review'` (contentEditable inline)
+- Can save edits via `POST /v1/handover/export/{id}/save-draft`
+- User draws signature on canvas → "Confirm & Sign"
+- POSTs to `/v1/handover/export/{id}/submit`
+- `review_status` moves to `pending_hod_signature`
+- HOD notified via ledger_events
+
+### Step 5 — HOD countersign
+- HOD sees notification in ledger panel
+- Reviews document → countersigns
+- POSTs to `/v1/handover/export/{id}/countersign`
+- `review_status` moves to `complete`
+- Captain + Manager notified via ledger_events
+- Document indexed for search
+
+### Step 6 — Incoming crew receives
+- Incoming crew member sees the completed handover on their device
+- Reads it, signs to acknowledge (uses same `/sign/incoming` route)
+- `signoff_complete = true` in `handover_signoffs` table
+
+---
+
+## 3. Architecture — Three Layers
+
+```
+LAYER 1: FRONTEND (Vercel — Next.js App Router)
+  app.celeste7.ai
+  Supabase client → MASTER DB only (auth only)
+  All operational data → via Render API
+
+LAYER 2: API (Render — Python FastAPI)
+  pipeline-core.int.celeste7.ai
+  Service-role access to TENANT DB
+  Validates MASTER JWT, then hits TENANT for all data
+
+LAYER 3: MICROSERVICE (Render — Python FastAPI)
+  handover-export.onrender.com
+  Stateless — receives items JSON, returns HTML + sections
+  No DB access. OpenAI GPT-4o-mini only.
+  Env flag: HANDOVER_USE_MICROSERVICE=true (in celeste-unified)
+```
+
+### Two Supabase Projects — CRITICAL
+
+```
+MASTER:  qvzmkaamzaqxpzbewjxe.supabase.co  → auth + user directory only
+TENANT:  vzsohavtuotocgrfkfyd.supabase.co  → ALL operational data
+```
+
+The frontend's `supabase` client (from `supabaseClient.ts`) points at **MASTER** via `NEXT_PUBLIC_SUPABASE_URL`. This is correct for auth. It is **completely wrong** for operational tables. Do not call `supabase.from('handover_items')` or any PMS table directly from the frontend — those tables don't exist in MASTER. You will get a 400 with no useful error message.
+
+All operational reads/writes from frontend → Render API → TENANT DB.
+
+---
+
+## 4. Database Tables
+
+All tables live in **TENANT DB** (`vzsohavtuotocgrfkfyd`).
+
+### Primary tables
+
+| Table | Purpose | Key columns |
+|---|---|---|
+| `handover_items` | The draft queue. One row per "Add to Handover" tap | `id, yacht_id, added_by, entity_type, entity_id, summary, category, section, is_critical, export_status, status, deleted_at` |
+| `handover_exports` | The generated document record | `id, yacht_id, draft_id, review_status, outgoing_signed_at, incoming_signed_at, hod_signed_at, signoff_complete, document_hash, original_storage_url, signed_storage_url` |
+| `handover_drafts` | The LLM-assembled document metadata | `id, yacht_id, state, period_start, period_end, department, generated_by_user_id, total_entries, critical_entries` |
+| `handover_draft_sections` | Department sections within a draft | `id, draft_id, bucket_name, section_order, display_title, item_count, critical_count` |
+| `handover_draft_items` | Individual LLM-summarised items | `id, draft_id, section_id, section_bucket, summary_text, domain_code, is_critical, item_order, entity_url, source_entry_ids` |
+| `handover_entries` | Immutable truth seeds from LLM merge | `id, yacht_id, narrative_text, source_entity_type, is_critical, status` — **NO DELETE policy — permanent** |
+| `handover_signoffs` | Outgoing/incoming signature records | `id, draft_id, outgoing_user_id, outgoing_signed_at, incoming_user_id, incoming_signed_at, signoff_complete, document_hash` |
+| `handover_sources` | Email/document sources for handover items | `id, yacht_id, source_type, is_processed, classification` |
+
+### Views
+
+| View | What it does |
+|---|---|
+| `v_handover_draft_complete` | Aggregates draft + sections as nested JSON. Use this to fetch a full document in one query. |
+| `v_handover_export_items` | Items joined to their section with section title, order, entity links. Use for export rendering. |
+| `v_handover_signoffs` | Flattens outgoing/incoming as separate rows with `signoff_type` column. |
+
+### Audit / Notification tables
+
+| Table | Purpose |
+|---|---|
+| `pms_audit_log` | Immutable compliance trail. One row per action per actor. Never deleted. |
+| `ledger_events` | Notification bus. Frontend polls/subscribes. Each row is a notification TO a specific `user_id`. |
+
+### Handover item `status` values
+
+```
+status column:       pending | acknowledged | completed | deferred
+export_status col:   pending | exported
+```
+
+Do not use `status="exported"` — that column has a check constraint. The export tracking uses `export_status`.
+
+### `handover_exports.review_status` state machine
+
+```
+pending_review → pending_hod_signature → complete
+```
+
+`save-draft` requires `pending_review`. `submit` requires `pending_review`. `countersign` requires `pending_hod_signature`.
+
+---
+
+## 5. Frontend Files — Exact Paths
+
+```
+apps/web/src/
+├── app/
+│   └── handover-export/
+│       ├── page.tsx                    ← Queue + Draft Items tabs
+│       └── [id]/
+│           └── page.tsx                ← Generated document detail page
+│
+├── components/
+│   ├── handover/
+│   │   ├── HandoverDraftPanel.tsx      ← Draft items list, CRUD, export button
+│   │   └── HandoverQueueView.tsx       ← Auto-detected candidate items
+│   └── lens-v2/
+│       └── entity/
+│           └── HandoverContent.tsx     ← The rendered document + signing UI
+│
+├── lib/
+│   ├── handoverExportClient.ts         ← API client helpers for handover export
+│   └── microactions/
+│       └── handlers/
+│           └── handover.ts             ← Microaction handler for add_to_handover
+│
+└── components/shell/
+    └── api.ts                          ← fetchHandoverQueue() lives here (line ~226)
+```
+
+### Key component details
+
+**`HandoverDraftPanel.tsx`**
+- Two variants: `drawer` (slides in from right, 460px) and `page` (inline, for the tab)
+- Reads items via `GET /v1/handover/items` (Render API — NOT direct Supabase)
+- Groups by day, collapsible, Today expanded by default
+- `ItemPopup` handles Edit / Add / Delete modes
+- Export button → `POST /v1/handover/export` → redirects to `/handover-export/{id}`
+- After export, calls `POST /v1/handover/items/mark-exported` to update status
+
+**`HandoverQueueView.tsx`**
+- Calls `fetchHandoverQueue(vesselId)` → `GET /v1/actions/handover/queue` (note: this is under `/v1/actions/` prefix, not `/v1/handover/`)
+- Four sections: Open Faults, Overdue Work Orders, Low Stock Parts, Pending Purchase Orders
+- Each item has `+ Add` → `POST /v1/actions/execute` with `action: 'add_to_handover'`
+- Already-queued items show green `✓ Added` (optimistic set of `entity_id`s)
+
+**`HandoverContent.tsx`**
+- The detail lens for a completed export
+- Renders the document HTML inline (cover, TOC, sections, items, entity links)
+- Inline editing when `status === 'pending_review'` (uses `contentEditable`)
+- Signature block: two columns (Prepared By / Reviewed By) — currently static layout
+- "Sign Handover" button → canvas wet-signature modal → `executeAction('sign_handover')`
+- **Gap:** The action ID in the component is `sign_handover` but the registry has `sign_handover_outgoing` and `sign_handover_incoming`. The button is present but the action doesn't resolve. This is the next thing to fix.
+- "Export PDF" → `window.print()`
+
+---
+
+## 6. Backend Files — Exact Paths
+
+```
+apps/api/
+├── routes/
+│   ├── handover_export_routes.py       ← ALL handover HTTP endpoints
+│   │                                      prefix: /v1/handover
+│   │                                      Endpoints: /export, /exports, /export/{id},
+│   │                                                /export/{id}/content,
+│   │                                                /export/{id}/save-draft,
+│   │                                                /export/{id}/submit,
+│   │                                                /export/{id}/countersign,
+│   │                                                /items (GET/PATCH/DELETE),
+│   │                                                /items/mark-exported
+│   │
+│   ├── p0_actions_routes.py            ← Action execution + handover queue
+│   │                                      prefix: /v1/actions
+│   │                                      Key endpoints: /handover/queue, /handover (GET items legacy)
+│   │
+│   └── handlers/
+│       ├── handover_handler.py         ← Delegates add_to_handover_execute to HandoverHandlers
+│       └── ledger_utils.py             ← build_ledger_event() helper — used everywhere
+│
+├── handlers/
+│   ├── handover_handlers.py            ← HandoverHandlers class
+│   │                                      add_to_handover_prefill()
+│   │                                      add_to_handover_execute()   ← MAIN add path
+│   │                                      edit_handover_item_execute()
+│   │                                      export_handover_execute()
+│   │                                      regenerate_handover_summary_execute()
+│   │
+│   └── handover_workflow_handlers.py   ← HandoverWorkflowHandlers class
+│                                          sign_outgoing(), sign_incoming()
+│                                          get_pending_handovers()
+│                                          _notify_ledger_export_ready()
+│
+├── services/
+│   ├── handover_export_service.py      ← HandoverExportService, create_export_ready_ledger_event()
+│   ├── handover_html_parser.py         ← Parses generated HTML back into editable sections
+│   └── handover_microservice_client.py ← HTTP client that calls handover-export.onrender.com
+│
+└── action_router/
+    ├── registry.py                     ← Action definitions (line ~905: add_to_handover)
+    ├── dispatchers/
+    │   └── internal_dispatcher.py      ← add_to_handover() function (line ~705)
+    │                                      THIS is what the action router actually calls
+    └── ledger_metadata.py              ← Maps action IDs to ledger event types
+```
+
+### Two `add_to_handover` paths — understand this or you will be confused
+
+There are **two separate code paths** for adding a handover item:
+
+**Path A — Action Router (primary, used by frontend Queue + entity lens):**
+```
+POST /v1/actions/execute {action: 'add_to_handover'}
+  → action_router/router.py
+  → INTERNAL_HANDLERS["add_to_handover"]  (registry.py line ~905)
+  → internal_dispatcher.py::add_to_handover()  (line ~705)
+  → direct INSERT into handover_items
+```
+
+**Path B — Handler route (secondary, called via p0_actions_routes.py):**
+```
+Some routes in p0_actions_routes.py (line ~177, ~201)
+  → routes/handlers/handover_handler.py::add_to_handover_action()
+  → handlers/handover_handlers.py::HandoverHandlers.add_to_handover_execute()
+  → INSERT into handover_items
+```
+
+Both paths insert into `handover_items`. Both have been fixed with `category_map`, correct column names, and critical cascade. But if you only fix one, the other breaks silently.
+
+---
+
+## 7. The Action Router — How "Add to Handover" Works
+
+When a user clicks `+ Add` on the Queue page or "Add to Handover" from an entity lens:
+
+1. Frontend calls `POST /v1/actions/execute` with:
+   ```json
+   {
+     "action": "add_to_handover",
+     "context": { "yacht_id": "..." },
+     "payload": {
+       "entity_type": "fault",
+       "entity_id": "uuid",
+       "summary": "Equipment name — Fault code",
+       "category": "standard",
+       "section": "Engineering"
+     }
+   }
+   ```
+
+2. Action router validates JWT → extracts `user_id`, `yacht_id`, `role` from token
+3. Checks `add_to_handover` allowed_roles: `["crew", "engineer", "eto", "chief_engineer", "chief_officer", "captain", "manager"]`
+4. Validates `required_fields: ["summary"]`
+5. Dispatches to `internal_dispatcher.py::add_to_handover()`
+6. Category normalised: `critical→urgent`, `standard→fyi`, `low→fyi`
+7. Entity ownership verified (fault/WO/equipment confirmed to belong to this yacht)
+8. Row inserted into `handover_items`
+9. Audit log written to `pms_audit_log`
+10. If `is_critical=True`: ledger notification fired to all HOD+ users on yacht
+
+### Prefill — auto-populated summaries
+
+Before the user confirms, `GET /v1/actions/add_to_handover/prefill` can be called to get pre-populated fields:
+
+- **Fault** → summary = `{equipment_name} — {fault_code}\n{description}`, category = `ongoing_fault`
+- **Work Order** → summary = `WO-{number}: {title}\nEquipment: {name}\nStatus: {status}`, category = `work_in_progress`
+- **Equipment** → summary = `{name} ({manufacturer} {model})\nLocation: {location}`, category = `equipment_status`
+- **Part** → summary = `{name} ({part_number})\nStock: {qty} ({stock_status})`, category = `general`
+
+This means the user almost never has to type. The form arrives pre-filled.
+
+---
+
+## 8. The LLM Microservice
+
+**Repo:** `github.com/shortalex12333/handover_export`  
+**URL:** `https://handover-export.onrender.com`  
+**Feature flag:** `HANDOVER_USE_MICROSERVICE=true` (set in Render env for celeste-unified)  
+**Local:** runs on `:10000` via `docker compose up` in the `handover_export` repo
+
+### What it does
+
+Takes raw `handover_items` (JSON array), returns professional HTML + structured sections. No DB. No storage. Stateless.
+
+### Pipeline
+
+```
+Input: [{entity_type, summary, category, is_critical, entity_url, ...}]
+
+Stage 1 — CLASSIFY (GPT-4o-mini, concurrent, semaphore=10)
+  Each item gets a maritime department bucket:
+  Electrical | Projects | Financial | Galley/Laundry | Risk |
+  Admin/Compliance | Fire Safety | Tenders | Logistics | Deck | General
+
+Stage 2 — GROUP
+  Items grouped by bucket. Only merges items with same entity_id (true duplicates).
+
+Stage 3 — MERGE (GPT-4o-mini, concurrent, semaphore=5)
+  Each group → one professional summary in 2nd person ("You need to...")
+  Preserves ALL specifics: part numbers, vendor names, measurements, dates.
+  Extracts action items with priority tags: CRITICAL | HIGH | NORMAL
+
+Stage 4 — RENDER (Jinja2)
+  templates/handover_report.html
+  A4-ready HTML: cover page, TOC, sections by department, items numbered,
+  entity deep links ("View Fault →"), dual signature block, footer with hash
+```
+
+### Key design decisions
+
+- Every item preserved (no AI curation of what to include)
+- Detail preservation over brevity (the merge prompt explicitly instructs GPT to keep all specifics)
+- System fonts only (no Google CDN — yacht satellite internet)
+- `autoescape=True` in Jinja2 (prevents XSS from LLM output)
+- SHA-256 of rendered HTML = `document_hash` (tamper evidence)
+
+### If the microservice is down
+
+Fallback path exists in `handover_export_routes.py`. If the microservice call fails, the old basic HTML export runs instead (less structured, no LLM processing).
+
+---
+
+## 9. Ledger + Notification Cascade
+
+### Tables
+
+- `pms_audit_log` — compliance trail. Every significant write gets one row. Has `old_values` / `new_values` jsonb. Never deleted.
+- `ledger_events` — notification bus. Frontend subscribes. Each row is a notification TO a `user_id`. Frontend shows these as the "recent activity" ledger panel.
+
+### Helper functions (in `handover_export_routes.py`)
+
+```python
+_get_role_users(db, yacht_id, roles)
+  # Queries auth_users_roles (NOT auth_users_profiles — see bugs section)
+  # Returns [{user_id, role, department, name}]
+
+_write_handover_event(db, yacht_id, actor_id, actor_role, target_user_id,
+                       entity_id, event_type, action, change_summary, ...)
+  # Writes one row to pms_audit_log AND one row to ledger_events
+  # Both writes in try/except — never raises, never blocks the main action
+```
+
+### Cascade hierarchy
+
+```
+CREW adds critical item
+  └─ ledger_events → all chief_engineer, chief_officer, captain on yacht
+     action: "critical_item_added"  event_type: "escalation"
+
+CREW deletes draft item
+  └─ ledger_events → all chief_engineer, chief_officer, captain
+     action: "draft_item_deleted"   event_type: "delete"
+
+CREW submits (signs) export
+  └─ ledger_events → all chief_engineer, chief_officer, captain
+     action: "requires_countersignature"  event_type: "handover"
+     (This is _notify_hod_for_countersign — fixed from broken version)
+
+HOD countersigns
+  └─ ledger_events → all captain, manager
+     action: "handover_countersigned"  event_type: "handover"
+
+EDIT / save-draft / mark-exported
+  └─ pms_audit_log only (actor-only, no notification cascade)
+```
+
+### Role lookup table
+
+```
+auth_users_roles (TENANT DB)
+  columns: id, user_id, yacht_id, role, department, is_active, assigned_at
+  roles: crew | engineer | eto | chief_engineer | chief_officer | captain | manager
+```
+
+---
+
+## 10. Domain Interactions
+
+The handover feature is connected to every other domain in the PMS. Here is what it reads from each:
+
+| Domain | Table | Why handover reads it |
+|---|---|---|
+| Faults | `pms_faults` | Prefill for add_to_handover. Queue auto-detection (open faults). |
+| Work Orders | `pms_work_orders` | Prefill. Queue auto-detection (overdue WOs). |
+| Equipment | `pms_equipment` | Prefill (equipment name, location, manufacturer). |
+| Parts/Inventory | `pms_parts`, `pms_part_stock` | Queue auto-detection (low stock). Prefill with stock levels. |
+| Purchase Orders | `pms_purchase_orders` | Queue auto-detection (pending orders). |
+| Documents | `documents` | Can be added to handover via entity lens. |
+| Certificates | `pms_vessel_certificates`, `pms_crew_certificates` | Relevant for vessel-level handover (expiring certs = critical items). |
+| Crew / Roles | `auth_users_roles` | HOD lookup for cascade notifications. Incoming crew selection. |
+| Ledger | `ledger_events`, `pms_audit_log` | Written to on every handover state change. |
+| Search index | `search_index` | Written to after countersign for full-text search. |
+| Supabase Storage | bucket: `handover-exports` | HTML documents stored at `{yacht_id}/original/{draft_id}.html` and `{yacht_id}/signed/{export_id}.html` |
+
+---
+
+## 11. Bugs Found and Fixed (This Session)
+
+These are real bugs that were in production. Know them so you don't reintroduce them.
+
+### Bug 1 — HandoverDraftPanel hitting MASTER DB
+**Symptom:** `POST https://qvzmkaamzaqxpzbewjxe.supabase.co/rest/v1/handover_items 400 (Bad Request)`  
+**Cause:** `HandoverDraftPanel.tsx` used `supabase.from('handover_items')` — the frontend supabase client points at MASTER, not TENANT. `handover_items` doesn't exist in MASTER.  
+**Fix:** All 6 direct supabase DB calls replaced with `fetch(RENDER_API_URL/...)`. Auth token still comes from `supabase.auth.getSession()` (correct — MASTER JWT).  
+**File:** `apps/web/src/components/handover/HandoverDraftPanel.tsx`
+
+### Bug 2 — Wrong column names in internal_dispatcher insert
+**Symptom:** `handover_items` insert silently failed or wrote to wrong fields  
+**Cause:** `internal_dispatcher.py::add_to_handover` used `summary_text` (no such column — it's `summary`) and `added_at` (no such column — DB uses `created_at` with default). Also lacked `is_critical`, `export_status`, `status` fields.  
+**Fix:** Corrected all field names. Added all required fields.  
+**File:** `apps/api/action_router/dispatchers/internal_dispatcher.py`
+
+### Bug 3 — Category validation rejected new UI values
+**Symptom:** `POST /v1/actions/execute` with `category='standard'` or `category='critical'` → "Invalid category" error  
+**Cause:** Backend only accepted `["urgent", "in_progress", "completed", "watch", "fyi"]`. Frontend sends `critical | standard | low`.  
+**Fix:** Added `category_map` in both `internal_dispatcher.py` and `handover_handlers.py`. `critical→urgent`, `standard→fyi`, `low→fyi`. Normalisation happens before validation.  
+**Files:** `apps/api/action_router/dispatchers/internal_dispatcher.py`, `apps/api/handlers/handover_handlers.py`
+
+### Bug 4 — `crew` role blocked from add_to_handover
+**Symptom:** `engineer.test@alex-short.com` (role: crew) got "Role 'crew' is not authorized"  
+**Cause:** `allowed_roles` in registry.py for `add_to_handover` didn't include `crew`. Every rank should be able to add items.  
+**Fix:** Added `crew` to `allowed_roles`. Also fixed `required_fields` from `["yacht_id", "title"]` (title doesn't exist in payload) to `["summary"]`.  
+**File:** `apps/api/action_router/registry.py` line ~911
+
+### Bug 5 — `_notify_hod_for_countersign` queried wrong table
+**Symptom:** Zero HOD notifications ever sent on handover submission. Silent failure.  
+**Cause:** The function queried `auth_users_profiles` for a `role` column. That table has no `role` column. `role` lives in `auth_users_roles`. The query returned 0 rows silently.  
+**Fix:** Replaced entire function body with `_get_role_users(supabase, yacht_id, ["chief_engineer", "chief_officer", "captain"])` which queries the correct table.  
+**File:** `apps/api/routes/handover_export_routes.py` line ~1262
+
+### Bug 6 — PATCH/DELETE missing ownership check
+**Symptom:** Any user on a yacht could edit or delete any other user's handover item  
+**Cause:** Agent-introduced regression. The `.eq("added_by", user_id)` filter was dropped from both the PATCH and DELETE queries.  
+**Fix:** Restored `.eq("added_by", user_id)` to both. DELETE also restored `deleted_by` and `deletion_reason` fields.  
+**File:** `apps/api/routes/handover_export_routes.py`
+
+### Bug 7 — mark-exported used wrong column
+**Symptom:** `POST /v1/handover/items/mark-exported` would try to set `status="exported"` — check constraint violation  
+**Cause:** The `status` column has a check constraint: only `pending | acknowledged | completed | deferred`. Export tracking uses the separate `export_status` column.  
+**Fix:** Changed to `export_status="exported"`, `status="completed"`. Removed invented `exported_at` column (doesn't exist).  
+**File:** `apps/api/routes/handover_export_routes.py`
+
+---
+
+## 12. What I Wish I Knew at the Start
+
+**1. There are two add_to_handover code paths.** Both insert into `handover_items`. If you fix the dispatcher, the handler path is still broken. If you fix the handler path, the dispatcher is still broken. They are completely independent. Always fix both.
+
+**2. The frontend supabase client is MASTER-only.** Never call `supabase.from(any_pms_table)` from the frontend. Always go through `fetch(RENDER_API_URL/...)`. The error you get (400 from MASTER) has no useful message about the table not existing.
+
+**3. `auth_users_profiles` has no `role` column.** Role lives in `auth_users_roles`. Name map:
+   - `auth_users_profiles`: `id, yacht_id, email, name, is_active`
+   - `auth_users_roles`: `id, user_id, yacht_id, role, department, is_active`
+
+**4. `p0_actions_routes.py` has prefix `/v1/actions`.** So `GET /handover` inside that file is actually `/v1/actions/handover`. The handover export routes are separate with prefix `/v1/handover`. This trips you up when adding new handover endpoints — put them in `handover_export_routes.py`, not `p0_actions_routes.py`.
+
+**5. `handover_items.status` vs `handover_items.export_status`.** Two separate columns. `status` tracks workflow state (pending/completed). `export_status` tracks whether items have been pulled into an export (pending/exported). Using the wrong one causes check constraint failures.
+
+**6. The microservice is feature-flagged.** `HANDOVER_USE_MICROSERVICE=true` in the Render environment. In local Docker without this flag, the old basic HTML fallback runs. You will not see the LLM output locally unless you run the handover_export repo separately on `:10000`.
+
+**7. Test data has 82+ HOD users.** Don't panic when you see 82 ledger_events for one critical item add. The test yacht has been seeded with dozens of test users. In real production there are 2-5.
+
+**8. The action registry `required_fields` is validated before dispatch.** If you add a new field that the payload needs to send but it's not in `required_fields`, the action will pass validation even without it. And if a field IS in `required_fields` but the frontend doesn't send it, you'll get a 400 at the gateway. `required_fields` in the registry is the contract.
+
+**9. `handover_entries` has no DELETE policy.** These are the LLM truth seeds — immutable by design. You can never clean them up even in tests. Don't insert junk data into this table.
+
+**10. `HandoverContent.tsx` reads `entity.sections` but the entity lens endpoint doesn't join to sections.** The document body shows "No handover content available" even for real exports because the entity handler returns `handover_exports` without joining `handover_draft_sections` / `handover_draft_items`. This is the next unfixed gap.
+
+---
+
+## 13. Open Gaps and Limitations
+
+These are known, intentional gaps — not bugs. They need to be built.
+
+### Gap 1 — HandoverContent signing action ID mismatch (NEXT PRIORITY)
+`HandoverContent.tsx` calls `executeAction('sign_handover', ...)` and checks `getAction('sign_handover')`. The registry has `sign_handover_outgoing` and `sign_handover_incoming`. There is no `sign_handover`. `canSign` is always false — the sign button never shows.
+**Fix:** Line 103 in `HandoverContent.tsx`: change `getAction('sign_handover')` to `getAction('sign_handover_outgoing') ?? getAction('sign_handover_incoming')`. Fix `handleSignConfirm` to dispatch the right action ID based on which is available.
+
+### Gap 2 — Entity lens doesn't return `sections` data
+`HandoverContent.tsx` reads `entity.sections` to render the document body. The entity handler for `handover_export` returns the raw DB row, which has no `sections`. Sections live in `v_handover_draft_complete`.
+**Fix:** In the entity handler for `handover_export`, after fetching the row, fetch `v_handover_draft_complete` by `draft_id` and attach `sections`.
+
+### Gap 3 — No department/role filter on export
+`ExportRequest` has `filter_by_user` but no `department` filter. A captain's export includes all items from all crew. A deckhand's export includes only their items because `filter_by_user=true` scopes to `added_by=user_id`.
+For a proper crew handover (scoped to their department), you'd want to also filter by `section` or `department`. Not implemented.
+
+### Gap 4 — No incoming crew selector in the export flow
+When exporting, there's no UI step to nominate the incoming crew member. `incoming_user_id` in `handover_exports` is always NULL until the incoming person actively signs.
+**Simple fix:** Add a `Select incoming crew member` optional dropdown before triggering export. Pull from `auth_users_roles` where `role = outgoing user's role` and `yacht_id = vessel`.
+
+### Gap 5 — Signing flow not complete end-to-end in production
+`handover_exports` has 1 row in production (as of 2026-04-14), `signoff_complete=false`. The submit/countersign routes exist and work, but the frontend `/handover-export/{id}` page doesn't show the signing UI yet (Gap 1 above). No handover has ever been fully signed.
+
+### Gap 6 — Vessel-level handover not implemented
+The marketing material describes a "vessel handover" — pulls all items across all crew, appends certificate status, open warranty claims, overdue PMS tasks. The DB has `handover_type` discussed but not implemented. Only crew-level handovers (scoped to one user) exist.
+
+### Gap 7 — PDF export is `window.print()`
+The "Export PDF" button calls `window.print()`. This uses the browser print dialog. It works but has no server-side PDF generation, no consistent formatting across environments, no stored PDF.
+WeasyPrint is installed in the handover_export microservice — a proper PDF endpoint could be added there.
+
+---
+
+## 14. How to Test Locally
+
+### Run the API
+
+```bash
+cd /Users/celeste7/Documents/Cloud_PMS
+docker compose --profile api up --build
+# API available at http://localhost:8000
+```
+
+### Run the microservice (for LLM export)
+
+```bash
+cd /Users/celeste7/Documents/handover_export
+docker compose up --build
+# Microservice available at http://localhost:10000
+# But celeste-unified calls handover-export.onrender.com by default
+# To use local: set HANDOVER_MICROSERVICE_URL=http://host.docker.internal:10000
+```
+
+### Test credentials
+
+```
+crew:         engineer.test@alex-short.com    / Password2!
+captain:      x@alex-short.com               / Password2!
+test yacht:   85fe1119-b04c-41ac-80f1-829d23322598
+```
+
+### Verify a full add_to_handover flow
+
+```bash
+# Get token
+TOKEN=$(curl -s -X POST "https://qvzmkaamzaqxpzbewjxe.supabase.co/auth/v1/token?grant_type=password" \
+  -H "apikey: {MASTER_ANON_KEY}" \
+  -H "Content-Type: application/json" \
+  -d '{"email":"engineer.test@alex-short.com","password":"Password2!"}' \
+  | python3 -c "import sys,json; print(json.load(sys.stdin)['access_token'])")
+
+# Add a standard note
+curl -X POST "http://localhost:8000/v1/actions/execute" \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"action":"add_to_handover","context":{},"payload":{"entity_type":"note","summary":"Test note","category":"standard","section":"Engineering"}}'
+
+# Add a critical note (triggers HOD cascade)
+curl -X POST "http://localhost:8000/v1/actions/execute" \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"action":"add_to_handover","context":{},"payload":{"entity_type":"note","summary":"Critical engine alarm","category":"critical","section":"Engineering"}}'
+
+# List items
+curl "http://localhost:8000/v1/handover/items" -H "Authorization: Bearer $TOKEN"
+```
+
+### Verify DB
+
+```bash
+psql "postgresql://postgres:%40-Ei-9Pa.uENn6g@db.vzsohavtuotocgrfkfyd.supabase.co:5432/postgres?sslmode=require" \
+  -c "SELECT action, count(*) FROM pms_audit_log WHERE action LIKE '%handover%' GROUP BY action;"
+```
+
+---
+
+## 15. Role Matrix
+
+Who can see and do what on the handover page.
+
+| Action | crew | engineer / eto | chief_engineer / chief_officer | captain | manager |
+|---|---|---|---|---|---|
+| Add item to handover | ✓ | ✓ | ✓ | ✓ | ✓ |
+| View own draft items | ✓ | ✓ | ✓ | ✓ | ✓ |
+| Edit own draft items | ✓ | ✓ | ✓ | ✓ | ✓ |
+| Delete own draft items | ✓ | ✓ | ✓ | ✓ | ✓ |
+| Export (generate document) | ✓ | ✓ | ✓ | ✓ | ✓ |
+| Submit (sign outgoing) | ✓ | ✓ | ✓ | ✓ | ✓ |
+| Countersign (HOD review) | ✗ | ✗ | ✓ | ✓ | ✓ |
+| Sign incoming (acknowledge) | ✓ | ✓ | ✓ | ✓ | ✓ |
+| View any export on yacht | ✗ | ✗ | ✓ | ✓ | ✓ |
+| Receive critical cascade notification | ✗ | ✗ | ✓ | ✓ | — |
+| Receive countersign-complete notification | ✗ | ✗ | ✗ | ✓ | ✓ |
+
+**Note:** "View own draft items" means items where `added_by = user_id`. HOD+ can view all exports on their yacht via the exports list endpoint.
+
+The countersign route enforces roles in code:
+```python
+# handover_export_routes.py — countersign_export()
+if auth['role'] not in ["hod", "captain", "manager"]:
+    raise HTTPException(status_code=403, detail="Only HOD+ can countersign")
+```
+Note: The original code checked `["hod", "captain", "manager"]`. `"hod"` is not a real DB role — actual values are `chief_engineer` and `chief_officer`. This was a live bug (any chief engineer would get a 403). Fixed to `["chief_engineer", "chief_officer", "captain", "manager"]` in PR #527.
+
+---
+
+## 16. Business Rules and Enforcement
+
+These are the rules the backend enforces — not suggestions, not frontend-only. Backend validates all of these.
+
+### Ownership on mutations
+Every `PATCH /items/{id}` and `DELETE /items/{id}` requires `.eq("added_by", user_id)`. You cannot edit or delete another user's handover item, even if you are on the same yacht. The 404 you get is intentional — it reveals no information about whether the item exists at all.
+
+### Category normalisation (not validation)
+The backend accepts `critical | standard | low` (new UI values) as well as `urgent | in_progress | completed | watch | fyi` (legacy DB values). They are normalised before storage:
+```
+critical  → urgent    (+ sets is_critical=True)
+standard  → fyi
+low       → fyi
+```
+The DB `category` column stores only the legacy values. The frontend sends new UI values. Both must be kept in sync.
+
+### `handover_entries` are immutable
+The `handover_entries` table has **no DELETE RLS policy**. These are the LLM truth seeds — the original AI-processed summaries before any editing. Once written, they cannot be deleted. Do not seed test data into this table unless you can live with it permanently.
+
+### `handover_exports` state machine
+State transitions are enforced by checking `review_status` before each operation:
+```
+pending_review
+  → save-draft:   allowed (can keep editing)
+  → submit:       allowed (moves to pending_hod_signature)
+  → countersign:  REJECTED (409 — "Not awaiting countersign")
+
+pending_hod_signature
+  → save-draft:   REJECTED (400 — "Cannot edit after submission")
+  → submit:       REJECTED (400 — "Already submitted")
+  → countersign:  allowed (moves to complete)
+
+complete
+  → anything:     REJECTED (all mutation routes check status)
+```
+
+### Document hash (tamper evidence)
+After countersign, `document_hash` = SHA-256 of the rendered HTML. If the HTML is changed after signing, the hash will not match. This is not cryptographically enforced in code today (there is no re-hash-and-compare on read), but the hash is recorded permanently in `pms_audit_log` and `ledger_events` for manual verification.
+
+### Duplicate items are allowed
+The `add_to_handover` handler checks for duplicates (`entity_type + entity_id` already in handover_items) but explicitly allows them:
+```python
+# Note: We allow duplicates for now — multiple shifts may reference same entity
+```
+This means a fault can be added to handover twice. The LLM merge stage deduplicates only when `entity_id` is identical (true duplicates). Multiple rotation mentions of the same fault are treated as separate items.
+
+### Summary minimum length
+3 characters. This was changed from 10 during this session. A standalone note saying "OK" is valid. The reason for lowering: queue items auto-populated from entity names can be short.
+
+### `export_status` vs `status`
+`handover_items` has two separate columns:
+- `status`: workflow state — `pending | acknowledged | completed | deferred` (check constraint)
+- `export_status`: export tracking — `pending | exported`
+
+After mark-exported: `export_status="exported"`, `status="completed"`. Never set `status="exported"` — the check constraint will reject it.
+
+---
+
+## 17. File Change History (This Session — 2026-04-14)
+
+Files changed during the HANDOVER01 session. If you're debugging a regression, these are the files to check.
+
+| File | What changed |
+|---|---|
+| `apps/web/src/components/handover/HandoverDraftPanel.tsx` | Replaced all 6 direct supabase DB calls with Render API fetch() calls |
+| `apps/api/routes/handover_export_routes.py` | Added _get_role_users, _write_handover_event helpers; fixed _notify_hod_for_countersign; added ledger to save_draft, countersign, PATCH, DELETE, mark-exported; fixed PATCH/DELETE ownership checks; fixed mark-exported column names |
+| `apps/api/action_router/dispatchers/internal_dispatcher.py` | Fixed add_to_handover: category_map, correct column names (summary not summary_text), no added_at, added critical HOD cascade |
+| `apps/api/action_router/registry.py` | Added crew to add_to_handover allowed_roles; fixed required_fields |
+| `apps/api/handlers/handover_handlers.py` | Added category_map normalisation; added critical HOD cascade; added edit audit trail to edit_handover_item_execute |
+| `apps/api/handlers/hours_of_rest_handlers.py` | Added ledger event on signoff creation; pms_notifications crew alert |
+
+PRs: #523 (CRUD fix), #525 (ledger cascade), #526 (sync)
+
+---
+
+*This document was written after a full session working on the handover feature end-to-end. Every bug in section 11 was found in production code and fixed during this session. Every gap in section 13 was confirmed in the live codebase.*

--- a/docs/explanations/LENS_DOMAINS/hours-of-rest.md
+++ b/docs/explanations/LENS_DOMAINS/hours-of-rest.md
@@ -1,0 +1,475 @@
+# Hours of Rest — Complete Domain Reference
+
+**For any new engineer touching this feature.** Read this before opening any file.
+
+---
+
+## What this is
+
+Hours of Rest (HoR) is the compliance tracking system for Maritime Labour Convention 2006 (MLC 2006) and STCW Convention. Every seafarer must get **minimum 10 hours rest in any 24-hour period** and **77 hours rest in any 7-day period**, with no more than 2 rest periods per day, and the longest must be ≥ 6 hours.
+
+Port state inspectors can board a vessel and demand HoR records. A violation can result in port detention. The data in this system is legally significant. Corrections and dismissals carry mandatory justification. Everything is signed.
+
+This is **not** a timekeeping tool for payroll. It is a compliance evidence trail.
+
+---
+
+## Role matrix — who sees what
+
+| Role | Tab: My Time | Tab: Department | Tab: All Departments | Tab: Fleet |
+|---|---|---|---|---|
+| `crew` / `engineer` / most deck ratings | ✓ | — | — | — |
+| `chief_engineer` / `chief_officer` / `eto` (HOD) | ✓ | ✓ | — | — |
+| `captain` | ✓ | ✓ | ✓ | — |
+| `manager` (fleet) | ✓ | — | ✓ | ✓ |
+
+**Important:** The role check in `page.tsx` uses local functions `isHODRole()`, `isCaptainRole()`, `isFleetManagerRole()` — do NOT use the global `AuthContext.isHOD` which is too broad for HoR. The local functions are the single source of truth for tab visibility.
+
+`chief_steward`, `purser` — can counter-sign at HOD level but do NOT get the Department tab (not in `isHODRole()`). This is intentional: they sign in the backend but don't manage a crew grid.
+
+---
+
+## File map — every file you need to know
+
+### Frontend
+
+```
+apps/web/src/app/hours-of-rest/page.tsx          ← Entry point. Tab routing. Role guards.
+apps/web/src/app/hours-of-rest/[id]/page.tsx     ← Individual record detail (thin, rarely used)
+apps/web/src/app/hours-of-rest/signoffs/page.tsx ← Signoff list page
+apps/web/src/app/hours-of-rest/signoffs/[id]/page.tsx ← Signoff detail
+
+apps/web/src/components/hours-of-rest/
+  MyTimeView.tsx          ← Crew's own week grid + slider + submit + signoff card
+  TimeSlider.tsx          ← 24h work-period input widget (exported standalone)
+  DepartmentView.tsx      ← HOD grid: all crew × 7 days + counter-sign queue
+  VesselComplianceView.tsx ← Captain: dept cards + sign chain + all-crew grid
+  FleetView.tsx           ← Fleet manager: per-vessel compliance summary
+
+apps/web/src/app/api/v1/hours-of-rest/[...path]/route.ts  ← Next.js catch-all proxy
+```
+
+### Backend
+
+```
+apps/api/routes/hours_of_rest_routes.py         ← FastAPI router. 19 endpoints. Request models.
+apps/api/routes/hor_compliance_routes.py        ← 4 enriched GET endpoints (my-week, dept, vessel, fleet)
+apps/api/handlers/hours_of_rest_handlers.py     ← All business logic. ~2430 lines. Single class.
+apps/api/routes/handlers/hours_of_rest_handler.py  ← Thin Phase 4 adapter (delegates to the class above)
+```
+
+### Tests
+
+```
+scripts/hor-integration-test/
+  run.py              ← Runner. 9 scenarios in dependency order.
+  auth.py             ← Real JWT auth for 4 test roles
+  state.py            ← Shared constants (TEST_WEEK_MONDAY = "2025-01-06", yacht_id)
+  teardown.py         ← Deletes all test data after run
+  scenarios/
+    s1_crew_submit.py          ← S1: crew submits a valid day
+    s2_hod_submit.py           ← S2: HOD submits their own day
+    s3_captain_submit.py       ← S3: captain submits their own day
+    s4_hod_countersign.py      ← S4: HOD counter-signs crew's signoff
+    s5_captain_sign_all.py     ← S5: captain gives master signature (requires S4)
+    s6_fleet_inspect.py        ← S6: fleet manager reads compliance (requires S5)
+    s7_violation_notification.py ← S7: submit violation, check HOD notification (requires S1)
+    s8_crew_undo.py            ← S8: crew undoes a submitted day (runs AFTER S9)
+    s9_correction_flow.py      ← S9: HOD adds correction to crew record (runs BEFORE S8)
+
+scripts/hor-proof/
+  hor-proof.spec.ts     ← Playwright screenshots for CEO review (3 roles × 7 proof screenshots)
+  playwright.config.ts  ← Config. Set PROOF_DIR env var for output location.
+```
+
+---
+
+## How a request travels
+
+```
+Browser
+  └─ fetch('/api/v1/hours-of-rest/...', { headers: { Authorization: 'Bearer JWT' } })
+       │
+       └─ Next.js route: apps/web/src/app/api/v1/hours-of-rest/[...path]/route.ts
+            │  (catch-all proxy — forwards all GET/POST verbatim)
+            │  RENDER_API_URL = process.env.NEXT_PUBLIC_API_URL
+            │
+            └─ Render API: apps/api/routes/hours_of_rest_routes.py (or hor_compliance_routes.py)
+                 │  router prefix: /v1/hours-of-rest
+                 │  get_authenticated_user() → validates JWT, extracts user_id, yacht_id, role, tenant_key_alias
+                 │  resolve_yacht_id(auth, yacht_id) → fleet-aware isolation check
+                 │
+                 └─ HoursOfRestHandlers (apps/api/handlers/hours_of_rest_handlers.py)
+                      │  Instantiated with get_tenant_client(tenant_key_alias)
+                      │  Returns ResponseBuilder / JSONResponse
+                      │
+                      └─ Supabase TENANT DB (vzsohavtuotocgrfkfyd)
+                           └─ Tables: pms_hours_of_rest, pms_hor_monthly_signoffs,
+                                      pms_crew_hours_warnings, pms_crew_normal_hours,
+                                      dash_crew_hours_compliance (view), pms_audit_log,
+                                      ledger_events, pms_notifications
+```
+
+**Two routers, same prefix.** Both `hours_of_rest_routes.py` and `hor_compliance_routes.py` use `prefix="/v1/hours-of-rest"`. They are registered separately in `main.py`. The compliance routes (`/my-week`, `/department-status`, `/vessel-compliance`, `/fleet-compliance`) are pure GET endpoints that do **not** use `HoursOfRestHandlers` — they query Supabase directly.
+
+---
+
+## The key design decision: crew inputs WORK, backend derives REST
+
+**This is the single most confusing thing about this domain. Read it twice.**
+
+The `TimeSlider` component draws **work blocks** (amber). Crew mark when they are working. The backend receives `work_periods` and computes `rest_periods` as the mathematical complement of 24 hours.
+
+```
+work_periods = [{"start": "06:00", "end": "14:00"}, {"start": "18:00", "end": "22:00"}]
+→ rest_periods = [{"start": "00:00", "end": "06:00"}, {"start": "14:00", "end": "18:00"}, {"start": "22:00", "end": "24:00"}]
+→ total_work_hours = 12.0
+→ total_rest_hours = 12.0
+```
+
+This inversion happened in April 2026. Prior to that, the system stored rest periods directly. The `UpdateHoursRequest` model still accepts `rest_periods` as a deprecated alias but ignores it. Do not pass `rest_periods` from new code.
+
+`TimeSlider.tsx` exports `invertToRestPeriods(workPeriods)` if you ever need the frontend to compute rest periods for display (e.g. for read-only submitted days).
+
+---
+
+## Database tables
+
+| Table | Purpose |
+|---|---|
+| `pms_hours_of_rest` | One row per (yacht_id, user_id, record_date). The primary daily record. Unique constraint: `uq_pms_hor_primary_record` on (yacht_id, user_id, record_date). |
+| `pms_hor_monthly_signoffs` | Sign-off workflow. One row per sign cycle. Holds crew/HOD/master signatures. Used for both monthly AND weekly periods (`period_type` column). |
+| `pms_crew_hours_warnings` | Compliance violations generated by `check_hor_violations` RPC. Status: active / acknowledged / dismissed. |
+| `pms_crew_normal_hours` | Schedule templates (4-on/8-off, etc). One row per template per yacht. |
+| `dash_crew_hours_compliance` | Materialised/computed view. Weekly summary per (yacht_id, user_id, week_start). Do NOT write to this. It is a read-only aggregation used by `/my-week` and `/department-status`. |
+| `pms_audit_log` | Immutable per-action trail. Written by `_write_hor_audit_log()` in handlers. `signature` is NEVER NULL — use `{}` for unsigned actions. |
+| `ledger_events` | Evidence bus. Written via `build_ledger_event()` from `routes/handlers/ledger_utils.py`. Every mutating HoR action writes here. |
+| `pms_notifications` | Notification bus. Written on violations, sign chain events, corrections. `idempotency_key` column prevents duplicates. |
+
+---
+
+## The 19 endpoints
+
+### Compliance endpoints (hor_compliance_routes.py) — READ ONLY
+
+| Endpoint | Who calls it | Frontend consumer |
+|---|---|---|
+| `GET /v1/hours-of-rest/my-week` | All roles | `MyTimeView.tsx` |
+| `GET /v1/hours-of-rest/department-status` | HOD+ only (403 otherwise) | `DepartmentView.tsx` |
+| `GET /v1/hours-of-rest/vessel-compliance` | captain/manager only | `VesselComplianceView.tsx` |
+| `GET /v1/hours-of-rest/fleet-compliance` | manager only | `FleetView.tsx` |
+
+These four endpoints return **enriched, composed responses** — they JOIN multiple tables in a single request and return a single shaped JSON object. They are NOT generic CRUD. The shape they return is documented in the interface types at the top of each frontend component.
+
+### Mutation endpoints (hours_of_rest_routes.py) — HoursOfRestHandlers
+
+| Endpoint | Action | Notes |
+|---|---|---|
+| `POST /v1/hours-of-rest/upsert` | `upsert_hours_of_rest` | Creates or updates daily record. Checks week/month lock first. Calls `check_hor_violations` RPC. |
+| `POST /v1/hours-of-rest/undo` | `undo_hours_of_rest` | Clears a submitted day. Only works if week is not finalized. Resets `work_periods` to `[]`. |
+| `POST /v1/hours-of-rest/corrections` | `create_hor_correction` | Creates a correction record linked to original. `reason` is mandatory (legal field). |
+| `POST /v1/hours-of-rest/request-correction` | `request_hor_correction` | HOD/captain sends kick-back to crew requesting a correction. |
+| `POST /v1/hours-of-rest/signoffs/create` | `create_monthly_signoff` | Opens a sign-off period. HOD can open one for a crew member (`target_user_id`). |
+| `POST /v1/hours-of-rest/signoffs/sign` | `sign_monthly_signoff` | Adds crew/hod/master signature. Enforces sequential workflow. |
+| `POST /v1/hours-of-rest/templates/create` | `create_crew_template` | Creates a named schedule template. |
+| `POST /v1/hours-of-rest/templates/apply` | `apply_crew_template` | Applies template to a week (bulk-creates daily records). |
+| `POST /v1/hours-of-rest/warnings/acknowledge` | `acknowledge_warning` | Crew acknowledges a violation. Notifies HODs. |
+| `POST /v1/hours-of-rest/warnings/dismiss` | `dismiss_warning` | HOD/captain dismisses a warning. `hod_justification` is mandatory (legally significant). |
+| `GET /v1/hours-of-rest/notifications/unread` | — | Unread count badge on Department tab. |
+| `POST /v1/hours-of-rest/notifications/mark-read` | — | Marks notifications read. |
+
+### Read endpoints (hours_of_rest_routes.py) — HoursOfRestHandlers
+
+| Endpoint | Action |
+|---|---|
+| `GET /v1/hours-of-rest` | `get_hours_of_rest` — basic date-range query, used by Phase 4 action router |
+| `POST /v1/hours-of-rest/export` | Export to JSON/PDF/CSV |
+| `GET /v1/hours-of-rest/signoffs` | `list_monthly_signoffs` |
+| `GET /v1/hours-of-rest/signoffs/details` | `get_monthly_signoff` |
+| `GET /v1/hours-of-rest/templates` | `list_crew_templates` |
+| `GET /v1/hours-of-rest/warnings` | `list_crew_warnings` |
+| `GET /v1/hours-of-rest/sign-chain` | `get_hor_sign_chain` — fleet manager view |
+
+---
+
+## The sign chain — exactly how it works
+
+MLC 2006 requires a three-tier weekly attestation: **crew → HOD → Master (captain)**. This is enforced as a state machine in `sign_monthly_signoff`.
+
+```
+draft
+  └─(crew signs)→ crew_signed
+       └─(HOD signs)→ hod_signed
+            └─(master signs)→ finalized
+```
+
+**Rules enforced in code:**
+
+1. HOD can only sign from `crew_signed`. Attempting from any other status → 400.
+2. Master can only sign from `hod_signed` (normal path) OR from `crew_signed` if no designated HOD exists for the department (bypass path — notifies all vessel HODs).
+3. **The same person cannot sign at both HOD and master level on the same signoff.** `hod_signed_by == user_id` check at master signature → 403. This is an MLC requirement for independent verification.
+4. `_DEPT_HOD_ROLES = ["chief_engineer", "chief_officer", "chief_steward", "eto", "purser"]` — these are the roles that qualify as a "designated HOD" for the bypass check. captain/manager are excluded intentionally.
+
+**Known gap:** A single captain with no HOD on the vessel can currently sign all three levels (crew, hod, master) on their own signoff because the HOD role check queries `auth_users_roles` for dept-specific HODs, not the signing user themselves. This requires a CEO decision before fixing.
+
+---
+
+## MLC 2006 compliance logic
+
+Located in `upsert_hours_of_rest` (handlers, line ~327):
+
+```python
+is_daily_compliant = total_rest_hours >= 10      # ≥10h rest per 24h
+
+has_valid_rest_periods = (
+    rest_period_count <= 2 and                    # ≤2 rest periods
+    longest_rest_period >= 6                      # longest ≥6h
+)
+
+record_is_compliant = is_daily_compliant and has_valid_rest_periods
+```
+
+After upsert, the Supabase RPC `check_hor_violations` is called with the new record ID. It creates rows in `pms_crew_hours_warnings`. If the record is a violation, a notification is sent to the crew member's HOD (found via `auth_users_roles` by department).
+
+**Weekly rule (77h)** is tracked in `dash_crew_hours_compliance.is_weekly_compliant`. This is a computed column/view — the backend does not compute it directly during upsert.
+
+---
+
+## Lock / immutability system
+
+Once a week is signed off, the daily records for that week are locked. `upsert_hours_of_rest` checks this before writing:
+
+1. If a **weekly** `pms_hor_monthly_signoffs` row with `status IN ("finalized", "locked")` exists for this user/week → reject with `LOCKED` error.
+2. If a **monthly** signoff with `status IN ("finalized", "locked", "captain_signed")` exists for this user/month → reject with `LOCKED` error.
+
+To modify a locked record, a correction must be raised. Corrections create a new linked row in `pms_hours_of_rest` (or a note-only row) and are permanently preserved alongside the original.
+
+---
+
+## Notification hierarchy
+
+Every significant action notifies the appropriate rank level. All notifications are **non-fatal** (try/except, failure never blocks the action).
+
+| Action | Who is notified |
+|---|---|
+| Violation submitted (upsert) | HOD of crew's department |
+| Warning acknowledged | All HOD/captain/manager in crew's department |
+| Warning dismissed | The crew member whose warning was dismissed |
+| Monthly signoff opened by HOD | The crew member (target_user_id) |
+| Weekly signoff signed (crew) | → cascades to HOD on counter-sign queue |
+| Undo submitted day | HOD/captain/manager (weekly tally changed) |
+| Correction note added by HOD/captain | The crew member whose record was corrected |
+| HOD step bypassed (no dept HOD) | All vessel HODs notified |
+
+Notifications use `idempotency_key` on `(yacht_id, user_id, idempotency_key)` to prevent duplicates on retry.
+
+---
+
+## Audit and ledger coverage (as of 2026-04-14)
+
+Every mutating action writes to **both** `pms_audit_log` and `ledger_events`. This is the evidence trail for MLC inspections.
+
+`pms_audit_log` — written by `_write_hor_audit_log()`:
+- `upsert_hours_of_rest` (action: `upsert_hours_of_rest:created` or `upsert_hours_of_rest:updated`)
+- `sign_monthly_signoff` (action: `sign_monthly_signoff:{level}`)
+- `undo_hours_of_rest` (action: `undo_hours_of_rest`, old_values includes prior work_periods)
+- `create_hor_correction` (action: `create_hor_correction`)
+
+`ledger_events` — written via `build_ledger_event()`:
+- `upsert_hours_of_rest` (event_type: create/update)
+- `sign_monthly_signoff` (event_type: approval)
+- `create_monthly_signoff` (event_type: create)
+- `create_crew_template` (event_type: create)
+- `apply_crew_template` (event_type: update)
+- `acknowledge_warning` (event_type: status_change)
+- `dismiss_warning` (event_type: status_change — includes hod_justification in metadata)
+
+`pms_audit_log` invariant: `signature` column is **NEVER NULL**. Use `{}` for unsigned actions. This is enforced in `_write_hor_audit_log`.
+
+---
+
+## The TimeSlider widget
+
+**File:** `apps/web/src/components/hours-of-rest/TimeSlider.tsx`
+
+Standalone 24-hour work-period input. Can be used independently of the HoR domain.
+
+```typescript
+<TimeSlider
+  value={workPeriods}           // existing work periods from saved data
+  onChange={(periods) => ...}   // called on every change, emits work_periods
+  readOnly={day.submitted}      // true = display only, no interaction
+/>
+```
+
+Interaction model:
+- **Click empty track** → creates new 1-hour work block
+- **Drag left/right handle** → resize block (snaps to 15-minute increments)
+- **Drag block body** → move block
+- **× button** → remove block
+
+Internal state uses minutes (0–1440). Exported periods use `"HH:MM"` strings.
+
+`invertToRestPeriods(workPeriods: RestPeriod[]): RestPeriod[]` — exported utility. Converts work blocks to rest gaps. Empty work array returns `[{start: "00:00", end: "24:00"}]` (full rest day, valid MLC).
+
+The `readOnly` prop hides all drag handles and the × button. The submitted day track is shown in a dimmed style.
+
+---
+
+## Response normalization — the gap between API and component
+
+The API responses are not perfectly shaped for the frontend. Each view component has a `normalize*` function that translates API output to component-expected types.
+
+**`MyTimeView.tsx` — `normalizeMyWeekResponse(json)`:**
+- `record_date` → `date` (backend field name mismatch)
+- Adds `label` (Mon/Tue/..) computed from week_start index
+- Maps `is_daily_compliant` → `is_compliant`
+- `compliance` object is flat from backend — `mlc_status`, `min_24h`, `min_7d`, `violations_this_month`, `rolling_7d_work` are not always present. The normalizer fills them with defaults.
+- `prior_weeks` may be absent (backend feature not fully implemented). Normalizer returns `[]`.
+
+**`DepartmentView.tsx` — normalizer in component body:**
+- `submitted_count` from backend → maps to `today_submitted`
+- `total_crew` from backend → maps to `today_total`
+- Crew names for pending counter-signs are looked up from `crew[]` array by `user_id`, not from `crew_names[]` (which doesn't exist)
+- `days[].submitted` is a bool from backend — not `days[].status`. Normalizer maps `submitted: true → status: 'submitted'`
+- Compliance summary (`compliant_days`, `total_days`, `violations`, `avg_rest_hours`) are computed from `crew[]` aggregates, not from a `compliance` sub-object
+
+**`VesselComplianceView.tsx` — normalizer in component body:**
+- `compliance_pct` per dept: computed as `compliant_count / total_crew * 100`
+- `violations` per dept: mapped from `pending_warnings`
+- Crew filter uses `d.department` (correct backend field), not `d.name`
+
+**`FleetView.tsx` — `normalizeFleetCompliance(json, fallbackVessels)`:**
+- `yacht_name` falls back to `user.fleet_vessels` lookup if backend omits it
+- `error: "unavailable"` → maps to `error: true` on the vessel summary
+
+---
+
+## `MyTimeView` is still on mock data
+
+As of 2026-04-14, `MyTimeView.tsx` has a `MOCK_MY_WEEK` constant at the top of the file. This is used as fallback when the API call fails, but the component does wire to the real API (`/api/v1/hours-of-rest/my-week`). The mock is there for development without a running API.
+
+When the API returns successfully, the real data is normalised via `normalizeMyWeekResponse`. If you see a static week showing Apr 7–13 2026, you're seeing the mock.
+
+---
+
+## Handler cache — singleton per tenant
+
+`hours_of_rest_routes.py` caches handler instances:
+
+```python
+_hor_handlers_cache = {}
+
+def get_hor_handlers(tenant_key_alias: str):
+    if tenant_key_alias not in _hor_handlers_cache:
+        ...
+    return _hor_handlers_cache[tenant_key_alias]
+```
+
+This is a module-level dict. In a multi-worker Uvicorn deployment, each worker has its own cache. In practice, the first request per worker per tenant initialises the handler. This is not a problem but worth knowing if you're debugging "first request slow" issues.
+
+---
+
+## Things I wish I knew at the start
+
+**1. Two separate route files, same URL prefix.**
+`hours_of_rest_routes.py` AND `hor_compliance_routes.py` both use `prefix="/v1/hours-of-rest"`. They are registered separately in `main.py`. The compliance routes are purely GET and hit Supabase directly. The main routes delegate to `HoursOfRestHandlers`. If an endpoint returns an unexpected response shape, check which file it's actually in.
+
+**2. `maybe_single()` throws on 0 rows in supabase-py 2.12.0.**
+This burned the team multiple times. `result.maybe_single().execute()` raises `APIError(204)` if the query returns 0 rows. Always use `.limit(1).execute()` and check `result.data[0] if result.data else None`. This pattern is now consistently used throughout the HoR handlers. If you see a 500 on a record lookup and the record doesn't exist, this is the bug.
+
+**3. `work_periods` → `rest_periods` inversion.**
+Crew inputs work. Backend derives rest. The `rest_periods` field on the request model is ignored. Many assumptions in early code assumed rest was the input. The TimeSlider widget draws work blocks (amber), not rest gaps. `invertToRestPeriods()` exists but is only needed for display of existing records.
+
+**4. `pms_hor_monthly_signoffs` is used for BOTH weekly and monthly sign-offs.**
+The `period_type` column (`weekly` | `monthly`) distinguishes them. The frontend primarily uses weekly signoffs for the lock signal. Monthly signoffs are the formal compliance document. Both flow through the same sign chain (crew → hod → master).
+
+**5. `yacht_id` on request bodies is deprecated.**
+All mutation request models have `yacht_id` marked `DEPRECATED`. The yacht_id now comes from the JWT auth context, extracted in the route handler. If you send `yacht_id` in the request body it is ignored (not an error). This was a security fix to prevent cross-vessel writes.
+
+**6. The lock check is FATAL on failure.**
+In `upsert_hours_of_rest`, the weekly/monthly lock check failure returns a `DATABASE_ERROR`, not a silent pass. This was a deliberate choice: it is better to block a submission than to allow an unchecked write to a potentially locked week. If you see `"Lock check failed"` errors, investigate the DB connection, not the lock logic.
+
+**7. `dash_crew_hours_compliance` is a view, not a table.**
+Multiple endpoints read from it to get weekly summaries. Do not INSERT or UPDATE it. It aggregates from `pms_hours_of_rest`. If a crew member's weekly summary looks wrong, check the underlying `pms_hours_of_rest` rows.
+
+**8. The RPC `check_hor_violations` is a DB-side function.**
+After every upsert, the backend calls `supabase.rpc("check_hor_violations", {"p_hor_id": record_id})`. This function lives in the Supabase DB (TENANT project). It checks the inserted record against MLC rules and inserts rows into `pms_crew_hours_warnings`. If violations are not being created, check the RPC exists and is working in the tenant DB.
+
+**9. HOD counter-sign queue badge.**
+The red badge on the "Department" tab comes from `useHoRUnreadCount()` — a 60-second polling hook that calls `GET /v1/hours-of-rest/notifications/unread`. It only runs if `showDept` is true (i.e., HOD role or above). The count reflects `pms_notifications` unread count, not the pending counter-sign queue directly.
+
+**10. Integration tests use a fixed past date.**
+`TEST_WEEK_MONDAY = "2025-01-06"` in `scripts/hor-integration-test/state.py`. This date was chosen as a clean past date with no production data. Do not change it — all 9 scenarios chain their data from this week. The test yacht_id is `85fe1119-b04c-41ac-80f1-829d23322598`.
+
+---
+
+## Common bugs and how to diagnose them
+
+| Symptom | Likely cause | Where to look |
+|---|---|---|
+| 500 on record fetch | `maybe_single()` on 0 rows | Check if the record exists; look for `.maybe_single()` in the handler |
+| Week shows mock data always | API call failing, component falling back | Check browser Network tab for the `/my-week` call |
+| "LOCKED" on upsert | Weekly or monthly signoff is finalized | Query `pms_hor_monthly_signoffs` for this user/week |
+| Violation not creating warning | `check_hor_violations` RPC issue | Test the RPC directly in Supabase SQL editor |
+| Department tab not showing for HOD | Role check in `page.tsx` | `isHODRole()` covers `chief_engineer`, `chief_officer`, `eto` only |
+| Counter-sign fails "not yet signed" | Wrong status in `pms_hor_monthly_signoffs` | Check `status` column — HOD can only sign from `crew_signed` |
+| HOD and master same person | MLC enforcement | This is intentional — system blocks it with 403 |
+| Notifications not arriving | `pms_notifications` idempotency | Check if an identical `idempotency_key` row already exists |
+| Compliance summary all zeros | Normalizer not mapping backend fields | Check `normalizeMyWeekResponse` — `mlc_status` may be absent from API |
+
+---
+
+## Interaction with other domains
+
+**Ledger domain** — `ledger_events` table. Every HoR mutation writes a ledger event via `build_ledger_event()` from `routes/handlers/ledger_utils.py`. The ledger panel on entity views reads these events to show HoR activity.
+
+**Notification domain** — `pms_notifications` table. HODs, captains, and crew receive notifications for violations, sign chain events, corrections. The notification centre reads `pms_notifications`. HoR is the heaviest writer.
+
+**Auth domain** — `auth_users_roles` table. Role and department data for every user. The HOD lookup for violation notifications queries this table. The counter-sign role enforcement queries this table. Errors here cascade to HoR silently (try/except guards notifications).
+
+**Audit/Compliance domain** — `pms_audit_log` table. Every mutation writes here. Port state inspectors may request these records. The `signature` column must never be NULL.
+
+**Fleet domain** — `auth_users_roles.vessel_ids` array. Fleet managers manage multiple vessels. `resolve_yacht_id(auth, yacht_id)` validates the requested yacht_id against the user's `vessel_ids`. The `FleetView` iterates `user.fleet_vessels` from the auth context.
+
+---
+
+## Running the integration tests
+
+```bash
+# Requires real API and real DB credentials
+export SUPABASE_URL=https://vzsohavtuotocgrfkfyd.supabase.co
+export SUPABASE_SERVICE_KEY=...
+export HOR_TEST_API_BASE=http://localhost:8000  # or Render URL
+
+cd scripts/hor-integration-test
+python3 run.py
+```
+
+Expected: `9/9 scenarios passed · 92/92 checks passed`
+
+Teardown runs automatically after every run and deletes all test data for `week_start = 2025-01-06` on yacht `85fe1119`.
+
+---
+
+## Running the Playwright proof screenshots
+
+```bash
+export SUPABASE_JWT_SECRET=...
+export PROOF_DIR=/tmp/hor-proof  # defaults to ~/hor-proof
+
+cd scripts/hor-proof
+npx playwright test --config playwright.config.ts
+```
+
+Produces 7–10 screenshots showing each role's view. Used for CEO review and compliance documentation. The spec mints real JWTs and injects them as Supabase localStorage session state.
+
+---
+
+## What is NOT implemented
+
+- **`prior_weeks` in MyTimeView** — the backend doesn't return historical week summaries. The component has a stub UI for it. Returns empty array.
+- **Monthly signoff sign-off flow in the frontend** — the signoff cards are present but the full monthly sign-off workflow (multi-month view, bulk signing) is not wired in the frontend. The backend supports it fully.
+- **Correction flow in the frontend** — `create_hor_correction` and `request_hor_correction` are implemented in the backend and tested in S9. The frontend shows a "correction requested" banner but doesn't yet wire the full correction submission UI.
+- **PDF export** — `export_hours_of_rest` with `format: "pdf"` is an endpoint but the PDF rendering is not fully implemented.
+- **The single-person sign-chain gap** — a captain with no designated HOD can technically sign all three levels on their own signoff. Awaiting CEO decision on how to enforce this.

--- a/docs/explanations/LENS_DOMAINS/warranty.md
+++ b/docs/explanations/LENS_DOMAINS/warranty.md
@@ -1,0 +1,543 @@
+# Warranty Lens — Complete Developer Guide
+
+> **Who this is for:** Any developer picking up warranty for the first time — frontend, backend, or full-stack.  
+> **Scope:** Everything from the database row to the rendered UI. Bugs found, traps hit, techniques used.  
+> **Verified against:** commit `6b7278c0` on `main`, April 2026.
+
+---
+
+## 1. What the warranty domain does
+
+A warranty claim is a formal record that a piece of equipment is defective, damaged, or failed within its warranty period, and the vessel is seeking repair, replacement, or reimbursement from the manufacturer or vendor.
+
+The lifecycle is:
+
+```
+crew/officer drafts claim
+       ↓
+HOD (Head of Department) submits for approval
+       ↓
+Captain or Manager approves OR rejects
+       ↓ (if approved)
+Captain or Manager closes the claim
+```
+
+Every state change is logged. Every read is logged. Every stakeholder is notified. Nothing is silent.
+
+---
+
+## 2. File map — exact paths
+
+### Frontend
+
+| File | Purpose |
+|---|---|
+| `apps/web/src/components/lens-v2/entity/WarrantyContent.tsx` | The entire detail view — all sections, all action buttons |
+| `apps/web/src/components/lens-v2/actions/AttachmentUploadModal.tsx` | Generic file upload modal (reusable, not warranty-specific) |
+| `apps/web/src/components/lens-v2/sections/AttachmentsSection.tsx` | Renders attachment rows — image or document thumbnail |
+| `apps/web/src/lib/normalizeWarranty.ts` | Defensive field normalisation between API response and component |
+| `apps/web/src/hooks/useEntityLens.ts` | Data fetch, action execution, refetch — shared by all entity lenses |
+| `apps/web/src/contexts/EntityLensContext.tsx` | React context that glues the hook to WarrantyContent |
+| `apps/web/src/app/warranties/page.tsx` | List page — renders all claims, "File New Claim" button |
+| `apps/web/src/app/warranties/[id]/page.tsx` | Detail page — thin wrapper, delegates to EntityLensPage |
+| `apps/web/e2e/shard-31-fragmented-routes/route-warranties.spec.ts` | Playwright e2e — 19 tests covering list, CRUD, state transitions |
+
+### Backend
+
+| File | Purpose |
+|---|---|
+| `apps/api/routes/entity_routes.py` | `GET /v1/entity/warranty/{id}` — serves the full detail payload |
+| `apps/api/action_router/dispatchers/internal_dispatcher.py` | All 7 warranty handler implementations |
+| `apps/api/action_router/registry.py` | ActionDefinition entries — RBAC, required_fields, field_metadata |
+| `apps/api/action_router/ledger_metadata.py` | Maps action → event_type for the safety net ledger write |
+| `apps/api/routes/handlers/internal_adapter.py` | Phase 4 bridge — see Section 7 |
+| `apps/api/routes/p0_actions_routes.py` | `POST /v1/actions/execute` — the single execute endpoint |
+| `apps/api/handlers/universal_handlers.py` | `soft_delete_entity()` — handles archive and void |
+
+---
+
+## 3. The state machine
+
+### States
+
+| State | What it means |
+|---|---|
+| `draft` | Being written. Not submitted. Crew can still edit. |
+| `submitted` | Sent to captain/manager for decision. Locked from edits. |
+| `approved` | Approved. Awaiting closure (payment received, repair done). |
+| `rejected` | Sent back. Drafter can revise and resubmit. |
+| `closed` | Done. Final state. |
+| `archived` | Soft-deleted. Removed from active view. `deleted_at` is set. |
+
+### Transitions
+
+```
+draft ──submit──→ submitted ──approve──→ approved ──close──→ closed
+                       │
+                    reject
+                       │
+                       ↓
+                   rejected ──submit──→ submitted (loop)
+
+draft ──archive──→ archived (at any point)
+```
+
+### Who can do what (RBAC)
+
+| Action | Roles |
+|---|---|
+| `draft_warranty_claim` | crew, chief_engineer, chief_officer, captain |
+| `file_warranty_claim` | chief_engineer, chief_officer, captain, manager |
+| `submit_warranty_claim` | chief_engineer, chief_officer, captain |
+| `approve_warranty_claim` | captain, manager |
+| `reject_warranty_claim` | captain, manager |
+| `close_warranty_claim` | captain, manager |
+| `add_warranty_note` | chief_engineer, chief_officer, captain, manager |
+| `compose_warranty_email` | chief_engineer, chief_officer, captain, manager |
+| `archive_warranty` | chief_engineer, chief_officer, captain, manager |
+| `void_warranty` | chief_engineer, chief_officer, captain, manager |
+
+The role check happens **before** the payload reaches the handler. Enforced in `p0_actions_routes.py` — role not in `allowed_roles` → `403` before any DB touch.
+
+---
+
+## 4. Data flow — end to end
+
+### Reading a warranty
+
+```
+Browser
+  → GET /v1/entity/warranty/{id}   (entity_routes.py line 446)
+  → auth middleware validates JWT
+  → resolve_yacht_id() enforces tenant scope
+  → query v_warranty_enriched view  (enriched with equipment name, days_until_expiry, status_label)
+  → _get_attachments()  generates signed URLs (1h TTL) from pms_attachments
+  → query pms_notes WHERE warranty_id = {id}
+  → query pms_audit_log WHERE entity_type='warranty' AND entity_id={id}
+  → fire-and-forget: write view event to ledger_events
+  → get_available_actions()  resolves which action buttons to show based on status + user role
+  → return full JSON response
+```
+
+The component (`WarrantyContent.tsx`) never fetches directly. It reads from `useEntityLensContext()`, which is fed by `useEntityLens.ts`, which called the endpoint above.
+
+### Executing an action
+
+```
+Button click in WarrantyContent.tsx
+  → executeAction(actionId, payload)  from context
+  → POST /v1/actions/execute  (p0_actions_routes.py)
+  → role check against registry
+  → required_fields validation
+  → context resolution: entity_id → warranty_id
+  → INTERNAL_HANDLERS[actionId](params)  via internal_adapter.py
+  → handler: update pms_warranty_claims
+  → handler: insert pms_audit_log
+  → handler: insert pms_notifications (per recipient)
+  → safety net: write ledger_events if handler didn't set _ledger_written=True
+  → return {status: "success", ...}
+  → WarrantyContent calls refetch()
+  → fresh GET re-renders the lens
+```
+
+---
+
+## 5. Database tables
+
+### `pms_warranty_claims`
+
+The primary table. One row per warranty claim.
+
+Key columns:
+
+```sql
+id                UUID        primary key
+yacht_id          UUID        tenant isolation — every query must include this
+claim_number      varchar     auto-generated: WC-YYYY-NNN
+title             text        human name for the claim
+status            enum        draft | submitted | approved | rejected | closed | archived
+claim_type        enum        repair | replacement | refund | manufacturer_defect |
+                              premature_failure | incorrect_part | damage_in_transit | other
+vendor_name       varchar
+manufacturer      varchar
+part_number       varchar
+serial_number     varchar
+purchase_date     date
+warranty_expiry   date        when the warranty period ends (NOT when the claim expires)
+claimed_amount    numeric
+approved_amount   numeric     set by approver, may differ from claimed
+currency          varchar     default USD
+equipment_id      UUID FK     optional — which piece of equipment is defective
+fault_id          UUID FK     optional — fault that triggered this claim
+work_order_id     UUID FK     optional — related work order
+drafted_by        UUID        who created the claim
+drafted_at        timestamp
+submitted_by      UUID
+submitted_at      timestamp
+approved_by       UUID
+approved_at       timestamp
+rejected_by       UUID
+rejected_at       timestamp
+rejection_reason  text
+email_draft       jsonb       {subject, to, body, composed_at, composed_by}
+deleted_at        timestamp   null = active, set = soft-deleted
+```
+
+### `v_warranty_enriched`
+
+A Postgres VIEW that joins `pms_warranty_claims` with `pms_equipment` and adds computed fields:
+
+- `equipment_name`, `equipment_code` — from the equipment join
+- `days_until_expiry` — integer, computed from `warranty_expiry - NOW()`
+- `status_label` — human-readable string ("Draft", "Submitted", etc.)
+- `workflow_stage` — integer (0=draft, 1=submitted, 2=approved/rejected, 3=closed)
+
+**Always query this view for the detail endpoint** — never query `pms_warranty_claims` directly in entity_routes. The view is used at `entity_routes.py line 453`.
+
+### `pms_notes` (warranty FK added)
+
+Notes belong to a single parent entity via a nullable FK column. Warranty's column:
+
+```sql
+warranty_id   UUID FK   references pms_warranty_claims(id)
+```
+
+**Important:** This column was added via migration in April 2026. If you see a warranty with no notes despite notes existing, check that `warranty_id` is populated correctly in the insert. The generic `add_note()` handler in the dispatcher maps `warranty_id` from params.
+
+### `pms_attachments`
+
+One row per uploaded file, regardless of entity type:
+
+```sql
+entity_type     varchar   "warranty"
+entity_id       UUID      warranty_id
+storage_bucket  varchar   "pms-warranty-documents"
+storage_path    varchar   "warranty/{id}/{timestamp}-{filename}"
+filename        varchar   original filename (unsanitized)
+mime_type       varchar
+file_size       integer   bytes
+category        varchar   "claim_document"
+uploaded_by     UUID
+```
+
+### `pms_audit_log`
+
+Direct state-change audit. Written by individual handlers (submit/approve/reject/close). **Not** the same as `ledger_events`.
+
+```sql
+entity_type   "warranty"
+entity_id     warranty_id
+action        "submitted" | "approved" | "rejected" | "closed"
+user_id       who did it
+new_values    {"status": "submitted"}
+```
+
+### `ledger_events`
+
+Immutable append-only global event log. Written two ways:
+
+1. **Direct by handlers** via `_ledger_read()` pattern (certificate style)
+2. **Safety net** via `p0_actions_routes.py` after every executed action
+3. **View events** via `entity_routes.py` — fires on every GET
+
+For warranty view events (entity_routes.py line 467):
+
+```python
+get_supabase_client().table("ledger_events").insert({
+    "event_type": "view",
+    "entity_type": "warranty",
+    "action": "view_warranty_claim",
+    "source_context": "microaction",   # MUST be one of: microaction|search|read_beacon|bulk|system
+    "proof_hash": sha256(yacht_id + warranty_id + action + timestamp),
+    ...
+})
+```
+
+**Critical:** Must use `get_supabase_client()` (service role key), NOT the tenant client. RLS policy `ledger_events_insert_service_only` blocks tenant-scoped clients from inserting. Using the wrong client causes a silent failure caught by `except Exception: pass`.
+
+### `pms_notifications`
+
+Delivery table for in-app notifications. Key constraint:
+
+```sql
+idempotency_key   varchar   NOT NULL — no default
+```
+
+**This catches new developers every time.** Any INSERT without `idempotency_key` raises a NOT NULL violation, caught silently by `except Exception: pass`. The notification is never written. Use the upsert pattern:
+
+```python
+supabase.table("pms_notifications").upsert(
+    rows,
+    on_conflict="yacht_id,user_id,idempotency_key"
+).execute()
+```
+
+Key format used: `warranty_{action}:{warranty_id}:{recipient_user_id}`.
+
+---
+
+## 6. Notification hierarchy
+
+When a crew member submits, the right people need to know. The warranty domain uses role-based escalation identical to the HoR violation pattern.
+
+```
+_get_approver_user_ids(supabase, yacht_id)
+  → queries auth_users_roles WHERE role IN ('captain', 'manager')
+  → deduplicates (same user may hold multiple roles)
+  → returns list of user_ids
+```
+
+| Action | Who gets notified | Priority |
+|---|---|---|
+| `submit_warranty_claim` | All captain + manager users on the vessel | normal |
+| `approve_warranty_claim` | Drafter + submitter (if different from approver) | normal |
+| `reject_warranty_claim` | Drafter + submitter (if different from approver) | **high** |
+| `close_warranty_claim` | Drafter + submitter | normal |
+| `compose_warranty_email` | All captain + manager users | normal |
+| `add_warranty_note` | Drafter + submitter + approver (excluding note author) | low |
+
+---
+
+## 7. The Phase 4 bridge (things you need to understand)
+
+The action dispatch system has two layers that confuse everyone:
+
+**Layer 1 — `INTERNAL_HANDLERS` dict** (`internal_dispatcher.py` near bottom)  
+Contains all callable warranty handlers. This is the "legacy" layer.
+
+**Layer 2 — `HANDLERS` dict** (`routes/handlers/__init__.py`)  
+This is what the execute endpoint actually looks up. Built from Phase 4 native handlers PLUS the internal_adapter shim.
+
+**The bridge** — `internal_adapter.py`:
+```python
+_ACTIONS_TO_ADAPT = [
+    "submit_warranty_claim",
+    "approve_warranty_claim",
+    ...
+]
+
+HANDLERS = {action_id: _make_adapter(action_id) for action_id in _ACTIONS_TO_ADAPT}
+```
+
+`_make_adapter()` wraps each `INTERNAL_HANDLERS` function to accept the Phase 4 calling convention `(payload, context, yacht_id, user_id, user_context, db_client)` and converts it to the flat `params` dict the legacy handlers expect.
+
+**If an action is in `INTERNAL_HANDLERS` but NOT in `_ACTIONS_TO_ADAPT`** → it returns `INVALID_ACTION` from the execute endpoint. This was the root bug found in April 2026 — all 6 warranty state-change actions were missing from `_ACTIONS_TO_ADAPT`. The UI showed action buttons (because `available_actions` reads from the registry, not the adapter), but clicking them did nothing.
+
+---
+
+## 8. Attachments — the upload flow
+
+The upload modal (`AttachmentUploadModal.tsx`) is **generic** — it works for any entity. Don't create a domain-specific upload modal. Pass props:
+
+```tsx
+<AttachmentUploadModal
+  open={uploadModalOpen}
+  onClose={() => setUploadModalOpen(false)}
+  entityType="warranty"
+  entityId={entityId}
+  bucket="pms-warranty-documents"
+  category="claim_document"
+  yachtId={entity?.yacht_id ?? user?.yachtId ?? ''}
+  userId={user?.id ?? ''}
+  onComplete={() => refetch()}
+/>
+```
+
+**Upload path format:** `warranty/{entityId}/{Date.now()}-{sanitizedFilename}`
+
+**Sanitisation rule:** `name.replace(/[^a-zA-Z0-9._-]/g, '_')` — replaces spaces and special chars with underscores.
+
+**Signed URL TTL:** 1 hour (3600 seconds). Signed URLs are generated fresh on every GET call to the entity endpoint. Do not cache them on the frontend.
+
+**Partial failure handling:** If the Supabase storage upload succeeds but the `pms_attachments` insert fails (network issue, RLS, etc.), the modal still calls `onComplete()` after 1.2s so the UI refreshes. The file exists in storage but has no metadata row. A reconciliation job could clean these up, but currently none exists.
+
+**Accepted MIME types:** PDF, JPEG, PNG, HEIC, WEBP, TIFF, Word (.doc/.docx), Excel (.xls/.xlsx), plain text, ZIP, application/octet-stream (catch-all).
+
+---
+
+## 9. `compose_warranty_email` — what it does and does not do
+
+This action **prepares a draft only**. It does not send an email.
+
+It reads all claim fields, builds a professional letter body, and stores the result as JSON in `pms_warranty_claims.email_draft`:
+
+```json
+{
+  "subject": "Warranty Claim WC-2026-001 — Defective Pump",
+  "to": "Vendor Name",
+  "body": "Dear Vendor Name,\n\nWe write regarding warranty claim...",
+  "composed_at": "2026-04-14T15:00:00Z",
+  "composed_by": "user-uuid"
+}
+```
+
+The email draft is returned in the entity GET response and rendered in `WarrantyContent.tsx`. Any actual sending would require an email integration (currently not wired to warranty). The action notifies captain/manager that the draft is ready for their review.
+
+---
+
+## 10. Things I wish I knew at the start
+
+### 1. `available_actions` and execute are completely separate systems
+
+`available_actions` in the entity response reads from the **registry** (`registry.py`). The execute endpoint routes through **`HANDLERS`** (built from `internal_adapter.py`). An action can exist in the registry (shows a button) but be missing from `_ACTIONS_TO_ADAPT` (execute returns `INVALID_ACTION`). Always verify both.
+
+### 2. `pms_warranty_claims`, not `pms_warranties`
+
+There is no `pms_warranties` table. The table is `pms_warranty_claims`. Every query, every migration, every handler uses this name. Getting it wrong causes a 500 that says "relation does not exist."
+
+### 3. `pms_audit_log.user_id`, not `performed_by`
+
+The audit log table has a `user_id` column. It does **not** have a `performed_by` column. Older documentation and auto-generated code uses `performed_by` — this is wrong. The insert will fail silently.
+
+### 4. `idempotency_key` is NOT NULL with no default
+
+Every `pms_notifications` insert must include `idempotency_key`. There is no default. Missing it causes a constraint violation swallowed by `except Exception: pass`. You'll never see an error — the notification just won't appear.
+
+### 5. `ledger_events` requires service role, not tenant client
+
+The entity_routes.py uses `get_tenant_client(tenant_key)` for all queries. But `ledger_events` has RLS policy `ledger_events_insert_service_only` that blocks the tenant client from inserting. Use `get_supabase_client()` specifically for ledger writes. Using the tenant client causes a silent failure.
+
+### 6. `source_context` on `ledger_events` has a CHECK constraint
+
+Valid values: `microaction`, `search`, `read_beacon`, `bulk`, `system`. Anything else causes `APIError: violates check constraint "valid_source_context"`. This is caught silently.
+
+### 7. The entity GET endpoint uses `v_warranty_enriched`, not the base table
+
+Never query `pms_warranty_claims` directly for the entity endpoint. The enriched view adds equipment name, expiry calculations, status labels. Frontend components expect these fields — they will render empty or crash without them.
+
+### 8. Docker does not hot-reload
+
+The API container bakes source at build time. If you change Python code and wonder why nothing changed, you need to `docker compose build api && docker compose up -d api`. A running container with stale code will silently ignore your changes.
+
+### 9. The warranty notes FK was added mid-project
+
+`pms_notes.warranty_id` was added via migration in April 2026. If your dev database is from an older dump, it won't have this column. The `add_warranty_note` handler will fail silently. Run the migration:
+```sql
+ALTER TABLE pms_notes ADD COLUMN IF NOT EXISTS warranty_id UUID REFERENCES pms_warranty_claims(id);
+CREATE INDEX IF NOT EXISTS idx_pms_notes_warranty_id ON pms_notes(warranty_id);
+```
+
+### 10. `maybe_single()` raises on empty results in some Supabase versions
+
+The Python Supabase client's `.maybe_single()` should return `None` for empty results, but certain versions raise `APIError` on 204 (no content) responses. The safe pattern is `.limit(1).execute()` followed by `result.data[0] if result.data else None`. Both patterns exist in the codebase — if you see warranty queries failing on empty results, switch to `.limit(1)`.
+
+---
+
+## 11. Cross-domain interactions
+
+### Equipment
+- Warranty claims optionally reference one equipment item via `equipment_id`
+- The enriched view joins to get `equipment_name` and `equipment_code`
+- Frontend renders a "Related Equipment" nav link
+- Equipment lens has no back-reference to warranty (navigation is one-directional from warranty)
+
+### Faults
+- Optional `fault_id` FK
+- A fault may have triggered the warranty claim (equipment failed, raising a fault)
+- No back-reference on the fault lens
+
+### Work Orders
+- Optional `work_order_id` FK
+- A work order may have been raised to document the defect that led to the warranty claim
+- No back-reference on the work order lens
+
+### Handover
+- Warranty claims can be referenced in handover items via the generic `related_entities` mechanism
+- No direct FK — handover items store `entity_type="warranty"` and `entity_id`
+
+### Email
+- `compose_warranty_email` stores a draft in the warranty record
+- No email is sent automatically
+- The email integration (Outlook/SMTP) is separate from this domain
+
+### Ledger / Audit
+- Every state change → `pms_audit_log` (direct, in handlers)
+- Every action → `ledger_events` (via safety net in `p0_actions_routes.py`)
+- Every read → `ledger_events` (via fire-and-forget in `entity_routes.py`)
+
+---
+
+## 12. e2e test coverage
+
+**File:** `apps/web/e2e/shard-31-fragmented-routes/route-warranties.spec.ts`  
+**19 tests** covering:
+- List page renders
+- Status badge rendering per state
+- Clicking into detail view
+- File new claim modal
+- State transition buttons appear/disappear by role
+- Attachment section renders
+- Notes section renders
+- Audit trail renders
+
+**Critical note for running e2e tests:**  
+Tests must point at the **MASTER** Supabase URL (for auth/JWT), not the TENANT URL. Using the tenant URL for auth causes JWT validation failures that appear as random 401s. See `CONTEXT_RECOVERY_PROMPT.md` for the env setup.
+
+---
+
+## 13. Limitations and known gaps
+
+| Gap | Description | Workaround |
+|---|---|---|
+| Email not sent | `compose_warranty_email` prepares only, no send | Manual copy-paste or future email integration |
+| No expiry alerts | Warranty expiry date stored but no cron job sends alerts | `days_until_expiry` available in view for frontend warning |
+| Attachment deduplication | Same file can be uploaded multiple times | No server-side dedup — check filename before uploading |
+| Signed URL TTL | Attachment URLs expire after 1 hour | Fresh URLs generated on every entity GET — don't cache them |
+| Partial upload state | If metadata insert fails after storage upload, file exists with no record | No cleanup job exists |
+| No multi-file upload | AttachmentUploadModal is single-file | Multiple uploads require multiple modal opens |
+| Role hierarchy rigidity | `_get_approver_user_ids` queries captain + manager only | Cannot configure different approvers per vessel |
+| `under_review` status removed | Old test data may have `under_review` in `status` column | Safe to ignore — state machine never produces it, UI handles unknown states gracefully |
+
+---
+
+## 14. Quick reference — action IDs
+
+| What you want to do | Action ID |
+|---|---|
+| Create a new claim | `draft_warranty_claim` or `file_warranty_claim` (same handler) |
+| Submit for approval | `submit_warranty_claim` |
+| Approve | `approve_warranty_claim` |
+| Reject with reason | `reject_warranty_claim` |
+| Close after approval | `close_warranty_claim` |
+| Add a note | `add_warranty_note` |
+| Prepare email draft | `compose_warranty_email` |
+| Soft-delete | `archive_warranty` |
+| Void (signed) | `void_warranty` |
+
+---
+
+## 15. How to verify it works
+
+```bash
+# 1. API health
+curl http://localhost:8000/health
+
+# 2. Mint a JWT (captain role) and fetch a warranty entity
+# See docs/explanations/Authentication.md for JWT minting
+
+# 3. Check ledger_events for view event after GET
+psql $TENANT_DB_URL -c "
+  SELECT action, user_role, created_at 
+  FROM ledger_events 
+  WHERE entity_type='warranty' 
+  ORDER BY created_at DESC LIMIT 5;
+"
+
+# 4. Check notifications after submit
+psql $TENANT_DB_URL -c "
+  SELECT user_id, notification_type, idempotency_key 
+  FROM pms_notifications 
+  WHERE notification_type='warranty_submitted' 
+  ORDER BY created_at DESC LIMIT 5;
+"
+
+# 5. Verify all captain/manager users were notified (count should match)
+psql $TENANT_DB_URL -c "
+  SELECT count(*) FROM auth_users_roles 
+  WHERE yacht_id='YOUR_YACHT_ID' AND role IN ('captain','manager');
+"
+```
+
+---
+
+*Last updated: April 2026 | Branch: main | Maintainer: CelesteOS Engineering*


### PR DESCRIPTION
## Four domain READMEs, written by the agents who built each feature

Each file covers:
- What the domain is (plain English, business context)
- File map (every file, exact path, frontend + backend)
- How a request travels (browser → API → DB)
- DB tables (every table touched, columns, views, constraints)
- All endpoints (who calls each, which component)
- Business rules enforced in code
- Audit and ledger coverage (what's logged where)
- Notification hierarchy (cascade rules)
- Things I wish I knew at the start
- Common bugs and diagnosis
- Cross-domain interactions
- What is NOT implemented (honest gap list)

## Files

| File | Author | Size |
|---|---|---|
| `certificates.md` | CERTIFICATE01 | 35KB |
| `handover.md` | HANDOVER01 | 39KB / 726 lines |
| `hours-of-rest.md` | HOURSOFREST01 | 28KB |
| `warranty.md` | WARRANTY01 | 23KB / 15 sections |

Naming convention: lowercase-hyphen throughout, matching `docs/explanations/` standard.

Related code PRs: #523 (handover CRUD), #525 (ledger cascade), #526 (sync), #527 (countersign role fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)