### PR TITLE
fix(registry): infer date-pick for _due/_on/survey fields

### DIFF
--- a/apps/api/action_router/entity_actions.py
+++ b/apps/api/action_router/entity_actions.py
@@ -223,7 +223,14 @@ def _build_field_schema(action_def) -> List[Dict[str, Any]]:
             field_type = "entity-search"
         elif "description" in fm.name or "notes" in fm.name or "reason" in fm.name or "draft" in fm.name:
             field_type = "text-area"
-        elif "date" in fm.name or fm.name.endswith("_at") or "expiry" in fm.name:
+        elif (
+            "date" in fm.name
+            or fm.name.endswith("_at")
+            or fm.name.endswith("_due")
+            or fm.name.endswith("_on")
+            or "expiry" in fm.name
+            or "survey" in fm.name
+        ):
             field_type = "date-pick"
         elif "amount" in fm.name or "minutes" in fm.name or "quantity" in fm.name or "cost" in fm.name or "total" in fm.name:
             field_type = "number"


### PR DESCRIPTION
## Summary

Extended `_build_field_schema` date inference to cover `_due`, `_on`, and `survey` patterns. Previously `next_survey_due` rendered as a plain text input in the frontend form.

## Before → After

| Field | Before | After |
|---|---|---|
| `issue_date` | date-pick | date-pick |
| `expiry_date` | date-pick | date-pick |
| `last_survey_date` | date-pick | date-pick |
| `next_survey_due` | **kv-edit** (bug) | **date-pick** |
| `commissioned_on` | kv-edit | date-pick |

## Test plan

Caught by comprehensive binary test (26/27 PASS) — this fix takes it to 27/27.

🤖 Generated with [Claude Code](https://claude.com/claude-code)