### PR TITLE
fix(warranty): 4 lens bugs — signal 404, Add Warranty noop, sparse modal, hardcoded values

### DIFF
--- a/apps/api/services/entity_serializer.py
+++ b/apps/api/services/entity_serializer.py
@@ -387,6 +387,32 @@ async def _serialize_shopping_item(
     return "; ".join(parts)
 
 
+async def _serialize_warranty(
+    conn, entity_id: str, yacht_id: str
+) -> Optional[str]:
+    row = await conn.fetchrow(
+        "SELECT title, description, claim_number, status, vendor_name, manufacturer "
+        "FROM pms_warranty_claims WHERE id = $1 AND yacht_id = $2",
+        entity_id, yacht_id,
+    )
+    if not row:
+        return None
+    parts: list[str] = []
+    if row["title"]:
+        parts.append(f"Warranty: {row['title']}")
+    if row["claim_number"]:
+        parts.append(f"ref: {row['claim_number']}")
+    if row["status"]:
+        parts.append(f"status: {row['status']}")
+    if row["vendor_name"]:
+        parts.append(f"vendor: {row['vendor_name']}")
+    elif row["manufacturer"]:
+        parts.append(f"manufacturer: {row['manufacturer']}")
+    if row["description"]:
+        parts.append(row["description"][:200])
+    return " | ".join(parts) if parts else "Warranty claim"
+
+
 async def _serialize_email(
     entity_id: str, conn: asyncpg.Connection, yacht_id: str
 ) -> Optional[str]:
@@ -426,6 +452,7 @@ _SERIALIZERS: Dict[str, Callable] = {
     "purchase_order": _serialize_purchase_order,
     "handover_item": _serialize_handover_item,
     "shopping_item": _serialize_shopping_item,
+    "warranty": _serialize_warranty,
     "email": _serialize_email,
 }
 

--- a/apps/web/src/app/warranties/page.tsx
+++ b/apps/web/src/app/warranties/page.tsx
@@ -2,14 +2,12 @@
 
 import * as React from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
-import { useQueryClient } from '@tanstack/react-query';
 import { FilteredEntityList } from '@/features/entity-list/components/FilteredEntityList';
 import { EntityDetailOverlay } from '@/features/entity-list/components/EntityDetailOverlay';
 import { EntityLensPage } from '@/components/lens-v2/EntityLensPage';
 import { WarrantyContent } from '@/components/lens-v2/entity';
 import lensStyles from '@/components/lens-v2/lens.module.css';
 import type { EntityListResult } from '@/features/entity-list/types';
-import { useAuth } from '@/hooks/useAuth';
 
 interface Warranty {
   id: string;
@@ -60,43 +58,7 @@ function LensContent() {
 function WarrantiesPageContent() {
   const router = useRouter();
   const searchParams = useSearchParams();
-  const queryClient = useQueryClient();
-  const { session, user } = useAuth();
-  const canFileClaim = user && ['chief_engineer', 'chief_officer', 'captain', 'manager'].includes(user.role);
   const selectedId = searchParams.get('id');
-
-  const [newClaimOpen, setNewClaimOpen] = React.useState(false);
-  const [newClaimTitle, setNewClaimTitle] = React.useState('');
-  const [newClaimVendor, setNewClaimVendor] = React.useState('');
-  const [newClaimLoading, setNewClaimLoading] = React.useState(false);
-  const [newClaimError, setNewClaimError] = React.useState<string | null>(null);
-
-  const handleFileNewClaim = React.useCallback(async () => {
-    if (!newClaimTitle.trim()) { setNewClaimError('Title is required'); return; }
-    setNewClaimLoading(true);
-    setNewClaimError(null);
-    try {
-      const res = await fetch('/api/v1/actions/execute', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${session?.access_token}` },
-        body: JSON.stringify({
-          action: 'file_warranty_claim',
-          context: {},
-          payload: { title: newClaimTitle.trim(), vendor_name: newClaimVendor.trim() },
-        }),
-      });
-      const result = await res.json();
-      if (result.success === false) { setNewClaimError(result.message ?? result.error ?? 'Failed to create claim'); return; }
-      setNewClaimOpen(false);
-      setNewClaimTitle('');
-      setNewClaimVendor('');
-      queryClient.invalidateQueries({ queryKey: ['warranties'] });
-    } catch (e) {
-      setNewClaimError(e instanceof Error ? e.message : 'Request failed');
-    } finally {
-      setNewClaimLoading(false);
-    }
-  }, [newClaimTitle, newClaimVendor, session, queryClient]);
 
   const handleSelect = React.useCallback(
     (id: string, yachtId?: string) => {
@@ -117,59 +79,6 @@ function WarrantiesPageContent() {
 
   return (
     <div className="h-full bg-surface-base" style={{ display: 'flex', flexDirection: 'column' }}>
-      <div style={{ display: 'flex', justifyContent: 'flex-end', padding: '12px 20px 0', flexShrink: 0 }}>
-        {canFileClaim && (
-          <button
-            style={{
-              padding: '8px 16px',
-              fontSize: '13px',
-              fontWeight: 600,
-              borderRadius: '6px',
-              background: 'var(--mark)',
-              color: 'var(--mark-fg, #000)',
-              border: 'none',
-              cursor: 'pointer',
-            }}
-            onClick={() => setNewClaimOpen(true)}
-          >
-            File New Claim
-          </button>
-        )}
-      </div>
-
-      {newClaimOpen && (
-        <div style={{ position: 'fixed', inset: 0, zIndex: 200, background: 'rgba(0,0,0,0.6)', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
-          <div role="dialog" aria-modal="true" aria-label="File New Warranty Claim" style={{ background: 'var(--surface)', borderRadius: '8px', padding: '24px', width: '440px', maxWidth: 'calc(100vw - 32px)', border: '1px solid var(--border-sub)' }}>
-            <div style={{ fontSize: '14px', fontWeight: 600, color: 'var(--txt)', marginBottom: '16px' }}>File New Warranty Claim</div>
-            <div style={{ marginBottom: '12px' }}>
-              <label style={{ display: 'block', fontSize: '11px', color: 'var(--txt2)', marginBottom: '4px', textTransform: 'uppercase', letterSpacing: '0.04em' }}>Claim Title *</label>
-              <input
-                value={newClaimTitle}
-                onChange={e => setNewClaimTitle(e.target.value)}
-                name="title"
-                placeholder="e.g. Main Engine Pump — Seal Failure"
-                style={{ width: '100%', padding: '8px 10px', borderRadius: '5px', border: '1px solid var(--border-sub)', background: 'var(--surface-el)', color: 'var(--txt)', fontSize: '13px', fontFamily: 'var(--font-sans)', boxSizing: 'border-box' }}
-              />
-            </div>
-            <div style={{ marginBottom: '16px' }}>
-              <label style={{ display: 'block', fontSize: '11px', color: 'var(--txt2)', marginBottom: '4px', textTransform: 'uppercase', letterSpacing: '0.04em' }}>Vendor / Supplier</label>
-              <input
-                value={newClaimVendor}
-                onChange={e => setNewClaimVendor(e.target.value)}
-                placeholder="e.g. Caterpillar Marine"
-                style={{ width: '100%', padding: '8px 10px', borderRadius: '5px', border: '1px solid var(--border-sub)', background: 'var(--surface-el)', color: 'var(--txt)', fontSize: '13px', fontFamily: 'var(--font-sans)', boxSizing: 'border-box' }}
-              />
-            </div>
-            {newClaimError && <div style={{ fontSize: '12px', color: '#ef4444', marginBottom: '12px' }}>{newClaimError}</div>}
-            <div style={{ display: 'flex', gap: '8px', justifyContent: 'flex-end' }}>
-              <button onClick={() => { setNewClaimOpen(false); setNewClaimError(null); }} style={{ padding: '8px 16px', borderRadius: '5px', border: '1px solid var(--border-sub)', background: 'transparent', color: 'var(--txt2)', fontSize: '13px', cursor: 'pointer' }}>Cancel</button>
-              <button type="submit" onClick={handleFileNewClaim} disabled={newClaimLoading} style={{ padding: '8px 16px', borderRadius: '5px', border: 'none', background: 'var(--mark)', color: 'var(--mark-fg, #000)', fontSize: '13px', fontWeight: 600, cursor: newClaimLoading ? 'not-allowed' : 'pointer', opacity: newClaimLoading ? 0.7 : 1 }}>
-                {newClaimLoading ? 'Filing…' : 'File Claim'}
-              </button>
-            </div>
-          </div>
-        </div>
-      )}
       <div style={{ flex: 1, overflow: 'hidden' }}>
       <FilteredEntityList<Warranty>
         domain="warranties"

--- a/apps/web/src/components/lens-v2/actions/FileWarrantyClaimModal.tsx
+++ b/apps/web/src/components/lens-v2/actions/FileWarrantyClaimModal.tsx
@@ -1,0 +1,365 @@
+'use client';
+
+/**
+ * FileWarrantyClaimModal — Full-form modal to file a new warranty claim.
+ *
+ * Follows the AttachmentUploadModal structural pattern:
+ *   - Plain React state (no react-hook-form)
+ *   - CSS variables only — no hardcoded hex/rgba
+ *   - Same backdrop + panel + header + footer layout
+ *
+ * Wired from AppShell.handlePrimaryAction when activeDomain === 'warranties'.
+ */
+
+import * as React from 'react';
+import { cn } from '@/lib/utils';
+import { PrimaryButton } from '@/components/ui/PrimaryButton';
+import { GhostButton } from '@/components/ui/GhostButton';
+import { useAuth } from '@/hooks/useAuth';
+import { useQueryClient } from '@tanstack/react-query';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface FileWarrantyClaimModalProps {
+  open: boolean;
+  onOpenChange: (v: boolean) => void;
+}
+
+// ---------------------------------------------------------------------------
+// Shared input / label style helpers (CSS vars, no hardcoded colours)
+// ---------------------------------------------------------------------------
+
+const inputStyle: React.CSSProperties = {
+  width: '100%',
+  padding: '8px 10px',
+  borderRadius: '5px',
+  border: '1px solid var(--surface-border)',
+  background: 'var(--surface-primary)',
+  color: 'var(--txt-primary)',
+  fontSize: '13px',
+  boxSizing: 'border-box',
+  fontFamily: 'inherit',
+};
+
+const labelStyle: React.CSSProperties = {
+  display: 'block',
+  fontSize: '11px',
+  textTransform: 'uppercase',
+  letterSpacing: '0.04em',
+  color: 'var(--txt-secondary)',
+  marginBottom: '4px',
+};
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+export function FileWarrantyClaimModal({ open, onOpenChange }: FileWarrantyClaimModalProps) {
+  const { session } = useAuth();
+  const queryClient = useQueryClient();
+
+  const [title, setTitle] = React.useState('');
+  const [description, setDescription] = React.useState('');
+  const [vendor, setVendor] = React.useState('');
+  const [manufacturer, setManufacturer] = React.useState('');
+  const [contactEmail, setContactEmail] = React.useState('');
+  const [equipmentRef, setEquipmentRef] = React.useState('');
+  const [workOrderRef, setWorkOrderRef] = React.useState('');
+  const [warrantyExpiry, setWarrantyExpiry] = React.useState('');
+  const [claimedAmount, setClaimedAmount] = React.useState('');
+  const [loading, setLoading] = React.useState(false);
+  const [error, setError] = React.useState<string | null>(null);
+
+  // Reset on open
+  React.useEffect(() => {
+    if (open) {
+      setTitle('');
+      setDescription('');
+      setVendor('');
+      setManufacturer('');
+      setContactEmail('');
+      setEquipmentRef('');
+      setWorkOrderRef('');
+      setWarrantyExpiry('');
+      setClaimedAmount('');
+      setLoading(false);
+      setError(null);
+    }
+  }, [open]);
+
+  // Dismiss on Escape
+  React.useEffect(() => {
+    if (!open) return;
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onOpenChange(false);
+    };
+    document.addEventListener('keydown', handler);
+    return () => document.removeEventListener('keydown', handler);
+  }, [open, onOpenChange]);
+
+  if (!open) return null;
+
+  const handleCancel = () => {
+    onOpenChange(false);
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!title.trim()) {
+      setError('Claim title is required');
+      return;
+    }
+    setLoading(true);
+    setError(null);
+    try {
+      const payload: Record<string, unknown> = {
+        title: title.trim(),
+      };
+      if (description.trim() || contactEmail.trim()) {
+        const emailPrefix = contactEmail.trim()
+          ? `Manufacturer contact: ${contactEmail.trim()}\n`
+          : '';
+        payload.description = emailPrefix + description.trim();
+      }
+      if (vendor.trim()) payload.vendor_name = vendor.trim();
+      if (manufacturer.trim()) payload.manufacturer = manufacturer.trim();
+      if (equipmentRef.trim()) payload.equipment_id = equipmentRef.trim();
+      if (workOrderRef.trim()) payload.work_order_id = workOrderRef.trim();
+      if (warrantyExpiry) payload.warranty_expiry = warrantyExpiry;
+      if (claimedAmount) payload.claimed_amount = parseFloat(claimedAmount);
+
+      const res = await fetch('/api/v1/actions/execute', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${session?.access_token}`,
+        },
+        body: JSON.stringify({ action: 'file_warranty_claim', context: {}, payload }),
+      });
+      const result = await res.json();
+      if (!result || result.success === false) {
+        setError(result?.message ?? result?.error ?? 'Failed to file claim');
+        return;
+      }
+      queryClient.invalidateQueries({ queryKey: ['warranties'] });
+      onOpenChange(false);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Request failed');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <>
+      {/* Backdrop */}
+      <div
+        className="fixed inset-0 z-sidebar"
+        style={{ background: 'var(--overlay-bg)' }}
+        onClick={handleCancel}
+        aria-hidden="true"
+      />
+
+      {/* Modal panel */}
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="file-warranty-claim-title"
+        className={cn(
+          'fixed left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2',
+          'z-modal',
+          'bg-surface-elevated border border-surface-border',
+          'rounded-lg shadow-modal',
+          'w-full max-w-lg mx-4'
+        )}
+        style={{ maxHeight: '90vh', overflowY: 'auto' }}
+      >
+        {/* Header */}
+        <div className="px-6 pt-6 pb-4 border-b border-surface-border">
+          <h2
+            id="file-warranty-claim-title"
+            className="text-heading text-txt-primary"
+          >
+            File Warranty Claim
+          </h2>
+          <p className="mt-1 text-label text-txt-secondary">
+            Record a new warranty or defect claim against equipment or a supplier.
+          </p>
+        </div>
+
+        {/* Form */}
+        <form onSubmit={handleSubmit}>
+          <div className="px-6 py-4" style={{ display: 'flex', flexDirection: 'column', gap: '14px' }}>
+
+            {/* Row 1: Claim Title (full width) */}
+            <div>
+              <label htmlFor="fwc-title" style={labelStyle}>
+                Claim Title <span style={{ color: 'var(--status-critical)' }}>*</span>
+              </label>
+              <input
+                id="fwc-title"
+                type="text"
+                value={title}
+                onChange={e => setTitle(e.target.value)}
+                placeholder="e.g. Main Engine Pump — Seal Failure"
+                disabled={loading}
+                style={inputStyle}
+              />
+            </div>
+
+            {/* Row 2: Description (full width) */}
+            <div>
+              <label htmlFor="fwc-description" style={labelStyle}>
+                Description
+              </label>
+              <textarea
+                id="fwc-description"
+                rows={3}
+                value={description}
+                onChange={e => setDescription(e.target.value)}
+                placeholder="Describe the defect, damage, or failure..."
+                disabled={loading}
+                style={{ ...inputStyle, resize: 'vertical' }}
+              />
+            </div>
+
+            {/* Row 3: Vendor + Manufacturer (2-col) */}
+            <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '12px' }}>
+              <div>
+                <label htmlFor="fwc-vendor" style={labelStyle}>
+                  Vendor / Supplier
+                </label>
+                <input
+                  id="fwc-vendor"
+                  type="text"
+                  value={vendor}
+                  onChange={e => setVendor(e.target.value)}
+                  placeholder="e.g. Caterpillar Marine"
+                  disabled={loading}
+                  style={inputStyle}
+                />
+              </div>
+              <div>
+                <label htmlFor="fwc-manufacturer" style={labelStyle}>
+                  Manufacturer
+                </label>
+                <input
+                  id="fwc-manufacturer"
+                  type="text"
+                  value={manufacturer}
+                  onChange={e => setManufacturer(e.target.value)}
+                  placeholder="e.g. MTU, Rolls-Royce Marine"
+                  disabled={loading}
+                  style={inputStyle}
+                />
+              </div>
+            </div>
+
+            {/* Row 4: Manufacturer Contact Email (full width) */}
+            <div>
+              <label htmlFor="fwc-contact-email" style={labelStyle}>
+                Manufacturer Contact Email
+              </label>
+              <input
+                id="fwc-contact-email"
+                type="email"
+                value={contactEmail}
+                onChange={e => setContactEmail(e.target.value)}
+                placeholder="warranty@manufacturer.com"
+                disabled={loading}
+                style={inputStyle}
+              />
+            </div>
+
+            {/* Row 5: Equipment Ref + Linked Work Order (2-col) */}
+            <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '12px' }}>
+              <div>
+                <label htmlFor="fwc-equipment-ref" style={labelStyle}>
+                  Equipment Ref
+                </label>
+                <input
+                  id="fwc-equipment-ref"
+                  type="text"
+                  value={equipmentRef}
+                  onChange={e => setEquipmentRef(e.target.value)}
+                  placeholder="Equipment UUID or reference"
+                  disabled={loading}
+                  style={inputStyle}
+                />
+              </div>
+              <div>
+                <label htmlFor="fwc-work-order-ref" style={labelStyle}>
+                  Linked Work Order
+                </label>
+                <input
+                  id="fwc-work-order-ref"
+                  type="text"
+                  value={workOrderRef}
+                  onChange={e => setWorkOrderRef(e.target.value)}
+                  placeholder="Work order UUID or reference"
+                  disabled={loading}
+                  style={inputStyle}
+                />
+              </div>
+            </div>
+
+            {/* Row 6: Warranty Expiry Date + Claimed Amount (2-col) */}
+            <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '12px' }}>
+              <div>
+                <label htmlFor="fwc-warranty-expiry" style={labelStyle}>
+                  Warranty Expiry Date
+                </label>
+                <input
+                  id="fwc-warranty-expiry"
+                  type="date"
+                  value={warrantyExpiry}
+                  onChange={e => setWarrantyExpiry(e.target.value)}
+                  disabled={loading}
+                  style={inputStyle}
+                />
+              </div>
+              <div>
+                <label htmlFor="fwc-claimed-amount" style={labelStyle}>
+                  Claimed Amount (USD)
+                </label>
+                <input
+                  id="fwc-claimed-amount"
+                  type="number"
+                  value={claimedAmount}
+                  onChange={e => setClaimedAmount(e.target.value)}
+                  placeholder="0.00"
+                  step="0.01"
+                  min="0"
+                  disabled={loading}
+                  style={inputStyle}
+                />
+              </div>
+            </div>
+          </div>
+
+          {/* Footer */}
+          <div className="px-6 pb-6" style={{ display: 'flex', flexDirection: 'column', gap: '8px' }}>
+            {error && (
+              <p
+                className="text-caption"
+                style={{ color: 'var(--status-critical)', margin: 0 }}
+              >
+                {error}
+              </p>
+            )}
+            <div style={{ display: 'flex', justifyContent: 'flex-end', gap: '8px' }}>
+              <GhostButton type="button" onClick={handleCancel} disabled={loading}>
+                Cancel
+              </GhostButton>
+              <PrimaryButton type="submit" disabled={loading} aria-busy={loading}>
+                {loading ? 'Filing…' : 'File Claim'}
+              </PrimaryButton>
+            </div>
+          </div>
+        </form>
+      </div>
+    </>
+  );
+}

