### PR TITLE
test(e2e): fix shard-49 timeout — LLM export pipeline needs 150s not 15s

### DIFF
--- a/apps/web/playwright.config.ts
+++ b/apps/web/playwright.config.ts
@@ -349,13 +349,19 @@ export default defineConfig({
     },
     // =========================================================================
     // SHARD 49: Handover Export E2E (Phases A/B — microservice delegation)
+    // Higher timeouts required: LLM pipeline (classify→group→merge) takes up to
+    // 120s. Global actionTimeout (15s) is too short for POST /handover/export.
     // =========================================================================
     {
       name: 'shard-49-handover-export-e2e',
       testDir: './e2e/shard-49-handover-export-e2e',
       testMatch: '**/*.spec.ts',
       dependencies: ['setup'],
-      use: { ...devices['Desktop Chrome'] },
+      timeout: 180_000,  // 3 min per test — LLM pipeline can take up to 120s
+      use: {
+        ...devices['Desktop Chrome'],
+        actionTimeout: 150_000,  // 2.5 min for API calls (LLM pipeline)
+      },
     },
     // =========================================================================
     // SHARD 50: Interface Pivot — Vessel Surface, Sidebar, Scope Tag, Auth


### PR DESCRIPTION
## Problem

shard-49 handover export e2e tests were failing with `TimeoutError: apiRequestContext.post: Timeout 15000ms exceeded`.

Global `actionTimeout: 15_000` is correct for most tests but wrong for `POST /handover/export` — that endpoint delegates to the LLM microservice (classify → group → merge → Jinja2 render) which takes up to 120s.

Tests were not broken — the timer was wrong.

## Fix

Override timeouts for shard-49 only:
- `timeout: 180_000` (3 min per test)
- `actionTimeout: 150_000` (2.5 min for API calls)

All other shards unchanged.

## Verified

```
2 passed (1.5m)
  ✓ Captain can export handover — sees all departments
  ✓ Sign flow: submit → countersign → complete
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)