### PR TITLE
fix(auth): define logger before cachetools try/except

### DIFF
--- a/apps/api/middleware/auth.py
+++ b/apps/api/middleware/auth.py
@@ -24,14 +24,14 @@ from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
 import os
 import logging
 
+logger = logging.getLogger(__name__)
+
 try:
     from cachetools import TTLCache
     HAS_CACHETOOLS = True
 except ImportError:
     HAS_CACHETOOLS = False
     logger.warning("[Auth] cachetools not installed - using dict cache without TTL")
-
-logger = logging.getLogger(__name__)
 
 # ============================================================================
 # INCIDENT MODE / KILL SWITCH CONFIGURATION


### PR DESCRIPTION
## Summary
- `logger` was referenced in an `except ImportError` clause **before** it was defined on the following line
- This is a latent `NameError` — harmless while `cachetools` is installed, fatal if it's ever absent from a deployed image
- Fix: move `logger = logging.getLogger(__name__)` above the try/except block

## Root cause context
Identified while diagnosing Render staging port-scan timeout on commit `0a27a92`. The timeout itself is likely a separate env/port configuration issue on the Render service, but this bug is a real startup kill-switch if `cachetools` goes missing.

## Test plan
- [ ] Verify `import apps.api.middleware.auth` succeeds even with `cachetools` removed from environment
- [ ] Confirm no other `logger` forward-reference patterns in the same file

🤖 Generated with [Claude Code](https://claude.com/claude-code)