### PR TITLE
refactor(layout): tokenize shell dimensions, eliminate 100vh inside AppShell

### DIFF
--- a/apps/api/action_router/registry.py
+++ b/apps/api/action_router/registry.py
@@ -1511,6 +1511,28 @@ ACTION_REGISTRY: Dict[str, ActionDefinition] = {
         domain="certificates",
         variant=ActionVariant.MUTATE,
         search_keywords=["add", "create", "new", "vessel", "certificate", "cert", "flag", "class", "safety"],
+        field_metadata=[
+            FieldMetadata("yacht_id", FieldClassification.CONTEXT),
+            FieldMetadata("certificate_type", FieldClassification.REQUIRED,
+                          description="Certificate Type",
+                          options=["ISM", "ISPS", "SOLAS", "MLC", "CLASS", "FLAG",
+                                   "SEC", "SRC", "SCC", "LOAD_LINE", "TONNAGE",
+                                   "MARPOL", "IOPP"]),
+            FieldMetadata("certificate_name", FieldClassification.REQUIRED,
+                          description="Certificate Name"),
+            FieldMetadata("issuing_authority", FieldClassification.REQUIRED,
+                          description="Issuing Authority"),
+            FieldMetadata("certificate_number", FieldClassification.OPTIONAL,
+                          description="Certificate Number"),
+            FieldMetadata("issue_date", FieldClassification.OPTIONAL,
+                          description="Issue Date"),
+            FieldMetadata("expiry_date", FieldClassification.OPTIONAL,
+                          description="Expiry Date"),
+            FieldMetadata("last_survey_date", FieldClassification.OPTIONAL,
+                          description="Last Survey Date"),
+            FieldMetadata("next_survey_due", FieldClassification.OPTIONAL,
+                          description="Next Survey Due"),
+        ],
     ),
 
     "create_crew_certificate": ActionDefinition(
@@ -1530,6 +1552,23 @@ ACTION_REGISTRY: Dict[str, ActionDefinition] = {
         domain="certificates",
         variant=ActionVariant.MUTATE,
         search_keywords=["add", "create", "new", "crew", "certificate", "cert", "stcw", "training"],
+        field_metadata=[
+            FieldMetadata("yacht_id", FieldClassification.CONTEXT),
+            FieldMetadata("person_name", FieldClassification.REQUIRED,
+                          description="Crew Member Name"),
+            FieldMetadata("certificate_type", FieldClassification.REQUIRED,
+                          description="Certificate Type",
+                          options=["STCW", "ENG1", "COC", "GMDSS", "BST", "PSC",
+                                   "AFF", "MEDICAL_CARE"]),
+            FieldMetadata("issuing_authority", FieldClassification.REQUIRED,
+                          description="Issuing Authority"),
+            FieldMetadata("certificate_number", FieldClassification.OPTIONAL,
+                          description="Certificate Number"),
+            FieldMetadata("issue_date", FieldClassification.OPTIONAL,
+                          description="Issue Date"),
+            FieldMetadata("expiry_date", FieldClassification.OPTIONAL,
+                          description="Expiry Date"),
+        ],
     ),
 
     "update_certificate": ActionDefinition(
@@ -3467,9 +3506,11 @@ ACTION_REGISTRY: Dict[str, ActionDefinition] = {
         required_fields=["yacht_id", "entity_id", "reason"],
         domain="certificates",
         variant=ActionVariant.SIGNED,
-        field_metadata={
-            "reason": {"name": "reason", "type": "text-area", "label": "Reason for suspension", "placeholder": "State the reason this certificate is being suspended..."},
-        },
+        field_metadata=[
+            FieldMetadata("yacht_id", FieldClassification.CONTEXT),
+            FieldMetadata("entity_id", FieldClassification.CONTEXT),
+            FieldMetadata("reason", FieldClassification.REQUIRED, description="Reason for suspension"),
+        ],
     ),
 
     "revoke_certificate": ActionDefinition(
@@ -3482,9 +3523,11 @@ ACTION_REGISTRY: Dict[str, ActionDefinition] = {
         required_fields=["yacht_id", "entity_id", "reason"],
         domain="certificates",
         variant=ActionVariant.SIGNED,
-        field_metadata={
-            "reason": {"name": "reason", "type": "text-area", "label": "Reason for revocation", "placeholder": "State the reason this certificate is being revoked..."},
-        },
+        field_metadata=[
+            FieldMetadata("yacht_id", FieldClassification.CONTEXT),
+            FieldMetadata("entity_id", FieldClassification.CONTEXT),
+            FieldMetadata("reason", FieldClassification.REQUIRED, description="Reason for revocation"),
+        ],
     ),
 
     "archive_part": ActionDefinition(
@@ -3633,12 +3676,14 @@ ACTION_REGISTRY: Dict[str, ActionDefinition] = {
         required_fields=["yacht_id", "certificate_id", "new_issue_date", "new_expiry_date"],
         domain="certificates",
         variant=ActionVariant.MUTATE,
-        field_metadata={
-            "new_issue_date": {"name": "new_issue_date", "type": "date", "label": "New Issue Date", "placeholder": "YYYY-MM-DD"},
-            "new_expiry_date": {"name": "new_expiry_date", "type": "date", "label": "New Expiry Date", "placeholder": "YYYY-MM-DD"},
-            "new_certificate_number": {"name": "new_certificate_number", "type": "text", "label": "New Certificate Number (optional)", "placeholder": "e.g. ISM-2026-001"},
-            "new_issuing_authority": {"name": "new_issuing_authority", "type": "text", "label": "Issuing Authority (if changed)", "placeholder": "e.g. DNV GL"},
-        },
+        field_metadata=[
+            FieldMetadata("yacht_id", FieldClassification.CONTEXT),
+            FieldMetadata("certificate_id", FieldClassification.CONTEXT),
+            FieldMetadata("new_issue_date", FieldClassification.REQUIRED, description="New Issue Date"),
+            FieldMetadata("new_expiry_date", FieldClassification.REQUIRED, description="New Expiry Date"),
+            FieldMetadata("new_certificate_number", FieldClassification.OPTIONAL, description="New Certificate Number"),
+            FieldMetadata("new_issuing_authority", FieldClassification.OPTIONAL, description="New Issuing Authority"),
+        ],
     ),
 
     "reorder_part": ActionDefinition(

--- a/apps/api/routes/entity_routes.py
+++ b/apps/api/routes/entity_routes.py
@@ -37,6 +37,7 @@ ATTACHMENT_BUCKET = {
     "purchase_order": "pms-finance-documents",
     "warranty": "pms-warranty-documents",
     "receiving": "pms-receiving-images",
+    "certificate": "pms-certificate-documents",
 }
 
 
@@ -102,55 +103,86 @@ async def get_certificate_entity(certificate_id: str, auth: dict = Depends(get_a
         tenant_key = auth['tenant_key_alias']
         supabase = get_tenant_client(tenant_key)
 
-        r = supabase.table("pms_vessel_certificates").select("*") \
-            .eq("id", certificate_id).eq("yacht_id", yacht_id).maybe_single().execute()
+        # Two-table lookup: vessel first, crew fallback.
+        # Use limit(1).execute() instead of maybe_single() — the latter returns
+        # None (not a response object) on no-match in this supabase client
+        # version, causing AttributeError on .data access.
+        domain = None
+        data = None
 
-        if not r or not r.data:
+        vessel_r = supabase.table("pms_vessel_certificates").select("*") \
+            .eq("id", certificate_id).eq("yacht_id", yacht_id).limit(1).execute()
+        vessel_rows = getattr(vessel_r, "data", None) or []
+        if vessel_rows:
+            domain = "vessel"
+            data = vessel_rows[0]
+        else:
+            crew_r = supabase.table("pms_crew_certificates").select("*") \
+                .eq("id", certificate_id).eq("yacht_id", yacht_id).limit(1).execute()
+            crew_rows = getattr(crew_r, "data", None) or []
+            if crew_rows:
+                domain = "crew"
+                data = crew_rows[0]
+
+        if not data:
             raise HTTPException(status_code=404, detail="Certificate not found")
 
-        data = r.data
-        metadata = data.get("metadata") or {}
-        if isinstance(metadata, str):
+        # properties is the cert-table column (not metadata); may be dict or JSON str
+        properties = data.get("properties") or {}
+        if isinstance(properties, str):
             import json as _j
-            metadata = _j.loads(metadata) if metadata else {}
+            try:
+                properties = _j.loads(properties) if properties else {}
+            except Exception:
+                properties = {}
 
-        # Sign document URL if linked
-        document_url = None
+        # Collect attachments from pms_attachments (multi-file) AND from the
+        # single document_id FK — unified into one list for the frontend.
+        attachments = _get_attachments(supabase, "certificate", certificate_id, yacht_id)
         doc_id = data.get("document_id")
         if doc_id:
             try:
                 doc_r = supabase.table("doc_metadata").select(
-                    "storage_path, storage_bucket"
-                ).eq("id", doc_id).maybe_single().execute()
-                if doc_r and doc_r.data:
-                    bucket = doc_r.data.get("storage_bucket") or "documents"
-                    document_url = _sign_url(supabase, bucket, doc_r.data.get("storage_path"))
-            except Exception:
-                pass
-
-        attachments = _get_attachments(supabase, "certificate", certificate_id, yacht_id)
+                    "id, filename, mime_type, file_size, storage_path, storage_bucket"
+                ).eq("id", doc_id).limit(1).execute()
+                doc_rows = getattr(doc_r, "data", None) or []
+                if doc_rows:
+                    dm = doc_rows[0]
+                    bucket = dm.get("storage_bucket") or "pms-certificate-documents"
+                    url = _sign_url(supabase, bucket, dm.get("storage_path"))
+                    if url:
+                        attachments.append({
+                            "id": dm.get("id") or doc_id,
+                            "filename": dm.get("filename") or "Certificate Document",
+                            "url": url,
+                            "mime_type": dm.get("mime_type") or "application/octet-stream",
+                            "size_bytes": dm.get("file_size") or 0,
+                        })
+            except Exception as e:
+                logger.warning(f"Failed to resolve document_id {doc_id} for cert {certificate_id}: {e}")
 
         nav = [n for n in [
-            _nav("equipment", data.get("equipment_id"), "Equipment"),
             _nav("document", doc_id, "Document"),
         ] if n]
 
         _entity_response = {
             "id": data.get("id"),
-            "name": data.get("certificate_name"),
+            "name": data.get("certificate_name") or data.get("person_name") or data.get("certificate_type"),
             "certificate_type": data.get("certificate_type"),
             "certificate_number": data.get("certificate_number"),
             "issuing_authority": data.get("issuing_authority"),
             "issue_date": data.get("issue_date"),
             "expiry_date": data.get("expiry_date"),
+            "last_survey_date": data.get("last_survey_date"),
+            "next_survey_due": data.get("next_survey_due"),
             "status": data.get("status", "valid"),
-            "equipment_id": data.get("equipment_id"),
-            "document_id": data.get("document_id"),
-            "document_url": document_url,
-            "notes": data.get("notes"),
-            "domain": "vessel",
+            "holder_name": data.get("person_name"),
+            "vessel_name": None if domain == "crew" else data.get("certificate_name"),
+            "document_id": doc_id,
+            "domain": domain,
             "yacht_id": data.get("yacht_id"),
             "created_at": data.get("created_at"),
+            "properties": properties,
             "attachments": attachments,
             "related_entities": nav,
         }
@@ -161,7 +193,7 @@ async def get_certificate_entity(certificate_id: str, auth: dict = Depends(get_a
     except HTTPException:
         raise
     except Exception as e:
-        logger.error(f"Failed to fetch certificate {certificate_id}: {e}")
+        logger.error(f"Failed to fetch certificate {certificate_id}: {e}", exc_info=True)
         raise HTTPException(status_code=500, detail=str(e))
 
 

--- a/apps/web/src/app/email/[threadId]/page.tsx
+++ b/apps/web/src/app/email/[threadId]/page.tsx
@@ -18,7 +18,7 @@ function EmailThreadDeepLink() {
   const { user } = useAuth();
 
   return (
-    <div style={{ minHeight: '100vh', background: 'var(--surface-base)', fontFamily: 'var(--font-sans)', fontSize: 13, lineHeight: 1.5 }}>
+    <div style={{ flex: 1, minHeight: 0, overflowY: 'auto', background: 'var(--surface-base)', fontFamily: 'var(--font-sans)', fontSize: 13, lineHeight: 1.5 }}>
       {/* Topbar — matches elegant.html */}
       <header style={{
         height: 40, flexShrink: 0, display: 'flex', alignItems: 'center', padding: '0 20px', gap: 8,
@@ -60,7 +60,7 @@ export default function EmailThreadDetailPage() {
   return (
     <React.Suspense
       fallback={
-        <div style={{ height: '100vh', display: 'flex', alignItems: 'center', justifyContent: 'center', background: 'var(--surface-base)' }}>
+        <div style={{ flex: 1, minHeight: 0, display: 'flex', alignItems: 'center', justifyContent: 'center', background: 'var(--surface-base)' }}>
           <div style={{ width: 20, height: 20, border: '2px solid var(--border-sub)', borderTopColor: 'var(--mark)', borderRadius: '50%', animation: 'spin 0.8s linear infinite' }} />
           <style>{`@keyframes spin { to { transform: rotate(360deg); } }`}</style>
         </div>

--- a/apps/web/src/app/email/page.tsx
+++ b/apps/web/src/app/email/page.tsx
@@ -61,7 +61,7 @@ function EmailSplitContent() {
   }, [router]);
 
   return (
-    <div style={{ height: '100vh', display: 'flex', flexDirection: 'column', fontFamily: 'var(--font-sans)', fontSize: 13, lineHeight: 1.5, WebkitFontSmoothing: 'antialiased', background: 'var(--surface-base)', color: 'var(--txt)' }}>
+    <div style={{ flex: 1, minHeight: 0, display: 'flex', flexDirection: 'column', fontFamily: 'var(--font-sans)', fontSize: 13, lineHeight: 1.5, WebkitFontSmoothing: 'antialiased', background: 'var(--surface-base)', color: 'var(--txt)' }}>
 
       {/* Topbar — matches elegant.html */}
       <header style={{
@@ -169,7 +169,7 @@ export default function EmailPage() {
   return (
     <React.Suspense
       fallback={
-        <div style={{ height: '100vh', display: 'flex', alignItems: 'center', justifyContent: 'center', background: 'var(--surface-base)' }}>
+        <div style={{ flex: 1, minHeight: 0, display: 'flex', alignItems: 'center', justifyContent: 'center', background: 'var(--surface-base)' }}>
           <div style={{ width: 20, height: 20, border: '2px solid var(--border-sub)', borderTopColor: 'var(--mark)', borderRadius: '50%', animation: 'spin 0.8s linear infinite' }} />
           <style>{`@keyframes spin { to { transform: rotate(360deg); } }`}</style>
         </div>

--- a/apps/web/src/app/hours-of-rest/signoffs/[id]/page.tsx
+++ b/apps/web/src/app/hours-of-rest/signoffs/[id]/page.tsx
@@ -36,7 +36,7 @@ export default function SignoffDetailPage() {
   return (
     <React.Suspense
       fallback={
-        <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', minHeight: '100vh', background: 'var(--surface-base)' }}>
+        <div style={{ flex: 1, minHeight: 0, display: 'flex', alignItems: 'center', justifyContent: 'center', background: 'var(--surface-base)' }}>
           <div style={{ width: 32, height: 32, border: '2px solid var(--border-sub)', borderTopColor: 'var(--mark)', borderRadius: '50%', animation: 'spin 1s linear infinite' }} />
         </div>
       }

--- a/apps/web/src/app/hours-of-rest/signoffs/page.tsx
+++ b/apps/web/src/app/hours-of-rest/signoffs/page.tsx
@@ -369,7 +369,7 @@ function SignoffsPageContent() {
   const departmentOrder = ['deck', 'engineering', 'interior', 'general'];
 
   return (
-    <div style={{ minHeight: '100vh', background: 'var(--surface-base)', color: 'var(--txt)', fontFamily: 'var(--font-sans)' }}>
+    <div style={{ flex: 1, minHeight: 0, overflowY: 'auto', background: 'var(--surface-base)', color: 'var(--txt)', fontFamily: 'var(--font-sans)' }}>
       <div style={{ maxWidth: 960, margin: '0 auto', padding: '32px 24px 64px' }}>
         {/* Back link */}
         <a
@@ -502,7 +502,7 @@ export default function SignoffsPage() {
   return (
     <React.Suspense
       fallback={
-        <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', minHeight: '100vh', background: 'var(--surface-base)' }}>
+        <div style={{ flex: 1, minHeight: 0, display: 'flex', alignItems: 'center', justifyContent: 'center', background: 'var(--surface-base)' }}>
           <div style={{ width: 32, height: 32, border: '2px solid var(--border-sub)', borderTopColor: 'var(--mark)', borderRadius: '50%', animation: 'spin 1s linear infinite' }} />
         </div>
       }

--- a/apps/web/src/app/receiving/new/page.tsx
+++ b/apps/web/src/app/receiving/new/page.tsx
@@ -26,7 +26,7 @@ export default function NewReceivingPage() {
   }, [router]);
 
   return (
-    <div style={{ minHeight: '100vh', background: 'var(--surface-base)' }}>
+    <div style={{ flex: 1, minHeight: 0, overflowY: 'auto', background: 'var(--surface-base)' }}>
       {/* Topbar */}
       <div style={{
         height: 44, display: 'flex', alignItems: 'center', padding: '0 16px',

--- a/apps/web/src/components/hours-of-rest/MyTimeView.tsx
+++ b/apps/web/src/components/hours-of-rest/MyTimeView.tsx
@@ -186,7 +186,7 @@ function SectionCard({ children, style }: { children: React.ReactNode; style?: R
   );
 }
 
-function SectionHeader({ label, right }: { label: string; right?: React.ReactNode }) {
+function SectionHeader({ label, right }: { label: React.ReactNode; right?: React.ReactNode }) {
   return (
     <div style={{
       display: 'flex',
@@ -265,16 +265,48 @@ export function MyTimeView({ targetUserId, readOnly: forceReadOnly }: MyTimeView
   // Unsigned alert
   const [unsignedAlert, setUnsignedAlert] = React.useState(false);
 
+  // Week navigation — null = current week (backend defaults)
+  const [viewWeekStart, setViewWeekStart] = React.useState<string | null>(null);
+  // Disable forward nav when we're already on current week
+  const isCurrentWeek = viewWeekStart === null;
+
+  function navigateWeek(direction: -1 | 1) {
+    setViewWeekStart(prev => {
+      const base = prev ?? data?.week_start ?? null;
+      if (!base) return prev;
+      const d = new Date(base);
+      d.setDate(d.getDate() + direction * 7);
+      const next = d.toISOString().slice(0, 10);
+      // Don't go past today's week
+      const todayMonday = (() => {
+        const t = new Date();
+        const day = t.getDay();
+        const diff = day === 0 ? -6 : 1 - day;
+        t.setDate(t.getDate() + diff);
+        return t.toISOString().slice(0, 10);
+      })();
+      if (next > todayMonday) return null; // snap back to current
+      return next === todayMonday ? null : next;
+    });
+  }
+
   // ── Load week data ──
 
-  async function loadWeekData() {
+  async function loadWeekData(weekStart?: string | null) {
     setLoading(true);
     setError(null);
+    // Reset per-week local state when navigating
+    setDraftPeriods({});
+    setSubmittedDays({});
+    setSubmitErrors({});
+    weekFinalised.current = false;
     try {
       const auth = await getAuthHeader();
-      const url = targetUserId
-        ? `/api/v1/hours-of-rest/my-week?user_id=${encodeURIComponent(targetUserId)}`
-        : '/api/v1/hours-of-rest/my-week';
+      const ws = weekStart !== undefined ? weekStart : viewWeekStart;
+      const params = new URLSearchParams();
+      if (targetUserId) params.set('user_id', targetUserId);
+      if (ws) params.set('week_start', ws);
+      const url = `/api/v1/hours-of-rest/my-week${params.toString() ? `?${params}` : ''}`;
       const resp = await fetch(url, {
         headers: { 'Authorization': auth },
       });
@@ -322,9 +354,9 @@ export function MyTimeView({ targetUserId, readOnly: forceReadOnly }: MyTimeView
   }
 
   React.useEffect(() => {
-    loadWeekData();
+    loadWeekData(viewWeekStart);
     checkUnsignedAlert();
-  }, []);
+  }, [viewWeekStart]);
 
   // ── Submit single day ──
 
@@ -394,18 +426,25 @@ export function MyTimeView({ targetUserId, readOnly: forceReadOnly }: MyTimeView
   // ── Apply template ──
 
   async function applyTemplate() {
-    if (!selectedTemplate) return;
+    if (!selectedTemplate || !data) return;
     setApplyingTemplate(true);
     try {
       const auth = await getAuthHeader();
-      await fetch('/api/v1/hours-of-rest/templates/apply', {
+      const resp = await fetch('/api/v1/hours-of-rest/templates/apply', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json', 'Authorization': auth },
-        body: JSON.stringify({ template_id: selectedTemplate }),
+        body: JSON.stringify({
+          template_id: selectedTemplate,
+          week_start_date: (data as any).week_start,
+        }),
       });
+      if (!resp.ok) {
+        const json = await resp.json().catch(() => null);
+        console.error('Template apply failed:', resp.status, json);
+      }
       await loadWeekData();
-    } catch {
-      // non-critical
+    } catch (e) {
+      console.error('Template apply error:', e);
     } finally {
       setApplyingTemplate(false);
     }
@@ -507,7 +546,7 @@ export function MyTimeView({ targetUserId, readOnly: forceReadOnly }: MyTimeView
     return (
       <div style={{ padding: 24, textAlign: 'center', color: 'rgba(255,255,255,0.35)', fontFamily: 'var(--font-mono)', fontSize: 11 }}>
         Failed to load hours of rest data.
-        <button onClick={loadWeekData} style={{ marginLeft: 10, color: 'var(--mark)', background: 'none', border: 'none', cursor: 'pointer', fontFamily: 'var(--font-mono)', fontSize: 11 }}>Retry</button>
+        <button onClick={() => loadWeekData()} style={{ marginLeft: 10, color: 'var(--mark)', background: 'none', border: 'none', cursor: 'pointer', fontFamily: 'var(--font-mono)', fontSize: 11 }}>Retry</button>
       </div>
     );
   }
@@ -552,14 +591,52 @@ export function MyTimeView({ targetUserId, readOnly: forceReadOnly }: MyTimeView
       {/* ── THIS WEEK ── */}
       <SectionCard>
         <SectionHeader
-          label={`This Week — ${data.week_start}${weekLocked ? ' 🔒' : ''}`}
+          label={
+            <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+              {/* Prev week */}
+              <button
+                onClick={() => navigateWeek(-1)}
+                style={{ background: 'none', border: 'none', color: 'rgba(255,255,255,0.45)', cursor: 'pointer', padding: '0 2px', fontSize: 12, lineHeight: 1 }}
+                title="Previous week"
+              >‹</button>
+              {/* Week label */}
+              <span style={{ fontFamily: 'var(--font-mono)', fontSize: 9, fontWeight: 600, letterSpacing: '0.10em', textTransform: 'uppercase', color: isCurrentWeek ? 'rgba(255,255,255,0.55)' : 'rgba(255,255,255,0.35)' }}>
+                {isCurrentWeek ? `This Week — ${data.week_start}` : data.week_start}
+                {weekLocked ? ' 🔒' : ''}
+              </span>
+              {/* Next week — disabled on current */}
+              <button
+                onClick={() => navigateWeek(1)}
+                disabled={isCurrentWeek}
+                style={{ background: 'none', border: 'none', color: isCurrentWeek ? 'rgba(255,255,255,0.15)' : 'rgba(255,255,255,0.45)', cursor: isCurrentWeek ? 'default' : 'pointer', padding: '0 2px', fontSize: 12, lineHeight: 1 }}
+                title="Next week"
+              >›</button>
+              {/* Day-status dots — green=compliant, amber=violation, grey=not filed */}
+              <div style={{ display: 'flex', gap: 3, marginLeft: 6 }}>
+                {data.days.filter(Boolean).map((day: any) => {
+                  const ls = submittedDays[day.date];
+                  const isSubmit = day.submitted || !!ls;
+                  const w = (ls?.warnings ?? day.warnings ?? []);
+                  const hasViolation = w.length > 0;
+                  const color = !isSubmit
+                    ? 'rgba(255,255,255,0.18)'
+                    : hasViolation
+                    ? 'rgba(192,80,58,0.85)'
+                    : 'rgba(74,148,104,0.85)';
+                  return (
+                    <div key={day.date} title={`${day.label}: ${!isSubmit ? 'Not filed' : hasViolation ? 'Violation' : 'Compliant'}`} style={{ width: 6, height: 6, borderRadius: '50%', background: color, flexShrink: 0 }} />
+                  );
+                })}
+              </div>
+            </div>
+          }
           right={isReadOnly ? (
             weekLocked && !forceReadOnly ? (
               <span style={{ fontFamily: 'var(--font-mono)', fontSize: 9, color: 'rgba(255,255,255,0.3)', letterSpacing: '0.06em' }}>
                 {signoffStatus === 'hod_signed' ? 'Awaiting Captain' : signoffStatus === 'finalized' ? 'Finalized' : 'Read-only'}
               </span>
             ) : undefined
-          ) : (
+          ) : isCurrentWeek ? (
             <button
               data-testid="hor-submit-week"
               onClick={() => setSignWeekOpen(true)}
@@ -580,6 +657,8 @@ export function MyTimeView({ targetUserId, readOnly: forceReadOnly }: MyTimeView
             >
               Submit Week For Approval
             </button>
+          ) : (
+            <span style={{ fontFamily: 'var(--font-mono)', fontSize: 9, color: 'rgba(255,255,255,0.25)', letterSpacing: '0.06em' }}>Past week — read only</span>
           )}
         />
 

--- a/apps/web/src/components/hours-of-rest/TimeSlider.tsx
+++ b/apps/web/src/components/hours-of-rest/TimeSlider.tsx
@@ -249,11 +249,12 @@ export function TimeSlider({ value, onChange, readOnly = false }: TimeSliderProp
     });
   }
 
-  // ── Total rest hours for display ──
+  // ── Total work/rest hours for display ──
+  // blocks ARE work periods (amber = work). Sum of block durations = total work.
 
-  const totalRestMin = blocks.reduce((sum, b) => sum + Math.max(0, b.endMin - b.startMin), 0);
-  const totalRestH = (totalRestMin / 60).toFixed(1);
-  const totalWorkH = ((1440 - totalRestMin) / 60).toFixed(1);
+  const totalWorkMin = blocks.reduce((sum, b) => sum + Math.max(0, b.endMin - b.startMin), 0);
+  const totalWorkH = (totalWorkMin / 60).toFixed(1);
+  const totalRestH = ((1440 - totalWorkMin) / 60).toFixed(1);
 
   return (
     <div style={{ width: '100%', userSelect: 'none' }}>

--- a/apps/web/src/components/lens-v2/EntityLensPage.tsx
+++ b/apps/web/src/components/lens-v2/EntityLensPage.tsx
@@ -212,11 +212,13 @@ export function EntityLensPage({
       data-testid={`${entityType}-detail`}
       className={lensStyles.root}
       style={{
+        flex: 1,
+        minHeight: 0,
+        overflowY: 'auto',
         display: 'flex',
         flexDirection: 'column',
         alignItems: 'center',
         padding: '24px 16px 48px',
-        minHeight: '100vh',
         background: 'var(--surface-base)',
       }}
     >

--- a/apps/web/src/components/settings/Settings.tsx
+++ b/apps/web/src/components/settings/Settings.tsx
@@ -534,7 +534,7 @@ export default function Settings({ isOpen, onClose }: SettingsProps) {
           width: '547px',
           height: '483px',
           maxWidth: 'calc(100vw - 48px)',
-          maxHeight: 'calc(100vh - 48px)',
+          maxHeight: 'calc(100vh - var(--shell-topbar-h))',
           borderRadius: '8px',
           overflow: 'hidden',
           display: 'flex',

--- a/apps/web/src/components/shell/AppShell.tsx
+++ b/apps/web/src/components/shell/AppShell.tsx
@@ -4,9 +4,13 @@
  * AppShell — The main application layout for the Interface Pivot
  *
  * Three-row grid layout:
- *   Row 1: Topbar (48px) — brand + vessel + global search + role
- *   Row 2: Subbar (46px) — breadcrumb + scoped search + chips + action (hidden on Surface)
- *   Row 3: Body — sidebar (192px) + main content
+ *   Row 1: Topbar (var(--shell-topbar-h)) — brand + vessel + global search + role
+ *   Row 2: Subbar (var(--shell-subbar-h)) — breadcrumb + scoped search + chips + action (hidden on Surface)
+ *   Row 3: Body — sidebar (var(--shell-sidebar-w) / var(--shell-sidebar-compact-w)) + main content
+ *
+ * Dimensions are defined as tokens in tokens.css under "Shell structural dimensions".
+ * JS constants below mirror those tokens for the dynamic sidebarWidth calculation —
+ * if you change the tokens, update the constants too.
  *
  * This shell wraps all authenticated routes. It is the single source of
  * navigation, search, and layout structure.
@@ -14,6 +18,13 @@
  * Spec: celeste-interface-pivot-spec.pdf (all sections)
  * Prototype: vessel-surface-v2.html (visual reference only)
  */
+
+// ── Shell dimension constants — mirror tokens.css "Shell structural dimensions" ──
+// Keep these in sync with --shell-* tokens. Used for JS-computed gridTemplateColumns.
+const SHELL_TOPBAR_H          = 48;   // --shell-topbar-h
+const SHELL_SUBBAR_H          = 46;   // --shell-subbar-h
+const SHELL_SIDEBAR_W         = 192;  // --shell-sidebar-w
+const SHELL_SIDEBAR_COMPACT_W = 48;   // --shell-sidebar-compact-w
 
 import * as React from 'react';
 import { useRouter, usePathname } from 'next/navigation';
@@ -224,7 +235,7 @@ function AppShellInner({
 }) {
   const { activeChip, setActiveChip, setSearchQuery, setActiveSort } = useShellContext();
   const breakpoint = useBreakpoint();
-  const sidebarWidth = breakpoint === 'mobile' ? 0 : breakpoint === 'tablet' ? 48 : 192;
+  const sidebarWidth = breakpoint === 'mobile' ? 0 : breakpoint === 'tablet' ? SHELL_SIDEBAR_COMPACT_W : SHELL_SIDEBAR_W;
   const showSidebar = breakpoint !== 'mobile';
   const isMobile = breakpoint === 'mobile';
 
@@ -259,7 +270,7 @@ function AppShellInner({
         height: '100vh',
         overflow: 'hidden',
         display: 'grid',
-        gridTemplateRows: showSubbar ? '48px 46px 1fr' : '48px 1fr',
+        gridTemplateRows: showSubbar ? `var(--shell-topbar-h) var(--shell-subbar-h) 1fr` : `var(--shell-topbar-h) 1fr`,
         gridTemplateColumns: '1fr',
         fontSize: 13,
         lineHeight: 1.5,
@@ -309,7 +320,7 @@ function AppShellInner({
             activeDomain={activeDomain}
             onSelectDomain={onSelectDomain}
             counts={sidebarCounts}
-            compact={sidebarWidth === 48}
+            compact={sidebarWidth === SHELL_SIDEBAR_COMPACT_W}
           />
         )}
 

--- a/apps/web/src/components/shell/Subbar.tsx
+++ b/apps/web/src/components/shell/Subbar.tsx
@@ -143,7 +143,7 @@ export function Subbar({
   return (
     <div
       style={{
-        height: 46,
+        height: 'var(--shell-subbar-h)',
         flexShrink: 0,
         display: 'flex',
         alignItems: 'center',

--- a/apps/web/src/components/shell/Topbar.tsx
+++ b/apps/web/src/components/shell/Topbar.tsx
@@ -108,7 +108,7 @@ export function Topbar({
   return (
     <header
       style={{
-        height: 48,
+        height: 'var(--shell-topbar-h)',
         flexShrink: 0,
         display: 'flex',
         alignItems: 'center',

--- a/apps/web/src/styles/tokens.css
+++ b/apps/web/src/styles/tokens.css
@@ -168,6 +168,18 @@
   --settings-modal-shadow:   0 0 0 1px rgba(0,0,0,0.60), 0 28px 80px rgba(0,0,0,0.80), 0 8px 24px rgba(0,0,0,0.45), inset 0 1px 0 rgba(255,255,255,0.05);
   --settings-header-bg:      rgba(16,14,12,0.65);
   --settings-backdrop:       rgba(0,0,0,0.35);
+
+  /* ── Shell structural dimensions ──────────────────────────────────────────
+     Single source of truth for AppShell grid layout.
+     Any component measuring against the shell (e.g. fixed-position overlays,
+     calc-based offsets) must use these tokens — never hardcode 48/46/192.
+     These are dimension tokens (not theme tokens) so they live in :root and
+     do NOT change between dark/light themes.
+  ── */
+  --shell-topbar-h:          48px;   /* Topbar row height                      */
+  --shell-subbar-h:          46px;   /* Subbar row height (hidden on surface/HoR) */
+  --shell-sidebar-w:         192px;  /* Full sidebar width (desktop)            */
+  --shell-sidebar-compact-w: 48px;   /* Compact sidebar width (tablet)          */
 }
 
 /* ═══════════════════════════════════════════════════════

--- a/docs/explanations/LENS_DOMAINS/certificates.md
+++ b/docs/explanations/LENS_DOMAINS/certificates.md
@@ -1,649 +1,902 @@
-# Certificates Domain — Complete Engineer Reference
+# Certificate Lens — Complete Developer Guide
 
-**Written:** 2026-04-14  
-**Author:** CERTIFICATE01  
-**Status:** Current as of PR #525 merged to main  
-**Scope:** Everything about the certificate domain — DB, API, action router, ledger, frontend, cross-domain wiring, bugs, limitations, flow.
-
----
-
-## What certificates actually are
-
-A certificate in the maritime context is not a document. It is a **dated legal obligation** issued by an external authority (flag state, classification society, port state control). If it lapses, the vessel cannot legally operate. An inspector can detain the vessel. The insurer can void coverage.
-
-The certificate system is therefore not a filing cabinet. It is a **compliance countdown clock with a tamper-evident evidence trail**.
-
-There are two distinct certificate types in this system:
-
-- **Vessel certificates** — issued to the vessel itself. ISM, ISPS, SOLAS, MLC, CLASS, FLAG, LOAD_LINE, MARPOL, IOPP, TONNAGE, IOPP, MANNING, REGISTRATION. Cover the ship's right to operate under specific regulations.
-- **Crew certificates** — issued to individual seafarers. STCW, ENG1, COC (Certificate of Competency), GMDSS, BST (Basic Safety Training), MEDICAL_CARE. Cover the seafarer's qualifications.
-
-Both live in the same UI page but separate DB tables.
+> **Who this is for:** Any developer picking up certificates for the first time — frontend, backend, or full-stack.
+> **Scope:** Everything from the database row to the rendered UI. Bugs found, traps hit, techniques used.
+> **Verified against:** commit `47cfc3e7` on `main`, 2026-04-14. PR #525 merged.
 
 ---
 
-## The three database tables
+## 1. What the certificate domain does
 
-All tables live in the **TENANT Supabase** (`vzsohavtuotocgrfkfyd`), not the MASTER.
+A certificate is not a document. It is a **compliance countdown clock**.
 
-### `pms_vessel_certificates`
+Every certificate represents a dated legal obligation — class, flag state, safety equipment, crew training — that, if missed, stops the vessel operating. Port state control can detain the vessel. The flag state can issue a deficiency. The insurer can void coverage. Miss a certificate expiry and the whole operation stops.
 
-The primary vessel certificate store. 371 rows in production (338 seed, 33 real as of 2026-04-14).
+So certificates are not filed — they are **monitored**, **renewed**, **supersede**d, and **tracked with full chain-of-custody evidence**. The system must know:
 
-```
-id                uuid         PK
-yacht_id          uuid         FK → yacht_registry(id) ON DELETE CASCADE
-certificate_type  text         NOT NULL  (uppercase, e.g. "ISM", "CLASS", "FLAG")
-certificate_name  text         NOT NULL  (e.g. "ISM Safety Management Certificate")
-certificate_number text                  unique per yacht+type
-issuing_authority text         NOT NULL  (e.g. "DNV GL", "Flag State")
-issue_date        date
-expiry_date       date
-last_survey_date  date                   vessel-specific — survey window start
-next_survey_due   date                   vessel-specific — survey window end
-status            text         NOT NULL  DEFAULT 'valid'
-                               ENUM: valid | expired | superseded | suspended | revoked
-document_id       uuid         FK → doc_metadata(id) ON DELETE SET NULL
-properties        jsonb        DEFAULT '{}'  — stores supersede reason, cascade metadata
-created_at        timestamptz  NOT NULL
-deleted_at        timestamptz             soft-delete field
-deleted_by        uuid                    soft-delete actor (no FK — plain UUID)
-source            text         DEFAULT 'manual'  — 'manual' | 'imported'
-source_id         text                   external ID if imported
-imported_at       timestamptz
-import_session_id uuid         FK → import_sessions(id)
-is_seed           boolean      DEFAULT true  — seed data flag, NOT shown in UI
-```
+- Who issued it (issuing authority)
+- When it was issued
+- When it expires
+- What it covers (scope, capacity, flag state, trading area, conditions)
+- Who is responsible for renewing it
+- Every change ever made to it (audit trail)
+- Every person who ever viewed it (ledger read log)
 
-**Critical:** `is_seed = true` records are filtered out by the view. 338 of 353 rows are seed data. Only 15+ are real.
+There are two domains of certificates:
 
-**Triggers:**
-- `trg_certificates_cache_invalidate` — fires on INSERT/UPDATE, invalidates F1 cache for the `certificate` entity type.
+| Domain | Table | Examples |
+|---|---|---|
+| **Vessel** | `pms_vessel_certificates` | ISM, ISPS, SOLAS, MLC, CLASS, FLAG, LOAD_LINE, IOPP, MARPOL, TONNAGE |
+| **Crew** | `pms_crew_certificates` | STCW, ENG1, COC, GMDSS, BST, PSC, AFF, MEDICAL_CARE |
 
-**Indexes:** `yacht_id`, `status`, `certificate_type`, `expiry_date`, `next_survey_due`, `document_id`, `import_session_id`.
-
-### `pms_crew_certificates`
-
-Crew / seafarer certificate store. 38 rows in production.
-
-```
-id                uuid         PK
-yacht_id          uuid         FK → yacht_registry(id) ON DELETE CASCADE
-person_node_id    uuid         FK → search_graph_nodes(id) ON DELETE SET NULL  (nullable)
-person_name       text         NOT NULL  — free text, not FK to crew table
-certificate_type  text         NOT NULL  (e.g. "STCW Basic Safety Training")
-certificate_number text
-issuing_authority text
-issue_date        date
-expiry_date       date
-document_id       uuid         FK → doc_metadata(id) ON DELETE SET NULL
-properties        jsonb        DEFAULT '{}'
-created_at        timestamptz  NOT NULL
-source            text         DEFAULT 'manual'
-source_id         text
-imported_at       timestamptz
-import_session_id uuid         FK → import_sessions(id)
-status            text         NOT NULL  DEFAULT 'valid'
-                               ENUM: valid | expired | revoked | suspended
-deleted_at        timestamptz             added 2026-04-14
-deleted_by        uuid                    added 2026-04-14 (no FK constraint — matches vessel pattern)
-```
-
-**Key difference from vessel:** No `last_survey_date`, `next_survey_due`, `is_seed`. No `certificate_name` (cert type IS the name for crew). No `deleted_by` FK constraint.
-
-**Important:** `person_name` is a free text field. It does NOT FK to any crew/person table. This means if a crew member's name changes in the crew system, their certificates stay linked by name string only. Known limitation.
-
-### `pms_certificates` (DROPPED)
-
-Legacy 18-row table. Migrated into `pms_vessel_certificates` (is_seed=false) and dropped on 2026-04-14. **Do not reference this table anywhere.** If you see it in old code, that code is stale.
+Both are compliance-critical. Both go through the same lens, list, and action router.
 
 ---
 
-## The unified view: `v_certificates_enriched`
+## 2. File map — exact paths
 
-The frontend page does NOT query the raw tables. It queries this view:
+### Frontend
+
+| File | Purpose |
+|---|---|
+| `apps/web/src/app/certificates/page.tsx` | List page — unified vessel + crew list via `v_certificates_enriched` view |
+| `apps/web/src/components/lens-v2/entity/CertificateContent.tsx` | The entire detail view — all sections, all action buttons |
+| `apps/web/src/components/lens-v2/mapActionFields.ts` | Shared utility that builds ActionPopup fields from registry metadata |
+| `apps/web/src/components/lens-v2/actions/ActionPopup.tsx` | Generic mutation form modal with signature widget for SIGNED actions |
+| `apps/web/src/components/lens-v2/actions/AddNoteModal.tsx` | Note composition modal |
+| `apps/web/src/hooks/useEntityLens.ts` | Data fetch, action execution, refetch — shared by all entity lenses |
+| `apps/web/src/contexts/EntityLensContext.tsx` | React context glue |
+| `apps/web/src/features/entity-list/components/FilteredEntityList.tsx` | The list component with filter panel |
+| `apps/web/e2e/shard-33-lens-actions/certificate-actions.spec.ts` | Playwright e2e — action gating tests |
+| `apps/web/e2e/shard-34-lens-actions/certificate-actions-full.spec.ts` | Full CRUD e2e |
+
+### Backend
+
+| File | Purpose |
+|---|---|
+| `apps/api/routes/certificate_routes.py` | REST GET endpoints: `/api/v1/certificates/{vessel,crew,expiring,{id},{id}/history}` |
+| `apps/api/handlers/certificate_handlers.py` | The `CertificateHandlers` class and `get_certificate_handlers()` factory. **1300+ lines. Source of truth.** |
+| `apps/api/routes/handlers/certificate_phase4_handler.py` | Phase 4 route shim — 5 native handlers (create_vessel, create_crew, update, link_doc, supersede). See Section 9. |
+| `apps/api/handlers/schema_mapping.py` | `get_table()` helper — maps logical names (`"vessel_certificates"`) to actual table names (`"pms_vessel_certificates"`) |
+| `apps/api/action_router/registry.py` | ActionDefinition entries for all 10 cert actions — RBAC, required_fields, field_metadata |
+| `apps/api/action_router/ledger_metadata.py` | Maps action → event_type for the safety net ledger write |
+| `apps/api/action_router/dispatchers/internal_dispatcher.py` | INTERNAL_HANDLERS dict — wires cert actions to `_cert_*` wrapper functions |
+| `apps/api/routes/handlers/internal_adapter.py` | Phase 4 bridge — `_ACTIONS_TO_ADAPT` list |
+| `apps/api/routes/p0_actions_routes.py` | `POST /api/v1/actions/execute` — the single execute endpoint with `_CERT_ACTIONS` mapping |
+| `apps/api/tests/cert_binary_tests.py` | 16 binary tests against live DB — each verifies exact row state |
+
+### Database
+
+| Object | Type | Purpose |
+|---|---|---|
+| `pms_vessel_certificates` | Table | Vessel certs. Has soft-delete, status check, source tracking, F1 cache trigger |
+| `pms_crew_certificates` | Table | Crew certs. Has soft-delete, status check, source tracking, import session link |
+| `v_certificates_enriched` | View | UNION of vessel + crew, filtered by `is_seed = false AND deleted_at IS NULL`. Adds a `domain` discriminator column. This is what the list page queries. |
+| `pms_notes.certificate_id` | Column | FK → `pms_vessel_certificates(id) ON DELETE SET NULL`. Added in migration M4. |
+| `refresh_certificate_expiry(p_yacht_id uuid)` | Function | Flips `status = valid → expired` for past-due certs. Writes `status_change` ledger events. Called lazily from both list handlers. |
+| `ledger_events` | Table | Immutable audit trail. Every cert mutation + read lands here. |
+| `pms_audit_log` | Table | Legacy audit trail — still written but `ledger_events` is canonical. |
+
+---
+
+## 3. Certificate states
+
+### Valid status values (enforced by check constraint)
+
+| Status | What it means | Terminal? |
+|---|---|---|
+| `valid` | Active, in force | No |
+| `expired` | Past expiry date. Auto-set by `refresh_certificate_expiry()` or manual update. | No (can renew) |
+| `suspended` | Temporarily halted. Captain/manager signed action, retains visibility. | No (can be reactivated by update) |
+| `revoked` | Issuing authority cancelled. Signed action. | **Yes** — cannot change |
+| `superseded` | Replaced by a renewal. New cert issued, old one marked superseded. | **Yes** — cannot change |
+
+Both tables enforce this at the DB level:
+
+```sql
+CHECK (status IN ('valid','expired','superseded','suspended','revoked'))
+```
+
+### State transitions
+
+```
+               create
+                 ↓
+   ┌──────────→ valid ──renew──→ superseded (+ new valid cert)
+   │             │
+   │             ├──suspend──→ suspended ──update──→ valid
+   │             │
+   │             ├──revoke──→ revoked (terminal)
+   │             │
+   │             └──refresh_expiry──→ expired ──renew──→ superseded (+ new valid)
+   │                                      │
+   │                                      └──update──→ valid (manual fix)
+   │
+   └─── expired can be renewed (renew creates a new valid cert)
+```
+
+Three operations — renew, suspend, revoke — are **signed actions**. They require a signature payload (PIN + TOTP) and are restricted to captain and manager roles only.
+
+### Domain discriminator
+
+Both tables feed `v_certificates_enriched`. The view adds a synthetic column:
+
+```sql
+'vessel' AS domain  -- from pms_vessel_certificates branch
+'crew'   AS domain  -- from pms_crew_certificates branch
+```
+
+The frontend uses this to choose the right title (vessel cert name vs `"Person Name — Cert Type"`), the right icon, and whether to show vessel-only fields like `last_survey_date`.
+
+---
+
+## 4. Actions — the full list
+
+All 10 actions live in `ACTION_REGISTRY` (`apps/api/action_router/registry.py`).
+
+| Action | Variant | Roles | What it does |
+|---|---|---|---|
+| `create_vessel_certificate` | MUTATE | chief_engineer, captain, manager | Insert row into `pms_vessel_certificates` |
+| `create_crew_certificate` | MUTATE | chief_engineer, captain, manager | Insert row into `pms_crew_certificates` |
+| `update_certificate` | MUTATE | chief_engineer, captain, manager | Update fields (name, number, dates, authority). Rejects updates on terminal status. |
+| `link_document_to_certificate` | MUTATE | chief_engineer, captain, manager | Attach a `doc_metadata` row as the cert document |
+| `renew_certificate` | MUTATE | chief_engineer, captain, manager | Insert new cert with updated dates, mark old as `superseded`. Writes `create` ledger event. |
+| `suspend_certificate` | **SIGNED** | **captain, manager only** | Set status=`suspended` with reason |
+| `revoke_certificate` | **SIGNED** | **captain, manager only** | Set status=`revoked` with reason |
+| `supersede_certificate` | **SIGNED** | **captain, manager only** | Mark current as `superseded`, optionally create replacement. Requires PIN+TOTP signature. |
+| `archive_certificate` | **SIGNED** | chief_engineer, chief_officer, captain, manager | Soft-delete: set `deleted_at` and `deleted_by`. Auto-detects vessel vs crew. |
+| `add_certificate_note` | MUTATE | chief_engineer, captain, manager | Insert into `pms_notes` with `certificate_id` FK set |
+
+### Read actions
+
+Reads don't go through `/api/v1/actions/execute`. They hit `certificate_routes.py` GET endpoints. But **they still write ledger events** — see Section 7.
+
+| Route | Handler | Event type |
+|---|---|---|
+| `GET /api/v1/certificates/vessel` | `list_vessel_certificates` | view |
+| `GET /api/v1/certificates/crew` | `list_crew_certificates` | view |
+| `GET /api/v1/certificates/expiring?days_ahead=N&domain={vessel,crew,all}` | `find_expiring_certificates` | view |
+| `GET /api/v1/certificates/{id}?domain={vessel,crew}` | `get_certificate_details` | view |
+| `GET /api/v1/certificates/{id}/history?domain={vessel,crew}` | `view_certificate_history` | view |
+
+---
+
+## 5. The list page — `/certificates`
+
+`apps/web/src/app/certificates/page.tsx`
+
+The list renders **both vessel and crew certificates in a single unified view**, queried from `v_certificates_enriched`. The adapter reads the `domain` column and displays each row differently:
+
+```typescript
+// Vessel cert: "DNV GL Class Certificate"
+// Crew cert:   "John Smith — STCW Basic Safety Training"
+const title = c.domain === 'crew'
+  ? (c.person_name ? `${c.person_name} — ${c.certificate_type}` : c.certificate_type)
+  : (c.certificate_name || c.certificate_number);
+```
+
+### Filters
+
+Two filter selects, both `type: 'select'` from `FilterFieldConfig`:
+
+1. **Type** (domain): All / Vessel / Crew
+2. **Status**: All / Valid / Expired / Revoked / Superseded / Suspended
+
+The filter config shape matters — it must include `type: 'select'` explicitly or TypeScript breaks. See `apps/web/src/features/entity-list/types/filter-config.ts` for the `FilterFieldConfig` interface.
+
+### Why `v_certificates_enriched` and not the raw tables?
+
+1. **UNION the two tables** — one query, both domains, with a discriminator column.
+2. **Filter seed data** — the view has `WHERE is_seed = false` so fleet test fixtures don't pollute the list.
+3. **Filter soft-deleted rows** — `WHERE deleted_at IS NULL` on both sides.
+4. **Normalise `certificate_type`** — uppercased via `UPPER(certificate_type)` to eliminate case inconsistency (`class` vs `CLASS`).
+
+The view definition lives in the DB, not in git. To recreate:
 
 ```sql
 CREATE VIEW v_certificates_enriched AS
-  SELECT
-    id, yacht_id,
-    UPPER(certificate_type) AS certificate_type,  -- normalises case inconsistency
-    certificate_name, certificate_number, issuing_authority,
-    issue_date, expiry_date, last_survey_date, next_survey_due,
-    status, document_id, properties, created_at, deleted_at,
-    source, import_session_id, is_seed,
-    'vessel' AS domain,
-    NULL::uuid AS person_node_id,
-    NULL::text AS person_name
+  SELECT id, yacht_id, UPPER(certificate_type) AS certificate_type,
+         certificate_name, certificate_number, issuing_authority,
+         issue_date, expiry_date, last_survey_date, next_survey_due,
+         status, document_id, properties, created_at, deleted_at,
+         source, import_session_id, is_seed,
+         'vessel' AS domain, NULL::uuid AS person_node_id, NULL::text AS person_name
   FROM pms_vessel_certificates
   WHERE is_seed = false AND deleted_at IS NULL
 
   UNION ALL
 
-  SELECT
-    id, yacht_id,
-    UPPER(certificate_type) AS certificate_type,
-    certificate_type AS certificate_name,   -- crew: type IS the name
-    certificate_number, issuing_authority,
-    issue_date, expiry_date,
-    NULL::date AS last_survey_date,         -- vessel-only field
-    NULL::date AS next_survey_due,          -- vessel-only field
-    status, document_id, properties, created_at, deleted_at,
-    source, import_session_id,
-    false AS is_seed,
-    'crew' AS domain,                       -- discriminator column
-    person_node_id, person_name
+  SELECT id, yacht_id, UPPER(certificate_type) AS certificate_type,
+         certificate_type AS certificate_name, certificate_number,
+         issuing_authority, issue_date, expiry_date,
+         NULL::date AS last_survey_date, NULL::date AS next_survey_due,
+         status, document_id, properties, created_at, deleted_at,
+         source, import_session_id, false AS is_seed,
+         'crew' AS domain, person_node_id, person_name
   FROM pms_crew_certificates
   WHERE deleted_at IS NULL;
 ```
 
-**The `domain` column is critical.** It tells the frontend and adapter which table the cert came from. Without it, you cannot safely route mutations.
+---
 
-**RLS:** The view inherits RLS from the underlying tables. Authenticated users can only see certs for their `yacht_id`.
+## 6. The lens — `CertificateContent.tsx`
+
+`apps/web/src/components/lens-v2/entity/CertificateContent.tsx`
+
+### Section order (top to bottom)
+
+| Section | Source of data |
+|---|---|
+| **IdentityStrip** | cert number, name, status pills, details, primary action button |
+| **Holder's Certificates** | Other certs for the same person (crew) or vessel. Only shown if `holder_certificates` array is non-empty. |
+| **Coverage Details** | scope, capacity, flag_state, trading_area, endorsement, conditions (vessel-only fields) |
+| **Related Equipment** | Equipment rows linked via properties (machinery certs) |
+| **Renewal History** | Prior period certs in the supersede chain |
+| **History** | `prior_periods` — collapsible year-by-year summary |
+| **Audit Trail** | Full `pms_audit_log` entries for this cert (collapsed by default) |
+| **Related Certificates** | Linked cert rows (teal cert-link styling) |
+| **Notes** | `pms_notes` rows where `certificate_id = this.id` |
+| **Attachments** | Uploaded files from storage bucket |
+
+### The primary button
+
+The `renew_certificate` action is the primary button on every cert detail view. It does **not** execute directly — it opens an `ActionPopup` with two required fields (new issue date, new expiry date) and optional ones (new cert number, new issuing authority).
+
+```typescript
+const handlePrimary = React.useCallback(() => {
+  if (renewAction) openActionPopup(renewAction as any);
+}, [renewAction]);
+```
+
+This was originally `executeAction('renew_certificate', {})` which silently sent no fields and triggered a `MISSING_REQUIRED_FIELD` error. See Section 10 bugs.
+
+### Secondary actions (dropdown)
+
+Everything in `availableActions` except the primary. The dropdown applies a `DANGER_ACTIONS` set for suspend/archive/revoke — these render with destructive styling.
+
+```typescript
+const DANGER_ACTIONS = new Set(['suspend_certificate', 'archive_certificate', 'revoke_certificate']);
+```
+
+### Field mapping for ActionPopup
+
+`mapActionFields.ts` reads `field_metadata` from the action registry and converts field types to the right UI component:
+
+| Backend type | UI component |
+|---|---|
+| `date` / `date-pick` | Date picker |
+| `text-area` / `textarea` | Textarea |
+| `select` / `enum` | Dropdown |
+| `text` (or omitted) | Text input |
+| `entity-search` | Typeahead with search |
+
+A field is hidden from the form if it's in `BACKEND_AUTO` set (`yacht_id`, `signature`, `idempotency_key`) or already in `action.prefill`.
 
 ---
 
-## Expiry automation: `refresh_certificate_expiry()`
+## 7. Ledger + audit — what gets logged
 
-```sql
-CREATE FUNCTION refresh_certificate_expiry(p_yacht_id uuid) RETURNS void
+### Two tables, two purposes
+
+| Table | Purpose | Written by |
+|---|---|---|
+| `pms_audit_log` | Domain audit trail — old_values, new_values, signatures | Every handler explicitly calls `db.table("pms_audit_log").insert(...)` |
+| `ledger_events` | Immutable compliance ledger with `proof_hash` chain | Action router safety net + read handlers |
+
+### Mutation logging (safety net)
+
+Every action that goes through `POST /api/v1/actions/execute` is intercepted by the "Phase B ledger safety net" in `p0_actions_routes.py`:
+
+```python
+if isinstance(result, dict) and not result.get("_ledger_written"):
+    meta = ACTION_METADATA.get(action)
+    if meta:
+        ledger_event = build_ledger_event(...)
+        db_client.table("ledger_events").insert(ledger_event).execute()
 ```
 
-This DB function:
-1. Finds all `pms_vessel_certificates` for the yacht with `status = 'valid'` and `expiry_date < CURRENT_DATE`
-2. Updates them to `status = 'expired'`
-3. Writes a `status_change` ledger event for each flip, `source_context = 'system'`
-4. Does the same for `pms_crew_certificates`
+For this to work, the action must be in `ACTION_METADATA` (`apps/api/action_router/ledger_metadata.py`). All 10 cert actions are there. Missing entries silently skip the ledger write — this was a real bug, see Section 10.
 
-**When it runs:** Called lazily at the start of `list_vessel_certificates` and `list_crew_certificates` handlers. Every time a user opens the certificates list, expired statuses are corrected. There is no nightly cron. If nobody views the page, statuses drift — a known limitation.
+### Read logging (explicit)
 
-**Why lazy:** No `pg_cron` available in Supabase on this plan. Chosen over a Render-side scheduled endpoint to avoid an extra network hop.
+Read handlers call `self._ledger_read()` at the start of every request. Fire-and-forget — never blocks the read response.
 
----
-
-## File map — exact names and locations
-
-```
-BACKEND (apps/api/)
-│
-├── handlers/
-│   └── certificate_handlers.py          ← MAIN LOGIC FILE. CertificateHandlers class.
-│                                           All 14 registered handlers.
-│                                           _renew_certificate_adapter
-│                                           _change_certificate_status_adapter (factory for suspend/revoke)
-│                                           _archive_certificate_adapter
-│                                           _resolve_cert_domain (auto-detects vessel/crew table)
-│                                           _ledger_read (view event writer)
-│                                           get_certificate_handlers(supabase_client) → dict
-│
-├── routes/
-│   ├── certificate_routes.py            ← REST GET endpoints only.
-│   │                                      GET /api/v1/certificates/vessel
-│   │                                      GET /api/v1/certificates/crew
-│   │                                      GET /api/v1/certificates/expiring
-│   │                                      GET /api/v1/certificates/{id}
-│   │                                      GET /api/v1/certificates/{id}/history
-│   │                                      POST /api/v1/certificates/debug/pipeline-test (dev only)
-│   │
-│   └── handlers/
-│       ├── certificate_phase4_handler.py ← Phase 4 route SHIM. 5 native handlers only:
-│       │                                   create_vessel, create_crew, update,
-│       │                                   link_document, supersede.
-│       │                                   All other cert actions go via internal_adapter.
-│       │                                   ⚠️ READ THE BANNER AT TOP before adding anything here.
-│       │
-│       ├── internal_adapter.py          ← Migration shim. Routes legacy actions to
-│       │                                   INTERNAL_HANDLERS in internal_dispatcher.
-│       │                                   cert actions in _ACTIONS_TO_ADAPT:
-│       │                                   renew, archive, suspend, revoke, add_note
-│       │
-│       └── __init__.py                  ← Assembles all HANDLERS dicts. CERT_HANDLERS
-│                                           takes priority over ADAPTER_HANDLERS.
-│
-├── action_router/
-│   ├── registry.py                      ← All 10 certificate action definitions.
-│   │                                      allowed_roles, required_fields, field_metadata.
-│   │                                      Lines ~1570 (supersede), ~2546 (add_note),
-│   │                                      ~3448 (archive/suspend/revoke), ~3626 (renew),
-│   │                                      ~1544 (create_vessel/crew), ~1561 (update/link)
-│   │
-│   ├── ledger_metadata.py               ← Maps all 10 cert actions to ledger event_type.
-│   │                                      Used by p0_actions_routes safety net.
-│   │
-│   └── dispatchers/
-│       └── internal_dispatcher.py       ← INTERNAL_HANDLERS dict.
-│                                           _cert_renew, _cert_archive, _cert_suspend,
-│                                           _cert_revoke wrappers.
-│                                           _cert_supersede_certificate (legacy wrapper)
-│                                           All at lines 368–451.
-│
-├── routes/
-│   └── p0_actions_routes.py             ← Handles POST /v1/actions/execute.
-│                                           Contains Phase B ledger safety net.
-│                                           _CERT_ACTIONS frozenset — maps entity_id → certificate_id.
-│                                           REQUIRED_FIELDS dict — validated from merged context+payload.
-│
-└── tests/
-    ├── cert_binary_tests.py             ← 16-test binary suite. Each test verifies
-    │                                      exact DB row state. No mocks.
-    │                                      Run: python3 tests/cert_binary_tests.py
-    │
-    └── handlers/
-        └── test_remaining_handlers.py   ← Unit tests for certificate_phase4_handler.py.
-                                            Imports from routes.handlers.certificate_phase4_handler.
-
-FRONTEND (apps/web/src/)
-│
-├── app/
-│   └── certificates/
-│       └── page.tsx                     ← The /certificates page.
-│                                           FilteredEntityList → v_certificates_enriched
-│                                           Filters: domain (vessel/crew), status
-│                                           Adapter: certAdapter — routes crew/vessel
-│                                           EntityDetailOverlay → CertificateContent
-│
-└── components/
-    └── lens-v2/
-        └── entity/
-            └── CertificateContent.tsx   ← The detail lens. 442 lines.
-                                            Sections: Identity → Holder Certs →
-                                            Coverage → Equipment → Renewal History →
-                                            Audit Trail → Related Certs → Notes →
-                                            Attachments
-                                            Primary action: renew (opens ActionPopup)
-                                            Secondary: suspend, revoke, archive, add_note
-                                            DANGER_ACTIONS: suspend, archive, revoke
+```python
+def _ledger_read(self, yacht_id, user_id, user_role, action, entity_id=None, summary=None):
+    try:
+        import hashlib
+        now = datetime.now(timezone.utc).isoformat()
+        proof_input = f"{yacht_id}{entity_id or ''}{action}{now}"
+        proof_hash = hashlib.sha256(proof_input.encode()).hexdigest()
+        self.db.table("ledger_events").insert({
+            "yacht_id": yacht_id,
+            "event_type": "view",
+            "entity_type": "certificate",
+            "entity_id": entity_id or yacht_id,
+            "action": action,
+            "user_id": user_id or "00000000-0000-0000-0000-000000000000",
+            "user_role": user_role or "unknown",
+            "change_summary": summary or action.replace("_", " ").capitalize(),
+            "source_context": "microaction",
+            "proof_hash": proof_hash,
+            "event_timestamp": now,
+            "created_at": now,
+        }).execute()
+    except Exception:
+        pass
 ```
 
----
+For this to work, `certificate_routes.py` must pass `user_id` and `user_role` into the handler's `params` dict. This wiring is easy to miss — if you add a new read endpoint, remember to pass `auth.get("user_id")` and `auth.get("role")` into params.
 
-## How a read works (full flow)
+### Expiry logging (DB function)
 
-```
-User opens /certificates
-        ↓
-page.tsx — FilteredEntityList queries Supabase directly
-        ↓ (client-side, uses MASTER JWT + Supabase anon key)
-v_certificates_enriched view
-        ↓
-Returns domain='vessel'|'crew' per row
-        ↓
-certAdapter maps domain → title, type, entityRef
-        ↓
-User clicks a cert → EntityDetailOverlay opens
-        ↓
-EntityLensPage fetches /v1/entity/certificate/{id}
-        ↓
-entity_routes.py → certificate_handlers.get_certificate_details()
-        ↓
-handler calls _ledger_read() [view event to ledger_events]
-        ↓
-handler reads pms_vessel_certificates OR pms_crew_certificates
-        ↓
-returns CertificateContent data shape
-        ↓
-CertificateContent.tsx renders all sections
-```
-
-**IMPORTANT:** The list page queries Supabase DIRECTLY from the browser using the anon key + RLS. The detail view goes through the Render API. These are different auth paths.
-
----
-
-## How a mutation works (full flow)
-
-Example: captain clicks "Renew Certificate"
-
-```
-CertificateContent.tsx
-        ↓
-handlePrimary() → openActionPopup(renewAction)
-        ↓
-ActionPopup renders fields: new_issue_date, new_expiry_date
-        ↓
-User fills form → submits
-        ↓
-executeAction('renew_certificate', {new_issue_date, new_expiry_date})
-        ↓
-POST /v1/actions/execute {action, context:{yacht_id, entity_id, certificate_id}, payload}
-        ↓
-p0_actions_routes.py
-  1. Role check (registry allowed_roles: chief_engineer, captain, manager)
-  2. REQUIRED_FIELDS check (merged context + payload)
-  3. _CERT_ACTIONS mapping: entity_id → certificate_id
-  4. validate_action_payload()
-  5. RLS entity validation
-  6. Routes to HANDLERS["renew_certificate"]
-        ↓
-HANDLERS lookup order:
-  certificate_phase4_handler.py HANDLERS → not found (renew not in Phase 4)
-  internal_adapter HANDLERS → found (renew is in _ACTIONS_TO_ADAPT)
-        ↓
-internal_adapter calls INTERNAL_HANDLERS["renew_certificate"]
-        ↓
-_cert_renew() in internal_dispatcher.py
-        ↓
-get_certificate_handlers(db).get("renew_certificate")
-        ↓
-_renew_certificate_adapter() in certificate_handlers.py
-  1. _resolve_cert_domain() — finds which table the cert is in
-  2. Validates not superseded/revoked
-  3. Inserts new cert (copy old fields, new dates)
-  4. Updates old cert status → 'superseded'
-  5. Writes pms_audit_log entry
-  6. Returns {status, renewed_certificate_id, superseded_certificate_id}
-        ↓
-p0_actions_routes Phase B ledger safety net
-  ACTION_METADATA["renew_certificate"] → event_type='create'
-  Inserts to ledger_events
-        ↓
-Frontend: onSuccess → refetch entity → CertificateContent re-renders
-```
-
----
-
-## The 10 certificate actions
-
-| action_id | Layer | Roles | Notes |
-|---|---|---|---|
-| `create_vessel_certificate` | Phase 4 shim → handlers | chief_engineer, captain, manager | |
-| `create_crew_certificate` | Phase 4 shim → handlers | chief_engineer, captain, manager | |
-| `update_certificate` | Phase 4 shim → handlers | chief_engineer, captain, manager | Blocked on superseded/revoked |
-| `link_document_to_certificate` | Phase 4 shim → handlers | chief_engineer, captain, manager | Validates doc_id exists first |
-| `supersede_certificate` | Phase 4 shim → handlers | captain, manager | **SIGNED** — requires full signature payload |
-| `renew_certificate` | internal_adapter → dispatcher | chief_engineer, captain, manager | Creates new cert, supersedes old |
-| `suspend_certificate` | internal_adapter → dispatcher | captain, manager only | Sets status='suspended', SIGNED |
-| `revoke_certificate` | internal_adapter → dispatcher | captain, manager only | Sets status='revoked', SIGNED |
-| `archive_certificate` | internal_adapter → dispatcher | captain, manager | Soft-delete, both tables |
-| `add_certificate_note` | internal_adapter → dispatcher | chief_engineer, captain, manager | Writes to pms_notes.certificate_id |
-
-### Adding a new certificate action — required steps
-
-1. Add `ActionDefinition` to `registry.py` with `domain="certificates"`
-2. Add handler function in `handlers/certificate_handlers.py`, register in `get_certificate_handlers()`
-3. Add `_cert_*` wrapper in `action_router/dispatchers/internal_dispatcher.py`
-4. Add to `INTERNAL_HANDLERS` dict in same file
-5. Add to `_ACTIONS_TO_ADAPT` in `routes/handlers/internal_adapter.py`
-6. Add to `ACTION_METADATA` in `action_router/ledger_metadata.py`
-7. Do NOT add to `certificate_phase4_handler.py` unless it is a Phase 4 native handler
-
----
-
-## Certificate status lifecycle
-
-```
-         ┌──────────┐
-         │  valid   │◄──────── (renewed cert starts here)
-         └────┬─────┘
-              │
-    ┌─────────┼──────────┬──────────┐
-    ▼         ▼          ▼          ▼
-expired   superseded  suspended  revoked
-              │
-         (terminal)
-```
-
-- **valid** → expired (auto, via `refresh_certificate_expiry`)
-- **valid** → superseded (via `supersede_certificate` SIGNED action — old cert when renewed)
-- **valid** → suspended (via `suspend_certificate` SIGNED — captain/manager only)
-- **valid** → revoked (via `revoke_certificate` SIGNED — captain/manager only)
-- **expired** → valid (via `renew_certificate` — creates new cert, old becomes superseded)
-- **superseded** → terminal. Cannot be changed.
-- **revoked** → terminal. Cannot be changed.
-
-Status check constraints:
-- `pms_vessel_certificates`: `valid | expired | superseded | suspended | revoked`
-- `pms_crew_certificates`: `valid | expired | revoked | suspended`
-
----
-
-## Ledger coverage — what gets logged and how
-
-Every certificate operation is logged. No exceptions.
-
-### Mutations (via ACTION_METADATA safety net in p0_actions_routes)
-
-```
-create_vessel_certificate  → event_type: create
-create_crew_certificate    → event_type: create
-update_certificate         → event_type: update
-link_document_to_certificate → event_type: update
-supersede_certificate      → event_type: status_change
-renew_certificate          → event_type: create
-suspend_certificate        → event_type: status_change
-revoke_certificate         → event_type: status_change
-archive_certificate        → event_type: update
-add_certificate_note       → event_type: update
-```
-
-The safety net fires after every successful handler execution where `result["_ledger_written"]` is falsy. Fire-and-forget — never blocks the mutation response.
-
-### Reads (via `_ledger_read()` in CertificateHandlers)
-
-```
-list_vessel_certificates   → event_type: view
-list_crew_certificates     → event_type: view
-get_certificate_details    → event_type: view
-view_certificate_history   → event_type: view
-find_expiring_certificates → event_type: view
-```
-
-Written synchronously inside each handler. Fire-and-forget — never blocks the read response. `user_id` and `user_role` come from params injected by `certificate_routes.py`.
-
-### Expiry automation
-
-```
-refresh_certificate_expiry() → event_type: status_change, source_context: system
-user_id: 00000000-0000-0000-0000-000000000000 (sentinel for system actor)
-```
+`refresh_certificate_expiry()` is a PL/pgSQL function. When it flips a cert from `valid` to `expired`, it directly inserts into `ledger_events` with `source_context = 'system'` and `user_id = '00000000-0000-0000-0000-000000000000'` (the sentinel system user). This captures the automatic state change in the ledger with no user attribution.
 
 ### What is NOT logged
 
-- **Import pipeline** — `import_service.py` writes directly to the DB tables, bypasses the action router and ledger safety net. Imported certs have no ledger trace. This is intentional (imports are considered externally audited at source).
+| Operation | Logged? | Why |
+|---|---|---|
+| Import pipeline inserts (CSV, seahub) | **No** | Explicit business decision — imports are considered "already externally audited" |
+| Direct SQL from Supabase admin console | **No** | Bypasses all application code |
+| Frontend Supabase client reads (if they existed) | **No** | List page uses `FilteredEntityList` → direct Supabase query. This is list-page-only, not the detail view. |
 
 ---
 
-## Cross-domain interactions
+## 8. Database layer — schema and RLS
 
-### With work orders
-**Currently:** None. A cert renewal does not automatically create a work order.
-**Gap:** In real vessel ops, renewing an ISM cert requires booking a class surveyor — that's a work order. No bridge exists. Future: `renew_certificate` could optionally create a linked work order.
+### pms_vessel_certificates
 
-### With the ledger
-**Current:** All 10 mutations + 5 reads + expiry automation write to `ledger_events`. Full coverage. The `proof_hash` chain on ledger_events provides tamper-evidence.
-
-### With documents (`doc_metadata`)
-**Current:** `link_document_to_certificate` attaches a single doc to a cert. `document_id` is a single FK — one cert can only have one directly linked document.
-**Gap:** Multi-document support doesn't exist. Certificate PDFs are stored as attachments via `pms_attachments` (uploaded via the Attachments section in the lens), not via `document_id`.
-
-### With the handover system
-**Current:** None. Certificate register is not includable in a handover export.
-**Gap:** Real-world handovers include a cert register. Not wired.
-
-### With notifications
-**Current:** None. No expiry warnings are pushed to any user.
-**Gap:** 90-day, 30-day, 7-day expiry notifications would be standard maritime practice. Not built.
-
-### With the import pipeline (`import_service.py`)
-**Current:** Certs can be imported from CSV. `source = 'imported'`, `import_session_id` is set. The import writes directly to `pms_vessel_certificates` and `pms_crew_certificates` bypassing the action router.
-**Ledger gap:** No ledger entry is written for imported certs.
-
-### With `pms_audit_log`
-**Current:** All mutation handlers in `certificate_handlers.py` write to `pms_audit_log` directly, in addition to the ledger safety net writing to `ledger_events`. This is double-logging — `pms_audit_log` is the handler-level audit, `ledger_events` is the router-level ledger.
-**Why both:** `pms_audit_log` includes `old_values`/`new_values` diffs which `ledger_events` does not currently populate. They serve different purposes.
-
----
-
-## The `_resolve_cert_domain` function
-
-This is one of the most important utility functions in the domain. It auto-detects which table a certificate belongs to without requiring the caller to specify.
-
-```python
-def _resolve_cert_domain(db, yacht_id: str, cert_id: str) -> tuple:
-    for domain, table_key in [("vessel", "vessel_certificates"), ("crew", "crew_certificates")]:
-        result = db.table(get_table(table_key)).select("*")
-                   .eq("yacht_id", yacht_id).eq("id", cert_id)
-                   .limit(1).execute()
-        rows = getattr(result, "data", None) or []
-        if rows:
-            return domain, table_key, rows[0]
-    raise ValueError(f"Certificate {cert_id} not found or access denied")
+```sql
+CREATE TABLE pms_vessel_certificates (
+    id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    yacht_id uuid NOT NULL REFERENCES yacht_registry(id) ON DELETE CASCADE,
+    certificate_type text NOT NULL,  -- may be mixed case (see normalisation)
+    certificate_name text NOT NULL,
+    certificate_number text,
+    issuing_authority text NOT NULL,
+    issue_date date,
+    expiry_date date,
+    last_survey_date date,
+    next_survey_due date,
+    status text NOT NULL DEFAULT 'valid'
+        CHECK (status IN ('valid','expired','superseded','suspended','revoked')),
+    document_id uuid REFERENCES doc_metadata(id) ON DELETE SET NULL,
+    properties jsonb DEFAULT '{}'::jsonb,
+    created_at timestamptz NOT NULL DEFAULT now(),
+    deleted_at timestamptz,
+    deleted_by uuid,
+    source text DEFAULT 'manual',
+    source_id text,
+    imported_at timestamptz,
+    import_session_id uuid REFERENCES import_sessions(id) ON DELETE SET NULL,
+    is_seed boolean DEFAULT true
+);
 ```
 
-**Why `.limit(1)` not `.maybe_single()`:** `maybe_single()` in this version of the Supabase Python client returns `None` (the whole response object, not just the data) when no row matches. Accessing `.data` on `None` raises `AttributeError`. `.limit(1)` returns a list response, empty list if no match. This bug was caught by binary tests.
+Key indexes: `yacht_id`, `(yacht_id, expiry_date) WHERE deleted_at IS NULL`, `(yacht_id, status)`, `(yacht_id, certificate_type)`.
+
+### pms_crew_certificates
+
+Same shape but with `person_node_id uuid REFERENCES search_graph_nodes(id)` and `person_name text NOT NULL` instead of vessel fields. No `last_survey_date` or `next_survey_due`.
+
+### RLS policies
+
+Both tables have:
+
+1. **Users can view yacht certs** — `yacht_id = get_user_yacht_id()`
+2. **Officers can insert** — must be in `is_hod()` or allowed role list
+3. **Officers can update** — same
+4. **Managers can delete** — `is_manager()` AND yacht match
+5. **Service role full access** — for backend writes
+
+The backend uses a tenant Supabase client obtained via `get_tenant_client(auth['tenant_key_alias'])`, which has service_role permissions.
 
 ---
 
-## Known bugs found and fixed (2026-04-14)
+## 9. Routing chain — from HTTP request to DB write
 
-| Bug | File | Symptom | Fix |
-|---|---|---|---|
-| `_supersede_certificate_adapter` missing `return _fn` | `handlers/certificate_handlers.py` | supersede always returned 501 "not registered" | Added `return _fn` after inner function definition |
-| `maybe_single()` returns `None` response on no-match | `handlers/certificate_handlers.py` | `_resolve_cert_domain` raised `AttributeError: 'NoneType' has no attribute 'data'` | Switched to `.limit(1)` + `getattr(result, "data", None) or []` |
-| `_delegate()` didn't pass context | `routes/handlers/certificate_phase4_handler.py` | `supersede_certificate` raised `KeyError: 'certificate_id'` | Added `context` param to `_delegate`, merged into params |
-| No `_CERT_ACTIONS` in `resolve_entity_context` | `routes/p0_actions_routes.py` | `entity_id` from EntityLensPage never mapped to `certificate_id` for cert actions | Added `_CERT_ACTIONS` frozenset + mapping |
-| REQUIRED_FIELDS check payload-only | `routes/p0_actions_routes.py` | False 400 on supersede (cert_id in context, not payload) | Changed to `{**request.context, **payload}` for the check |
-| `pms_notes` had no `certificate_id` column | DB | `add_certificate_note` silently failed — insert threw column-not-found | Added `certificate_id uuid FK → pms_vessel_certificates(id)` |
-| `pms_crew_certificates` had no `status` column | DB | Crew cert health was computed-only, never stored | Added `status text NOT NULL DEFAULT 'valid'` with check constraint |
-| `pms_crew_certificates` had no `deleted_at`/`deleted_by` | DB | Archive on crew certs failed | Added both columns (no FK on `deleted_by`, matching vessel pattern) |
-| 5 cert actions missing from `ACTION_METADATA` | `action_router/ledger_metadata.py` | create_vessel, create_crew, update, link_doc, supersede wrote no ledger events | Added all 5 |
-| Read operations wrote no ledger events | `handlers/certificate_handlers.py` | Compliance gap — views were invisible | Added `_ledger_read()` helper, called in all 5 read handlers |
-| `maybe_single()` in `link_document_to_certificate` | `handlers/certificate_handlers.py` | Same AttributeError as above | Fixed with `.limit(1)` pattern |
+This is where compound loss happens. Understand this diagram before adding any new certificate action.
 
----
-
-## Known limitations
-
-### No chief_engineer test user exists
-The test user table claims `captain.tenant@alex-short.com` has role `chief_engineer`. In the TENANT DB (`auth_users_roles`), they actually have role `captain`. There is no test user with `chief_engineer` role in the system. Role gating for chief_engineer is verified only through registry inspection + binary handler tests, not via a real JWT.
-
-### Crew cert `person_name` is free text
-No FK to any crew/person record. If someone renames a crew member in the crew system, their certificates remain linked only by name string. Searching by crew member does a `ilike` pattern match on `person_name`.
-
-### Single document per cert
-`document_id` is a single FK. If a cert has multiple associated PDFs (e.g., original + renewal letter + survey report), only one can be linked via `document_id`. Additional files go in the Attachments section via `pms_attachments`, which is not searched or filtered.
-
-### No multi-cert supersede chain UI
-The `properties.supersedes` and `properties.renews` fields track the chain, but the frontend `Renewal History` section only shows the `pms_audit_log` entries — not a visual chain of cert → superseded → superseded by → new cert.
-
-### Expiry is lazy-evaluated
-`refresh_certificate_expiry()` only runs when a list endpoint is called. If nobody views the page, certs past expiry date stay `status='valid'` in the DB indefinitely. There is no background job.
-
-### Import pipeline has no ledger trail
-Certs ingested from Seahub CSV or other import sources arrive silently — no `ledger_events` row is written. The `import_session_id` column tracks the batch, but not at ledger level.
-
-### Feature flag dependency
-All certificate API routes (`/api/v1/certificates/*`) check `FEATURE_CERTIFICATES=true` env var. If this is not set on Render, every read endpoint returns 404. The action router path (`/v1/actions/execute`) does not check this flag — mutations work regardless. This asymmetry is a known inconsistency.
-
-### No notifications
-No 90/30/7-day expiry warnings are sent to any user. No assignment field exists per certificate to know who is responsible for renewal.
-
-### Certificate type case inconsistency
-Historical data in `pms_vessel_certificates` has mixed case types: `class`, `CLASS`, `safety`, `SOLAS`. The view normalises to UPPERCASE via `UPPER(certificate_type)`. New inserts should always be uppercase. The handlers do not enforce this on create — only the view normalises on read.
-
----
-
-## Things I wish I knew at the start
-
-**1. There are three routing layers and they interact in a specific priority order.**
-When `/v1/actions/execute` receives a cert action, it hits `p0_actions_routes.py`, which consults the unified `HANDLERS` dict. That dict is assembled in `routes/handlers/__init__.py` with this priority: `CERT_HANDLERS` (certificate_phase4_handler.py) takes precedence over `ADAPTER_HANDLERS` (internal_adapter.py). If a cert action is in `CERT_HANDLERS`, it goes there. If not, it falls through to the adapter which routes to `INTERNAL_HANDLERS` in `internal_dispatcher.py`.
-
-**2. The Phase 4 shim (`certificate_phase4_handler.py`) handles exactly 5 actions.**
-All others (renew, archive, suspend, revoke, add_note) go through the adapter path. Adding a new action to the shim when it should go in the dispatcher causes it to work for the Phase 4 path but fail on the action router path. The banner at the top of `certificate_phase4_handler.py` explains this.
-
-**3. `maybe_single()` in this Supabase Python client is broken.**
-When no row matches, it returns `None` for the whole response object, not a response object with `data=None`. Any code that does `result = ...maybe_single().execute(); if result.data:` will raise `AttributeError: 'NoneType' object has no attribute 'data'` when the cert is not in that table. Always use `.limit(1)` + `getattr(result, "data", None) or []`.
-
-**4. The frontend queries the view directly, not the API, for the list.**
-`FilteredEntityList` uses the Supabase client directly (browser-side, anon key + RLS) to query `v_certificates_enriched`. The detail view goes through the Render API. These are different auth paths. This matters when debugging 404s vs empty lists.
-
-**5. `is_seed = true` hides 338 of 353 vessel cert rows.**
-The view filters `WHERE is_seed = false`. If the list is empty, this is usually why. The seed data is there but hidden. Any cert you create via the UI will have `is_seed = false`.
-
-**6. The ledger safety net only fires on mutations via p0_actions_routes.**
-Read operations via GET endpoints (`/api/v1/certificates/*`) do not go through the safety net. They write to the ledger only because `_ledger_read()` was explicitly added to each handler. If you add a new read handler, you must also add a `_ledger_read()` call.
-
-**7. `entity_id` from the frontend context is NOT automatically `certificate_id`.**
-The EntityLensPage sends `entity_id` in the context. For most domains (fault, work order, equipment) the `resolve_entity_context()` function in `p0_actions_routes.py` maps this to the domain-specific key. For certificates, `_CERT_ACTIONS` frozenset handles this mapping to `certificate_id`. If you add a new cert action and forget to add it to `_CERT_ACTIONS`, the action will fail with MISSING_REQUIRED_FIELD.
-
-**8. `supersede_certificate` requires a complete signature payload.**
-Not just `{"signature": {}}` — the router validates that these four keys are present: `signed_at`, `user_id`, `role_at_signing`, `signature_type`. Any test that sends a minimal signature will get 400 from the router, not 403.
-
-**9. The test user roles are NOT what the test table says.**
-`captain.tenant@alex-short.com` appears to be `chief_engineer` in documentation but is actually `captain` in the TENANT DB `auth_users_roles` table. The action router resolves role from TENANT DB, not from the MASTER DB `user_accounts` table. Always check `auth_users_roles` directly to know what role a user actually has.
-
-**10. `deleted_by` has no FK constraint on crew certs.**
-I added it without a FK initially (matching the vessel cert pattern where `deleted_by` also has no FK). Then I made the mistake of adding `REFERENCES auth.users(id)`. This caused test failures when the synthetic test user UUID didn't exist in `auth.users`. The correct pattern — matching vessel certs — is a plain UUID with no FK constraint.
-
----
-
-## Running the binary tests
-
-The 16-test binary suite hits the live tenant DB. Each test verifies exact DB row state — no mocks.
-
-```bash
-cd /Users/celeste7/Documents/CLOUD_PMS/apps/api
-
-SUPABASE_URL="https://vzsohavtuotocgrfkfyd.supabase.co" \
-SUPABASE_SERVICE_KEY="<from /Documents/Cloud_PMS/env/env vars.md>" \
-MASTER_SUPABASE_URL="https://qvzmkaamzaqxpzbewjxe.supabase.co" \
-MASTER_SUPABASE_JWT_SECRET="<from env vars.md>" \
-FEATURE_CERTIFICATES="true" \
-python3 tests/cert_binary_tests.py
+```
+HTTP POST /api/v1/actions/execute
+    │
+    ▼
+p0_actions_routes.py::execute_action()
+    │
+    ├─── Role check (before anything else, for security)
+    │
+    ├─── resolve_entity_context() — maps entity_id → certificate_id if action in _CERT_ACTIONS
+    │
+    ├─── REQUIRED_FIELDS check — scans {**request.context, **payload}
+    │
+    ├─── validate_action_payload() — UUID validation, enum checks
+    │
+    ├─── Look up handler in HANDLERS dict (routes/handlers/__init__.py)
+    │    │
+    │    ├─ CERT_HANDLERS (certificate_phase4_handler.py) — PRIORITY
+    │    │   Handles: create_vessel, create_crew, update, link_doc, supersede
+    │    │   Calls _delegate() → get_certificate_handlers() → adapter → CertificateHandlers method
+    │    │
+    │    └─ ADAPTER_HANDLERS (internal_adapter.py) — fallback
+    │        Handles: renew, suspend, revoke, archive, add_note
+    │        Calls INTERNAL_HANDLERS[action_id] from internal_dispatcher.py
+    │        Which calls _cert_renew/_cert_suspend/_cert_revoke/_cert_archive
+    │        Which calls get_certificate_handlers() → adapter → CertificateHandlers method
+    │
+    ▼
+CertificateHandlers._fn(**params)  ← the actual business logic
+    │
+    ├─── DB operations on pms_vessel_certificates / pms_crew_certificates
+    ├─── Audit log insert into pms_audit_log
+    │
+    ▼
+Return result dict
+    │
+    ▼
+p0_actions_routes.py "Ledger safety net"
+    │
+    ├─ If result doesn't have `_ledger_written: true`
+    ├─ If action is in ACTION_METADATA
+    ├─ Write to ledger_events table
+    │
+    ▼
+HTTP 200 response
 ```
 
-Expected output: `RESULTS: 16/16 PASS | 0/16 FAIL`
+### Why two handler layers?
 
-The pre-push Docker check also runs these:
+Historical migration. The system is moving from "Phase 3" (everything in `internal_dispatcher.py`'s `INTERNAL_HANDLERS` dict) to "Phase 4" (domain-native handlers in `routes/handlers/*.py`). Five cert actions were rewritten as Phase 4 native. Five are still routed through the adapter. Both work identically from the user perspective.
+
+**The priority rule:** `CERT_HANDLERS` is merged FIRST in `routes/handlers/__init__.py`, so if an action is in both, the Phase 4 version wins. The adapter only handles what Phase 4 doesn't cover.
+
+### Adding a new certificate action
+
+Follow this checklist exactly. Missing a step creates a silent failure.
+
+1. Add to `ACTION_REGISTRY` in `apps/api/action_router/registry.py` with correct `allowed_roles`, `required_fields`, `field_metadata`, `variant`, `domain="certificates"`.
+2. Implement the handler in `apps/api/handlers/certificate_handlers.py` as an adapter function (see existing patterns).
+3. Register it in the dict returned by `get_certificate_handlers()`.
+4. Add a wrapper in `apps/api/action_router/dispatchers/internal_dispatcher.py` (pattern: `_cert_<name>`).
+5. Add the wrapper to `INTERNAL_HANDLERS` dict in `internal_dispatcher.py`.
+6. Add the action name to `_ACTIONS_TO_ADAPT` list in `apps/api/routes/handlers/internal_adapter.py`.
+7. Add to `ACTION_METADATA` in `apps/api/action_router/ledger_metadata.py` — if missed, mutations succeed but don't log to the ledger.
+8. Add the action name to `_CERT_ACTIONS` frozenset in `apps/api/routes/p0_actions_routes.py` — if missed, `entity_id` from context won't map to `certificate_id`.
+9. Add to `REQUIRED_FIELDS` dict in `p0_actions_routes.py` if there are required fields beyond yacht_id.
+10. Update the frontend `CertificateContent.tsx` to surface the action (add to primary button or dropdown).
+
+Miss step 7 → action works but no ledger entry.
+Miss step 8 → 400 "MISSING_REQUIRED_FIELD: certificate_id" in production.
+Miss step 9 → 400 for any field not listed.
+
+This is precisely why `certificate_phase4_handler.py` now has an architectural boundary banner at the top — to force engineers to read this checklist.
+
+---
+
+## 10. Bugs I hit during this work — and fixes
+
+### Bug 1: `_supersede_certificate_adapter` missing `return _fn`
+
+**Symptom:** `supersede_certificate` returned HTTP 501 "not registered in certificate_handlers".
+
+**Cause:** The outer factory function was missing `return _fn` at the end. It implicitly returned `None`. The dict had `"supersede_certificate": None` — the key existed but the value was falsy, so `handlers.get("supersede_certificate")` returned None and `_delegate` raised 501.
+
+**Fix:** Added `return _fn` after the inner async function definition.
+
+**Lesson:** Every adapter factory in `certificate_handlers.py` MUST end with `return _fn`. If you copy-paste a new adapter, verify the return.
+
+### Bug 2: `maybe_single()` returns None (not a response object) on no-match
+
+**Symptom:** Crew cert operations returned `'NoneType' object has no attribute 'data'`.
+
+**Cause:** The Supabase Python client's `maybe_single()` behaviour depends on version. In the version we're using, when no row matches it returns `None` for the whole response, not a response object with `data=None`. Code like `result.data` then crashes.
+
+**Fix:** Use `.limit(1).execute()` and guard with `getattr(result, 'data', None) or []` instead of `maybe_single()`. See `_resolve_cert_domain()` in `certificate_handlers.py`.
+
+**Lesson:** Never use `maybe_single()` in this codebase. Use `.limit(1).execute()` and check `rows[0]` if the list is non-empty.
+
+### Bug 3: `_delegate()` didn't pass context → KeyError on `certificate_id`
+
+**Symptom:** Supersede returned 400 `VALIDATION_ERROR: 'certificate_id'` even though `certificate_id` was sent in the request.
+
+**Cause:** The frontend sends `certificate_id` in the request `context`, not the `payload`. The `_delegate()` function in `certificate_phase4_handler.py` was only passing `{**{"yacht_id": ..., "user_id": ...}, **payload}` to the adapter. The `context` dict was never merged in, so `certificate_id` was lost.
+
+**Fix:** Updated `_delegate()` to accept `context` as an argument and merge it into the params dict.
+
+**Lesson:** Any handler that reads `certificate_id` from params must have context merged into those params. Double-check the handler chain if you see KeyError on an ID field.
+
+### Bug 4: `p0_actions_routes.py` had no `_CERT_ACTIONS` mapping
+
+**Symptom:** Even after Bug 3 was fixed, the p0_actions_routes layer was still rejecting requests. The `resolve_entity_context()` function maps `entity_id` → domain-specific IDs (`equipment_id`, `fault_id`, etc.) but had no mapping for certificate actions.
+
+**Fix:** Added `_CERT_ACTIONS` frozenset with all 10 cert action names and an `elif action in _CERT_ACTIONS: ctx.setdefault("certificate_id", entity_id)` branch in `resolve_entity_context()`.
+
+**Lesson:** The EntityLensPage frontend always sends `entity_id` in context. Every domain needs a mapping in `resolve_entity_context()` to translate that to its specific ID field name.
+
+### Bug 5: `p0_actions_routes.py` REQUIRED_FIELDS check only scanned `payload`
+
+**Symptom:** Even after Bugs 3 and 4, supersede was returning 400 `MISSING_REQUIRED_FIELD: certificate_id`.
+
+**Cause:** `payload.get(f)` on line 896 only checked the payload dict. Certificate_id was in the context, so it was invisible to this check.
+
+**Fix:** Changed to `merged_for_check = {**request.context, **payload}` and scanned the merged dict.
+
+**Lesson:** Required fields validation must always check merged context+payload, not just payload.
+
+### Bug 6: `pms_notes` was missing `certificate_id` column
+
+**Symptom:** `add_certificate_note` threw a DB error "column certificate_id does not exist".
+
+**Cause:** The `add_note` handler in `internal_dispatcher.py` had `if params.get("certificate_id"): note_data["certificate_id"] = params["certificate_id"]` — it was designed to support the column, but the migration to actually add it was never run.
+
+**Fix:** Migration M4 — `ALTER TABLE pms_notes ADD COLUMN certificate_id uuid REFERENCES pms_vessel_certificates(id) ON DELETE SET NULL;`
+
+**Lesson:** When adding a note to any entity, check that `pms_notes` actually has that FK column. The handler code might reference a column that doesn't exist.
+
+### Bug 7: Legacy `pms_certificates` table still existed but was bypassed
+
+**Symptom:** 18 real vessel certificates were in `pms_certificates` (a legacy table) that the frontend never queried. `v_certificates_enriched` only reads `pms_vessel_certificates`. Users couldn't see those 18 certs.
+
+**Fix:** Migration M1 — copied 18 rows into `pms_vessel_certificates` with `is_seed=false`, normalised `certificate_type` to uppercase, dropped the legacy table.
+
+**Lesson:** If you find a table with fewer rows than the "active" one, check if it's being queried by the frontend. Legacy tables silently hide data.
+
+### Bug 8: `pms_crew_certificates` had no `status` column
+
+**Symptom:** Crew cert expiry couldn't be tracked. Suspend/revoke had nowhere to write the new status.
+
+**Fix:** Migration M3 — `ALTER TABLE pms_crew_certificates ADD COLUMN status text NOT NULL DEFAULT 'valid' CHECK (status IN ('valid','expired','revoked','suspended'));`
+
+**Lesson:** Check that every domain table has the columns the handlers expect. Don't assume schema parity between related tables.
+
+### Bug 9: `pms_crew_certificates` had no `deleted_at` column
+
+**Symptom:** `archive_certificate` worked for vessel certs (which had `deleted_at`) but silently failed for crew certs (which didn't).
+
+**Fix:** Migration M6 — added `deleted_at timestamptz` and `deleted_by uuid` columns to crew certs.
+
+**Lesson:** Soft-delete needs two columns on every table that supports it. Don't add a FK constraint on `deleted_by` unless you're sure the user UUIDs will exist in `auth.users` — I tried that initially and it caused test failures.
+
+### Bug 10: 5 certificate actions missing from `ACTION_METADATA`
+
+**Symptom:** Create, update, supersede, link_document actions ran successfully but left no ledger trace.
+
+**Cause:** `ACTION_METADATA` in `ledger_metadata.py` had only 5 cert entries. The other 5 actions (`create_vessel_certificate`, `create_crew_certificate`, `update_certificate`, `link_document_to_certificate`, `supersede_certificate`) were missing.
+
+**Fix:** Added all 5 entries with correct event types (create / update / status_change).
+
+**Lesson:** Always audit `ACTION_METADATA` when touching any domain. The safety net is only a net for actions it knows about.
+
+### Bug 11: `refresh_certificate_expiry()` flipped status but didn't log
+
+**Symptom:** Expired certs auto-flipped from `valid → expired` with no audit trail. Silent status change.
+
+**Fix:** Rewrote the PL/pgSQL function to insert a `ledger_events` row for every cert it flipped, with `source_context='system'` and the sentinel system user UUID.
+
+**Lesson:** Any automatic state change (triggers, cron jobs, DB functions) must write to the ledger. Automatic does not mean invisible.
+
+### Bug 12: Import pipeline bypassed the ledger
+
+**Symptom:** Certs created by the import pipeline never appeared in the ledger.
+
+**Decision:** Explicit business decision — imports are treated as "already externally audited" and intentionally do not write to the ledger. This is documented behaviour, not a bug. If this ever changes, the import service needs to write `create` ledger events for every inserted cert.
+
+### Bug 13: `ENTITY_TABLE_MAP["certificate"]` pointed only to vessel
+
+**Symptom:** Generic `soft_delete_entity()` handler worked for vessel certs but couldn't delete crew certs.
+
+**Fix:** Stopped using generic `soft_delete_entity` for certificates. Wrote a dedicated `_archive_certificate_adapter` that calls `_resolve_cert_domain()` to auto-detect which table the cert lives in.
+
+**Lesson:** Generic entity handlers break for domains with multiple tables. Don't use them — write domain-aware handlers.
+
+### Bug 14: Pre-push hook rejected branch names containing "main"
+
+**Symptom:** `git push -u origin feat/certificate-domain-...` was rejected with "BLOCKED: Direct push to 'main'".
+
+**Cause:** `.git/hooks/pre-push` used `[[ "$remote_ref" == *"main"* ]]` — substring match. Branch names containing "domain", "remain", "maintenance" etc. all matched.
+
+**Fix:** Changed to exact match: `[[ "$remote_ref" == "refs/heads/main" ]]`.
+
+**Lesson:** Never use substring matching for branch protection.
+
+---
+
+## 11. Things I wish I knew at the start
+
+### The two-file naming collision
+
+`handlers/certificate_handlers.py` (plural, CertificateHandlers class) and `routes/handlers/certificate_handler.py` (singular, Phase 4 route shim) coexisted. The one-letter difference was a compound-loss trap. I renamed the singular one to `certificate_phase4_handler.py` to make the shim boundary explicit.
+
+If you see `certificate_handlers.py` in an import, it's the source of truth (CertificateHandlers class, 1300+ lines). If you see `certificate_phase4_handler.py`, it's a thin shim that delegates back to `certificate_handlers.py`. Adding logic to the shim is almost always wrong.
+
+### Render vs local deployments
+
+The Render backend auto-deploys on merge to `main`. If role tests fail against Render with errors like "501 not implemented" that match OLD code paths, the cause is always that your fix hasn't been deployed yet. Render deploys take 3–5 minutes after merge.
+
+Use Docker locally BEFORE pushing. Run:
 
 ```bash
 bash scripts/dev/pre-push-check.sh
 ```
 
+This builds the Dockerfile exactly as Render will, runs the 16 binary handler tests, and reports pass/fail. If it passes locally, Render will pass. If Render fails but Docker passes, the deploy hasn't completed.
+
+### The `FEATURE_CERTIFICATES` env var
+
+Every certificate route in `certificate_routes.py` has `if not check_feature_flag(): raise HTTPException(404, ...)`. This checks `os.getenv("FEATURE_CERTIFICATES", "false").lower() == "true"`.
+
+- **Local Docker:** must be set in `docker-compose.yml` under the api service environment section. I added it during this work.
+- **Render:** must be set in the Render dashboard. It is currently set.
+- **Frontend dev:** irrelevant — the frontend doesn't check this flag.
+
+If you get mysterious 404s on `/api/v1/certificates/*` endpoints, this is the first thing to check.
+
+### The user role comes from TENANT DB, not MASTER
+
+The test users table was wrong. `captain.tenant@alex-short.com` is labelled "HOD / chief_engineer" in the test docs but is actually `captain` in the `auth_users_roles` table on the TENANT DB. There is **no chief_engineer test user**.
+
+The action router resolves the user role via `lookup_tenant_for_user()` which queries:
+
+```
+TENANT DB → auth_users_roles table → role column
+```
+
+It does NOT use `user_accounts.role` on the MASTER DB. Don't trust the master user_accounts table for role authorization.
+
+To check a real role:
+
+```sql
+SELECT u.email, ar.role, ar.department
+FROM auth_users_roles ar
+JOIN auth.users u ON u.id = ar.user_id
+WHERE u.email = 'captain.tenant@alex-short.com';
+```
+
+### The route prefix is `/api/v1/certificates`, not `/v1/certificates`
+
+The `certificate_routes.py` router is mounted at `/api/v1/certificates/*` in `pipeline_service.py` line 299:
+
+```python
+app.include_router(certificate_router, prefix="/api/v1/certificates", tags=["certificates"])
+```
+
+If you try to hit `localhost:8000/v1/certificates/vessel` it will 404. The action router (`/v1/actions/execute`) and the REST routes (`/api/v1/certificates/*`) use different prefixes.
+
+### Supabase pooler ports differ
+
+The tenant DB has two ports:
+
+- **5432** — direct connection (preferred for testing)
+- **6543** — Supavisor pooler (what the app uses in production)
+
+Port 6543 often has connection timeouts from local machines. Use 5432 for ad-hoc SQL. The app config uses 6543 for pooling.
+
+```bash
+# Direct:
+psql "postgresql://postgres:PASSWORD@db.vzsohavtuotocgrfkfyd.supabase.co:5432/postgres?sslmode=require"
+
+# Pooler:
+psql "postgresql://postgres:PASSWORD@db.vzsohavtuotocgrfkfyd.supabase.co:6543/postgres?sslmode=require"
+```
+
+### Binary testing means DB row verification, not HTTP codes
+
+Don't trust HTTP 200 as proof of success. A handler can return 200 while writing nothing to the DB, or writing the wrong thing. Binary tests must verify the exact row state in the DB AFTER the operation:
+
+```python
+# Call the handler
+await handlers["renew_certificate"](**params)
+
+# Verify the exact state change
+old_row = db.table("pms_vessel_certificates").select("*").eq("id", old_id).execute().data[0]
+assert old_row["status"] == "superseded"
+
+new_row = db.table("pms_vessel_certificates").select("*").eq("id", new_id).execute().data[0]
+assert new_row["expiry_date"] == "2027-02-01"
+
+audit = db.table("pms_audit_log").select("*").eq("entity_id", old_id).execute().data
+assert any(a["action"] == "renew_certificate" for a in audit)
+```
+
+16/16 binary tests live in `apps/api/tests/cert_binary_tests.py`. Run them after any cert change.
+
 ---
 
-## Role permissions quick reference
+## 12. Known limitations and Phase 2 work
 
-| Action | crew | chief_engineer | captain | manager |
-|---|---|---|---|---|
-| View list | ✓ | ✓ | ✓ | ✓ |
-| View detail | ✓ | ✓ | ✓ | ✓ |
-| View history | ✓ | ✓ | ✓ | ✓ |
-| Create vessel cert | ✗ | ✓ | ✓ | ✓ |
-| Create crew cert | ✗ | ✓ | ✓ | ✓ |
-| Update cert | ✗ | ✓ | ✓ | ✓ |
-| Renew cert | ✗ | ✓ | ✓ | ✓ |
-| Link document | ✗ | ✓ | ✓ | ✓ |
-| Add note | ✗ | ✓ | ✓ | ✓ |
-| Supersede (SIGNED) | ✗ | ✗ | ✓ | ✓ |
-| Suspend (SIGNED) | ✗ | ✗ | ✓ | ✓ |
-| Revoke (SIGNED) | ✗ | ✗ | ✓ | ✓ |
-| Archive | ✗ | ✗ | ✓ | ✓ |
-| Delete (hard) | ✗ | ✗ | ✗ | ✓ |
-
-SIGNED actions require a signature payload with: `signed_at`, `user_id`, `role_at_signing`, `signature_type`.
+- **No notification system** — 90/30/7 day expiry alerts don't exist. `find_expiring_certificates` is a read endpoint only; nothing calls it automatically or sends alerts to assigned officers.
+- **No certificate assignment** — there is no "responsible officer" per cert. You can't say "Chief Engineer owns renewal of this ISM cert".
+- **No ledger integration with finance** — cert renewal costs (class survey fees, flag state fees) cannot be recorded against a cert entity in the finance ledger. Planned for Phase 2.
+- **No PDF export / compliance register** — port state control inspections expect a printable cert register. Not built. The closest is `find_expiring_certificates` which returns JSON grouped by urgency.
+- **No cert template library** — every cert is entered manually. No library of standard cert types with pre-filled fields per issuing authority.
+- **`view_certificate_history` reads from `pms_audit_log`** — not from `ledger_events`. These two tables have drifted slightly. The canonical compliance trail is `ledger_events`; the domain audit view still uses `pms_audit_log` for backwards compatibility.
+- **Import pipeline is deliberately excluded from the ledger** — see Bug 12.
+- **Only one `document_id` per cert** — the table has `document_id uuid` as a single FK, not a list. For multiple documents use `pms_attachments` with `entity_type='certificate'` and `entity_id=<cert_id>`.
 
 ---
 
-## Environment variables
+## 13. Test strategy
 
-All from `/Users/celeste7/Documents/Cloud_PMS/env/env vars.md`
+### 1. Binary handler tests (the bedrock)
 
-| Variable | Used by | Purpose |
-|---|---|---|
-| `FEATURE_CERTIFICATES` | Render + Docker | Gates all `/api/v1/certificates/*` GET endpoints. Must be `true`. Does NOT gate mutation endpoints via action router. |
-| `SUPABASE_URL` | Render API | Tenant DB URL (`vzsohavtuotocgrfkfyd`) |
-| `SUPABASE_SERVICE_KEY` | Render API | Bypasses RLS for service operations |
-| `MASTER_SUPABASE_URL` | Render API | Master DB URL (`qvzmkaamzaqxpzbewjxe`) for auth |
-| `MASTER_SUPABASE_JWT_SECRET` | Render API | JWT verification |
+`apps/api/tests/cert_binary_tests.py` — 16 tests that:
 
-The frontend (`apps/web`) uses the Supabase anon key + RLS for direct DB queries (the list view). No additional env vars needed for cert reads.
+1. Create a fresh test cert
+2. Call the handler directly against the live tenant DB
+3. Query the DB to verify exact row state
+4. Clean up
+
+These don't test HTTP routing. They test that the handler logic produces the correct DB state.
+
+Run with:
+
+```bash
+SUPABASE_URL="https://vzsohavtuotocgrfkfyd.supabase.co" \
+SUPABASE_SERVICE_KEY="<tenant_service_key>" \
+MASTER_SUPABASE_URL="https://qvzmkaamzaqxpzbewjxe.supabase.co" \
+MASTER_SUPABASE_JWT_SECRET="<master_jwt_secret>" \
+FEATURE_CERTIFICATES="true" \
+python3 apps/api/tests/cert_binary_tests.py
+```
+
+### 2. Role-based API tests
+
+`/tmp/role_test_verified.sh` (not committed, write fresh per session). Tests:
+
+- crew → 403 on all mutations
+- captain → 200 on renew, suspend, revoke, supersede
+- manager → 200 on renew, suspend, revoke, create
+
+Uses real JWTs from Supabase auth. Points at either `localhost:8000` (Docker) or `https://pipeline-core.int.celeste7.ai` (Render).
+
+### 3. Docker pre-push check
+
+`scripts/dev/pre-push-check.sh` — builds Docker image, starts container, runs healthcheck, runs binary handler tests, tears down. This is the gate that makes sure Render never receives broken code.
+
+### 4. Playwright e2e
+
+- `apps/web/e2e/shard-33-lens-actions/certificate-actions.spec.ts`
+- `apps/web/e2e/shard-34-lens-actions/certificate-actions-full.spec.ts`
+
+These test the frontend — clicking buttons, filling ActionPopup forms, verifying the UI updates. They do NOT test the ledger or audit layer — that's what binary tests cover.
+
+### 5. Role test verification checklist
+
+Before claiming a role test failure is real:
+
+1. Is the user's TENANT role (from `auth_users_roles`) what you think it is? Query the DB.
+2. Is FEATURE_CERTIFICATES set in the environment?
+3. Is the route prefix `/api/v1/certificates/*` or `/v1/actions/execute`?
+4. Is the request hitting the right container (local Docker vs live Render)?
+5. Has the latest code been deployed? Check by hitting an endpoint that returned an error in the old code.
 
 ---
 
-## PR history (this domain)
+## 14. Communication with other domains
 
-| PR | What | Status |
-|---|---|---|
-| #522 | Complete cert domain — renew/suspend/revoke/expiry/crew parity, 4 pre-existing bugs fixed, Docker pre-push check | Merged |
-| #524 | Cert ledger reads + ACTION_METADATA gaps (opened separately, landed in #525) | Merged via #525 |
-| #525 | Full package: cert+ledger+HoR+handover — all domains on one branch | Merged to main 2026-04-14T16:08Z |
+### Documents
+
+`link_document_to_certificate` attaches a row from `doc_metadata` to a cert via the `document_id` FK. The cert handler validates the document exists before linking. Document deletion cascades via `ON DELETE SET NULL`.
+
+### Equipment
+
+Vessel certs can link to equipment via the `properties` JSON field (e.g., machinery certs for a specific engine). There is no FK — the link is soft via `properties.equipment_id`. The frontend `Related Equipment` section reads from `related_equipment` in the detail response.
+
+### Notes
+
+`pms_notes` has `certificate_id` as one of several optional FKs. Adding a note calls the generic `add_note` handler which detects the FK column based on which ID is in the params. This handler is shared with equipment, faults, work orders, warranties, documents, parts.
+
+### Audit log
+
+`pms_audit_log` is written by every cert mutation with `entity_type = "certificate"` and `entity_id = <cert_uuid>`. This is how `view_certificate_history` produces its response.
+
+### Ledger
+
+`ledger_events` is written by:
+- The action router safety net (all mutations)
+- The `_ledger_read` helper (all reads)
+- `refresh_certificate_expiry()` DB function (auto-expiry)
+
+Every row has `entity_type = "certificate"` and forms part of the tamper-evident compliance chain via `proof_hash`.
+
+### Handover
+
+Handover exports can include cert status snapshots. The handover module pulls from `pms_vessel_certificates` and `pms_crew_certificates` directly via its own queries — it doesn't go through the cert handlers. Changes to cert schema need to be communicated to HANDOVER01 because their queries may break.
+
+### Hours of Rest (HoR)
+
+No direct interaction. Crew certs and HoR records both reference crew via person_name/person_node_id but are independent domains.
+
+### Warranty
+
+No direct interaction. Both have signed actions and audit/ledger coverage but operate on different tables.
+
+---
+
+## 15. Quick-reference commands
+
+### DB queries
+
+```sql
+-- Count certs by domain and status
+SELECT domain, status, COUNT(*) FROM v_certificates_enriched GROUP BY domain, status;
+
+-- Recent ledger events for certs
+SELECT action, event_type, entity_id, user_role, change_summary, created_at
+FROM ledger_events
+WHERE entity_type = 'certificate'
+ORDER BY created_at DESC
+LIMIT 20;
+
+-- Force expiry refresh for a yacht
+SELECT refresh_certificate_expiry('<yacht_uuid>');
+
+-- Find all certs linked to a specific document
+SELECT id, certificate_name FROM pms_vessel_certificates WHERE document_id = '<doc_id>';
+```
+
+### Action router calls
+
+```bash
+# Get a JWT (any role)
+JWT=$(curl -s -X POST "https://qvzmkaamzaqxpzbewjxe.supabase.co/auth/v1/token?grant_type=password" \
+  -H "apikey: $MASTER_ANON" \
+  -H "Content-Type: application/json" \
+  -d '{"email":"x@alex-short.com","password":"Password2!"}' | jq -r .access_token)
+
+# Call renew
+curl -X POST "https://pipeline-core.int.celeste7.ai/v1/actions/execute" \
+  -H "Authorization: Bearer $JWT" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "action": "renew_certificate",
+    "context": {"yacht_id": "85fe1119-...", "certificate_id": "<cert_id>"},
+    "payload": {"new_issue_date": "2026-01-01", "new_expiry_date": "2027-01-01"}
+  }'
+```
+
+### Read certs
+
+```bash
+# List vessel certs
+curl "https://pipeline-core.int.celeste7.ai/api/v1/certificates/vessel?limit=10" \
+  -H "Authorization: Bearer $JWT"
+
+# Get single cert
+curl "https://pipeline-core.int.celeste7.ai/api/v1/certificates/<cert_id>?domain=vessel" \
+  -H "Authorization: Bearer $JWT"
+
+# Find expiring within 90 days
+curl "https://pipeline-core.int.celeste7.ai/api/v1/certificates/expiring?days_ahead=90&domain=all" \
+  -H "Authorization: Bearer $JWT"
+```
+
+### Local Docker
+
+```bash
+# Start the API locally
+docker compose --profile api up -d
+
+# Healthcheck
+curl localhost:8000/health
+
+# Run binary tests
+bash scripts/dev/pre-push-check.sh
+
+# Tear down
+docker compose --profile api down
+```
+
+---
+
+## 16. Handover notes to the next engineer
+
+1. **Never use `maybe_single()`** in this codebase. Use `.limit(1).execute()` with a length check.
+2. **Don't add logic to `certificate_phase4_handler.py`** unless it's a Phase 4 native action. The architectural banner at the top of that file explains why.
+3. **Always update `ACTION_METADATA` and `_CERT_ACTIONS`** when adding a new cert action. Six places total — the checklist is in Section 9.
+4. **Binary test every change** against the live tenant DB. HTTP 200 lies.
+5. **Use Docker locally before pushing.** Render is the last gate, not the first.
+6. **The `renew_certificate` button opens a popup, it doesn't execute directly.** Don't "simplify" this back.
+7. **Crew certs lived without a `status` column for months.** Double-check schema parity if you add anything that assumes both tables are identical.
+8. **The import pipeline intentionally bypasses the ledger.** This is a business decision. If you need to change it, ask.
+9. **`captain.tenant@alex-short.com` is a captain, not an HOD.** The test docs lie. Query `auth_users_roles` to check.
+10. **`v_certificates_enriched` is the single source of truth for the list page.** Both tables feed it. Don't query either table directly from the frontend.


### PR DESCRIPTION
## Summary

- **tokens.css**: Add `--shell-topbar-h`, `--shell-subbar-h`, `--shell-sidebar-w`, `--shell-sidebar-compact-w` as canonical shell dimension tokens — single source of truth for the entire shell grid
- **AppShell / Topbar / Subbar**: All hardcoded `48px`/`46px`/`192px` replaced with token references; JS constants `SHELL_SIDEBAR_W/COMPACT_W` mirror the tokens for dynamic `gridTemplateColumns`; `minHeight: 0` on body row + `<main>` so the flex chain fills full viewport height on every screen size
- **6 authenticated pages/components** (`email/page.tsx`, `email/[threadId]/page.tsx`, `signoffs/page.tsx`, `signoffs/[id]/page.tsx`, `receiving/new/page.tsx`, `EntityLensPage.tsx`): replace `height/minHeight: 100vh` with `flex: 1 + minHeight: 0` — pages now fill `<main>` correctly instead of fighting the AppShell viewport constraint
- **Settings.tsx**: `calc(100vh - 48px)` → `calc(100vh - var(--shell-topbar-h))`
- **TimeSlider.tsx**: fix WORK/REST label inversion (variable was named `totalRestMin` but summed work block durations)
- **MyTimeView.tsx**: fix template apply 422 (missing `week_start_date` in request body); add week prev/next navigation + 7-dot status strip

## Test plan

- [ ] Verify shell fills full screen height at multiple viewport sizes — no clipped content, scroll area adapts
- [ ] Email page: loads within AppShell without internal double-topbar overflow
- [ ] Signoffs page: fills available height, content scrollable
- [ ] EntityLensPage: lens detail pages scroll correctly within AppShell
- [ ] TimeSlider: drag work blocks — WORK label shows hours worked, REST shows hours remaining (previously inverted)
- [ ] Template apply: select template + Insert My Template — no longer 422
- [ ] Week navigation: ‹ / › arrows change week, dots update, past weeks read-only
- [ ] `tsc --noEmit` exit 0 ✓ (verified before commit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)