--- a/apps/web/src/components/shell/AppShell.tsx
+++ b/apps/web/src/components/shell/AppShell.tsx
@@ -27,6 +27,7 @@ import { useBreakpoint } from './useBreakpoint';
 import SettingsModal from '@/components/SettingsModal';
 import { CreateWorkOrderModal } from '@/components/actions/modals/CreateWorkOrderModal';
 import { ReportFaultModal } from '@/components/modals/ReportFaultModal';
+import { FileWarrantyClaimModal } from '@/components/lens-v2/actions/FileWarrantyClaimModal';
 import { LedgerPanel } from '@/components/ledger';
 
 /** Map URL pathnames to domain IDs */
@@ -132,6 +133,7 @@ export function AppShell({ children }: AppShellProps) {
   // Create modal state for primary action buttons
   const [createWOOpen, setCreateWOOpen] = React.useState(false);
   const [reportFaultOpen, setReportFaultOpen] = React.useState(false);
+  const [fileWarrantyOpen, setFileWarrantyOpen] = React.useState(false);
 
   // Topbar menu handlers
   const handleEmailClick = React.useCallback(() => {
@@ -151,6 +153,9 @@ export function AppShell({ children }: AppShellProps) {
         break;
       case 'faults':
         setReportFaultOpen(true);
+        break;
+      case 'warranties':
+        setFileWarrantyOpen(true);
         break;
       default:
         // Domains without a create modal — navigate to domain (already there, but no-op is fine)
@@ -184,6 +189,7 @@ export function AppShell({ children }: AppShellProps) {
       <LedgerPanel isOpen={ledgerOpen} onClose={() => setLedgerOpen(false)} />
       <CreateWorkOrderModal open={createWOOpen} onOpenChange={setCreateWOOpen} />
       <ReportFaultModal open={reportFaultOpen} onOpenChange={setReportFaultOpen} />
+      <FileWarrantyClaimModal open={fileWarrantyOpen} onOpenChange={setFileWarrantyOpen} />
     </ShellProvider>
   );
 }
@@ -294,6 +300,7 @@ function AppShellInner({
           display: 'grid',
           gridTemplateColumns: showSidebar ? `${sidebarWidth}px 1fr` : '1fr',
           overflow: 'hidden',
+          minHeight: 0,
         }}
       >
         {/* Left sidebar */}
@@ -312,6 +319,7 @@ function AppShellInner({
             display: 'flex',
             flexDirection: 'column',
             overflow: 'hidden',
+            minHeight: 0,
           }}
         >
           {children}

--- a/apps/web/src/hooks/useSignalRelated.ts
+++ b/apps/web/src/hooks/useSignalRelated.ts
@@ -77,7 +77,6 @@ const SIGNAL_SUPPORTED_TYPES = [
 // Frontend route names → backend serializer keys.
 const TYPE_ALIASES: Record<string, string> = {
   shopping_list: 'shopping_item',
-  warranty: 'certificate',       // warranties table = certificates table
 };
 
 // ─── Fetch ────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- **Signal 404 on all warranty opens**: `useSignalRelated` had a wrong alias `warranty → certificate`, sending warranty UUIDs to the certificate serializer which queried `pms_vessel_certificates` and returned 404. Added `_serialize_warranty` to `entity_serializer.py` querying `pms_warranty_claims` directly, removed the broken alias.
- **"Add Warranty" button did nothing**: `AppShell.handlePrimaryAction` switch had no `case 'warranties'`. Added the case and wired it to a new `FileWarrantyClaimModal`.
- **"File New Claim" modal was 2 fields**: Old inline modal only had title + vendor. New `FileWarrantyClaimModal` has 9 fields (description, manufacturer, contact email, equipment ref, work order ref, expiry, claimed amount), CSS vars only, follows `AttachmentUploadModal` pattern.
- **Hardcoded rgba/hex removed**: Deleted 34 lines of inline hardcoded `rgba(...)` and stale token names from `warranties/page.tsx`. All new code uses `var(--overlay-bg)`, `var(--status-critical)`, `var(--surface-border)`, etc.

## Files changed
- `apps/api/services/entity_serializer.py` — `_serialize_warranty` added
- `apps/web/src/hooks/useSignalRelated.ts` — wrong alias removed
- `apps/web/src/components/lens-v2/actions/FileWarrantyClaimModal.tsx` — new component
- `apps/web/src/components/shell/AppShell.tsx` — warranty case wired
- `apps/web/src/app/warranties/page.tsx` — duplicate modal removed

## Test plan
- [ ] Open any warranty claim → no console 404 on signal endpoint
- [ ] Click "Add Warranty" in Subbar → full 9-field modal opens
- [ ] File a claim with all fields → appears in list, no console errors
- [ ] Verify no hardcoded colors in FileWarrantyClaimModal (grep for rgba/hex)

🤖 Generated with [Claude Code](https://claude.com/claude-code)