### PR TITLE
fix(hor): warnings endpoint contract + clickable history rows

### DIFF
--- a/apps/api/routes/hours_of_rest_routes.py
+++ b/apps/api/routes/hours_of_rest_routes.py
@@ -705,7 +705,7 @@ async def apply_crew_template_route(
 
 @router.get("/warnings")
 async def list_crew_warnings_route(
-    yacht_id: str,
+    yacht_id: Optional[str] = None,
     user_id: Optional[str] = None,
     status: Optional[str] = None,
     warning_type: Optional[str] = None,

--- a/apps/web/src/components/hours-of-rest/MyTimeView.tsx
+++ b/apps/web/src/components/hours-of-rest/MyTimeView.tsx
@@ -325,13 +325,14 @@ export function MyTimeView({ targetUserId, readOnly: forceReadOnly }: MyTimeView
   async function loadWarnings() {
     try {
       const auth = await getAuthHeader();
-      const resp = await fetch('/api/v1/hours-of-rest/warnings', {
+      const resp = await fetch('/api/v1/hours-of-rest/warnings?status=active', {
         headers: { 'Authorization': auth },
       });
       if (resp.ok) {
         const json = await resp.json();
-        const list = json.data ?? json.warnings ?? [];
-        setWarnings(list.filter((w: any) => w.status === 'active'));
+        // Response: { data: { warnings: [...], summary: {...} } }
+        const list: any[] = json.data?.warnings ?? json.warnings ?? [];
+        setWarnings(list);
       }
     } catch {
       // non-critical
@@ -1062,7 +1063,17 @@ export function MyTimeView({ targetUserId, readOnly: forceReadOnly }: MyTimeView
           {historyOpen && (
             <div style={{ borderTop: '1px solid rgba(255,255,255,0.05)' }}>
               {data.prior_weeks.map((w: any) => (
-                <div key={w.week_start} style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', padding: '9px 16px', borderBottom: '1px solid rgba(255,255,255,0.03)' }}>
+                <div
+                  key={w.week_start}
+                  onClick={() => setViewWeekStart(w.week_start)}
+                  style={{
+                    display: 'flex', alignItems: 'center', justifyContent: 'space-between',
+                    padding: '9px 16px', borderBottom: '1px solid rgba(255,255,255,0.03)',
+                    cursor: 'pointer', transition: 'background 0.1s',
+                  }}
+                  onMouseEnter={e => (e.currentTarget.style.background = 'rgba(255,255,255,0.03)')}
+                  onMouseLeave={e => (e.currentTarget.style.background = 'transparent')}
+                >
                   <div>
                     <span style={{ fontSize: 12, color: 'rgba(255,255,255,0.55)' }}>{w.label}</span>
                     {w.days_filed < 7 && (
@@ -1074,6 +1085,7 @@ export function MyTimeView({ targetUserId, readOnly: forceReadOnly }: MyTimeView
                   <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
                     <span style={{ fontFamily: 'var(--font-mono)', fontSize: 9, color: 'rgba(255,255,255,0.35)' }}>{w.total_rest_hours}h rest</span>
                     <StatusBadge ok={w.is_compliant} />
+                    <span style={{ fontFamily: 'var(--font-mono)', fontSize: 9, color: 'rgba(255,255,255,0.20)' }}>›</span>
                   </div>
                 </div>
               ))}


### PR DESCRIPTION
## Summary
- **Bug**: `GET /warnings` required `yacht_id` as mandatory query param, but frontend (and all callers) have yacht_id in JWT — no frontend component passes it as a query param. Made `Optional`, `resolve_yacht_id()` already handles `None` by falling back to JWT's `yacht_id`.
- **Bug**: `loadWarnings()` response normalization was wrong — `json.data` is `{ warnings: [], summary: {} }` (an object), not an array. Calling `.filter()` on it throws a runtime error. Fixed to `json.data?.warnings ?? json.warnings ?? []`.
- Pass `status=active` query param to backend to avoid fetching acknowledged/dismissed warnings unnecessarily.
- History rows in the HoR "My Time" view are now clickable — clicking any past week navigates to it directly (same as using the ‹ arrow but one click instead of N clicks). Hover highlight and `›` indicator added.

## Test plan
- [ ] Load HoR page — confirm no 422 on `GET /warnings` in network tab
- [ ] Create a test violation day, verify it appears in Active Warnings
- [ ] Click Acknowledge — confirm warning disappears
- [ ] Expand History section, click a past week row — confirm it loads that week's data
- [ ] `npx tsc --noEmit` → 0 errors
- [ ] `python3 -c "import ast; ..."` → OK for both changed py files

🤖 Generated with [Claude Code](https://claude.com/claude-code)