### PR TITLE
fix(extraction_worker): omit tsv from chunk INSERT (generated column)

### DIFF
--- a/apps/api/workers/extraction_worker.py
+++ b/apps/api/workers/extraction_worker.py
@@ -155,6 +155,21 @@ def atomic_chunk_replacement(cur, doc_id: str, yacht_id: str, chunks: list) -> b
     Atomically replace all chunks for a document.
     DELETE old → INSERT new in one transaction.
     Pattern from projection_worker.py:484-521.
+
+    NOTE 2026-04-15 — `search_document_chunks.tsv` is a `GENERATED ALWAYS AS
+    (to_tsvector('english', COALESCE(content, ''))) STORED` column.
+    Generated columns cannot be written to directly — Postgres rejects
+    every INSERT that names them with `GeneratedAlways: cannot insert a
+    non-DEFAULT value into column "tsv"`.
+
+    Previous version of this function explicitly wrote `to_tsvector(...)`
+    into the `tsv` column, which silently failed for every chunk in
+    production. The exception was swallowed by the caller's non-fatal
+    handler, leaving search_document_chunks empty for every uploaded
+    document. Discovered via the diag patch in PR #541.
+
+    Fix: omit `tsv` from the INSERT column list. Postgres will populate
+    it from `content` automatically.
     """
     if not chunks:
         return False
@@ -165,15 +180,15 @@ def atomic_chunk_replacement(cur, doc_id: str, yacht_id: str, chunks: list) -> b
         (doc_id,),
     )
 
-    # Insert new chunks
+    # Insert new chunks — DO NOT write to `tsv` (generated column).
     for chunk in chunks:
         content_hash = compute_content_hash(chunk["content"])
         cur.execute(
             """
             INSERT INTO search_document_chunks
-                (document_id, yacht_id, chunk_index, content, content_hash, tsv)
+                (document_id, yacht_id, chunk_index, content, content_hash)
             VALUES
-                (%s, %s, %s, %s, %s, to_tsvector('english', %s))
+                (%s, %s, %s, %s, %s)
             """,
             (
                 doc_id,
@@ -181,7 +196,6 @@ def atomic_chunk_replacement(cur, doc_id: str, yacht_id: str, chunks: list) -> b
                 chunk["chunk_index"],
                 chunk["content"],
                 content_hash,
-                chunk["content"],
             ),
         )
 


### PR DESCRIPTION
## Root cause

`search_document_chunks.tsv` is `GENERATED ALWAYS AS (to_tsvector('english', COALESCE(content, ''))) STORED`. The extraction worker was explicitly writing to it, which Postgres rejects:

```
GeneratedAlways: cannot insert a non-DEFAULT value into column "tsv"
DETAIL: Column "tsv" is a generated column.
```

The exception was swallowed by a non-fatal handler. Result: every upload reached `indexed` with `chunks=0`. Body-content search has been silently broken across all upload paths since the schema drift on `tsv`.

This bug pre-dates F1 (PR #538). It was masked because every download 404'd before F1.

## Discovery

PR #541 added `extract_diag` telemetry into search_index.payload. A test TXT upload returned the exception explicitly. Schema confirmed:

```
column: tsv  is_generated: ALWAYS
gen_expr: to_tsvector('english'::regconfig, COALESCE(content, ''::text))
```

## Fix

Remove `tsv` from the INSERT column list in `atomic_chunk_replacement`. Postgres populates it automatically.

## Verification plan

After merge + Render redeploy:
1. Upload a reportlab PDF via /v1/documents/upload
2. Read `extract_diag` — should show `chunks_written > 0`
3. Query search_document_chunks for the doc_id — should have rows with content
4. Run /v2/search for the unique keyword — should return the doc

🤖 Generated with [Claude Code](https://claude.com/claude-code)