### PR TITLE
fix(serializer): correct _serialize_warranty parameter order

### DIFF
--- a/apps/api/services/entity_serializer.py
+++ b/apps/api/services/entity_serializer.py
@@ -388,7 +388,7 @@ async def _serialize_shopping_item(
 
 
 async def _serialize_warranty(
-    conn, entity_id: str, yacht_id: str
+    entity_id: str, conn: asyncpg.Connection, yacht_id: str
 ) -> Optional[str]:
     row = await conn.fetchrow(
         "SELECT title, description, claim_number, status, vendor_name, manufacturer "


### PR DESCRIPTION
## Fix

`serialize_entity` calls `serializer(entity_id, conn, yacht_id)` at line 47. `_serialize_warranty` was written as `(conn, entity_id, yacht_id)` — the first two parameters were swapped, causing `'str' object has no attribute 'fetchrow'` and returning `None`.

## Evidence of fix

```
HTTP STATUS: 200
entity_type: warranty
entity_text: 'Warranty: Test Claim | ref: WC-2026-002 | status: draft | Testing from Postman'
count: 5
status: success
```

Real DB, real JWT, real endpoint. Verified locally before pushing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)