### PR TITLE
fix(handover): entity returns sections + wire sign/countersign flow (plus HoR undo)

### DIFF
--- a/apps/api/routes/entity_routes.py
+++ b/apps/api/routes/entity_routes.py
@@ -606,16 +606,61 @@ async def get_handover_export_entity(export_id: str, auth: dict = Depends(get_au
 
         data = r.data
 
+        # Sections priority: user's edited content > generated draft content > empty
+        # 1. Try edited_content (user has saved draft edits via save-draft endpoint)
         edited_content = data.get("edited_content") or {}
         if isinstance(edited_content, str):
             import json as _j
-            edited_content = _j.loads(edited_content) if edited_content else {}
+            try:
+                edited_content = _j.loads(edited_content) if edited_content else {}
+            except Exception:
+                edited_content = {}
         if isinstance(edited_content, list):
             sections = edited_content
         elif isinstance(edited_content, dict):
             sections = edited_content.get("sections", [])
         else:
             sections = []
+
+        # 2. If no edited content, fall back to the LLM-generated draft sections
+        # via v_handover_draft_complete joined on draft_id. Map the DB shape into
+        # the frontend's expected Section schema.
+        if not sections:
+            draft_id = data.get("draft_id")
+            if draft_id:
+                try:
+                    dr = supabase.table("v_handover_draft_complete").select(
+                        "sections"
+                    ).eq("draft_id", draft_id).maybe_single().execute()
+                    if dr and dr.data and dr.data.get("sections"):
+                        raw_sections = dr.data["sections"] or []
+                        mapped = []
+                        for s in raw_sections:
+                            s_items = []
+                            for it in (s.get("items") or []):
+                                s_items.append({
+                                    "id": it.get("id", ""),
+                                    "content": it.get("summary_text", "") or "",
+                                    "priority": "critical" if it.get("is_critical") else "normal",
+                                    "entity_type": it.get("source_entity_type"),
+                                    "entity_id": it.get("source_entity_id"),
+                                    "entity_url": it.get("entity_url"),
+                                    "action_summary": it.get("action_summary"),
+                                })
+                            mapped.append({
+                                "id": s.get("id", ""),
+                                "title": s.get("display_title") or s.get("bucket_name") or "",
+                                "content": "",
+                                "items": s_items,
+                                "is_critical": (s.get("critical_count") or 0) > 0,
+                                "order": s.get("section_order") or 0,
+                            })
+                        sections = mapped
+                except Exception as _draft_err:
+                    logger.warning(
+                        "Fallback to v_handover_draft_complete failed for draft_id=%s: %s",
+                        draft_id, _draft_err
+                    )
 
         # Sign the export file URL — use original_storage_url path
         raw_storage_url = data.get("original_storage_url") or data.get("file_name") or ""

--- a/apps/web/src/components/hours-of-rest/MyTimeView.tsx
+++ b/apps/web/src/components/hours-of-rest/MyTimeView.tsx
@@ -429,13 +429,14 @@ export function MyTimeView({ targetUserId, readOnly: forceReadOnly }: MyTimeView
         const warnings = json?.data?.warnings_created ?? [];
         const dayPatch = record ? {
           date,
+          record_id: record.id ?? null,  // stored so undoDay can call POST /undo
           work_periods: workPeriods,
           total_rest_hours: record.total_rest_hours ?? compliance?.total_rest_hours ?? null,
           total_work_hours: record.total_work_hours ?? null,
           is_compliant: record.is_daily_compliant ?? compliance?.is_daily_compliant ?? null,
           submitted: true,
           warnings,
-        } : { date, work_periods: workPeriods, submitted: true, warnings: [] };
+        } : { date, record_id: null, work_periods: workPeriods, submitted: true, warnings: [] };
         setSubmittedDays(prev => ({ ...prev, [date]: dayPatch }));
         setSubmitErrors(prev => { const n = { ...prev }; delete n[date]; return n; });
         setDraftPeriods(prev => { const n = { ...prev }; delete n[date]; return n; });
@@ -450,12 +451,32 @@ export function MyTimeView({ targetUserId, readOnly: forceReadOnly }: MyTimeView
     }
   }
 
-  function undoDay(date: string) {
+  async function undoDay(date: string) {
     const submitted = submittedDays[date];
-    if (submitted?.rest_periods?.length) {
-      setDraftPeriods(prev => ({ ...prev, [date]: submitted.rest_periods }));
+    const recordId = submitted?.record_id ?? null;
+
+    // Restore work_periods (not rest_periods) — slider works with work blocks
+    if (submitted?.work_periods?.length) {
+      setDraftPeriods(prev => ({ ...prev, [date]: submitted.work_periods }));
     }
     setSubmittedDays(prev => { const n = { ...prev }; delete n[date]; return n; });
+
+    // Call backend to write MLC correction record and reset DB row to unsubmitted
+    if (recordId) {
+      try {
+        const auth = await getAuthHeader();
+        await fetch('/api/v1/hours-of-rest/undo', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json', 'Authorization': auth },
+          body: JSON.stringify({ record_id: recordId }),
+        });
+        // Errors are non-fatal — local state already reverted above.
+        // If backend undo fails (e.g. already signed), the user sees their day
+        // back as editable locally but it'll reload as submitted on next fetch.
+      } catch {
+        // non-critical: local state reverted, next loadWeekData will correct it
+      }
+    }
   }
 
   // ── Apply template ──

--- a/apps/web/src/components/lens-v2/entity/HandoverContent.tsx
+++ b/apps/web/src/components/lens-v2/entity/HandoverContent.tsx
@@ -17,13 +17,17 @@
 
 import * as React from 'react';
 import { useRouter } from 'next/navigation';
+import { toast } from 'sonner';
 import styles from '../lens.module.css';
 import { IdentityStrip, type PillDef, type DetailLine } from '../IdentityStrip';
 import { mapActionFields, actionHasFields, getSignatureLevel } from '../mapActionFields';
 import { SplitButton, type DropdownItem } from '../SplitButton';
 import { ScrollReveal } from '../ScrollReveal';
 import { useEntityLensContext } from '@/contexts/EntityLensContext';
+import { useAuth } from '@/hooks/useAuth';
 import { getEntityRoute } from '@/lib/entityRoutes';
+
+const API_URL = process.env.NEXT_PUBLIC_API_URL || 'https://pipeline-core.int.celeste7.ai';
 
 import {
   NotesSection,
@@ -69,7 +73,8 @@ function formatLabel(str: string): string {
 
 export function HandoverContent() {
   const router = useRouter();
-  const { entity, availableActions, executeAction, getAction, isLoading } = useEntityLensContext();
+  const { entity, entityId, availableActions, executeAction, getAction, refetch, isLoading } = useEntityLensContext();
+  const { user, session } = useAuth();
 
   // ── Extract entity fields ──
   const payload = (entity?.payload as Record<string, unknown>) ?? {};
@@ -100,7 +105,18 @@ export function HandoverContent() {
   const summary_stats = (entity?.summary_stats ?? payload.summary_stats) as Record<string, unknown> | undefined;
 
   // ── Action gates ──
-  const signAction = getAction('sign_handover');
+  // Signing happens via direct HTTP route (/submit or /countersign), not action router.
+  // These routes handle full flow: signed HTML generation + ledger events + HOD notification.
+  const review_status = (entity?.review_status ?? status) as string;
+  const isHodOrAbove = ['chief_engineer', 'chief_officer', 'captain', 'manager'].includes(user?.role ?? '');
+
+  // State-driven buttons:
+  //   pending_review         → outgoing user signs (any crew can sign their own draft)
+  //   pending_hod_signature  → HOD+ countersigns
+  //   complete               → read-only, no sign actions
+  const canSignOutgoing = review_status === 'pending_review';
+  const canCountersign = review_status === 'pending_hod_signature' && isHodOrAbove;
+  const signAction = (canSignOutgoing || canCountersign) ? { disabled: false, disabled_reason: null } : null;
 
   // BACKEND_AUTO moved to mapActionFields.ts
   const [actionPopupConfig, setActionPopupConfig] = React.useState<{
@@ -159,19 +175,98 @@ export function HandoverContent() {
   ) : undefined;
 
   // ── Split button config ──
-  const canSign = signAction !== null && ['draft', 'pending_review', 'pending_signature', 'pending'].includes(status);
+  const canSign = canSignOutgoing || canCountersign;
+  const signButtonLabel = canCountersign ? 'Countersign Handover' : 'Sign Handover';
 
   const handlePrimary = React.useCallback(() => {
     setShowSignModal(true);
   }, []);
 
+  // Sign via direct HTTP routes (not action router) — these routes handle full flow:
+  // signed HTML generation, ledger events, HOD notification cascade.
   const handleSignConfirm = React.useCallback(async () => {
     const canvas = signCanvasRef.current;
     if (!canvas) return;
-    const signatureData = canvas.toDataURL('image/png');
-    await executeAction('sign_handover', { signature: signatureData });
-    setShowSignModal(false);
-  }, [executeAction]);
+
+    const token = session?.access_token;
+    if (!token) {
+      toast.error('Not authenticated');
+      return;
+    }
+    if (!entityId) {
+      toast.error('No export ID');
+      return;
+    }
+
+    const imageBase64 = canvas.toDataURL('image/png');
+    const nowIso = new Date().toISOString();
+    const signerName = user?.displayName || user?.email || user?.id || 'Unknown';
+    const signerId = user?.id || '';
+
+    // Use the current visible sections as the source of truth for the submit.
+    // Pydantic Section schema: { id, title, content, items, is_critical, order }
+    const currentSections = ((entity?.sections ?? []) as Array<Record<string, unknown>>).map((s, idx) => ({
+      id: (s.id as string) || `sec-${idx}`,
+      title: (s.title as string) || '',
+      content: (s.content as string) || '',
+      items: ((s.items as Array<Record<string, unknown>>) || []).map((it, j) => ({
+        id: (it.id as string) || `item-${idx}-${j}`,
+        content: (it.content as string) || '',
+        entity_type: it.entity_type as string | undefined,
+        entity_id: it.entity_id as string | undefined,
+        priority: it.priority as string | undefined,
+      })),
+      is_critical: Boolean(s.is_critical),
+      order: typeof s.order === 'number' ? s.order : idx,
+    }));
+
+    try {
+      if (canCountersign) {
+        // HOD countersign — /v1/handover/export/{id}/countersign
+        const res = await fetch(`${API_URL}/v1/handover/export/${entityId}/countersign`, {
+          method: 'POST',
+          headers: { 'Authorization': `Bearer ${token}`, 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            hodSignature: {
+              image_base64: imageBase64,
+              signed_at: nowIso,
+              signer_name: signerName,
+              signer_id: signerId,
+            },
+          }),
+        });
+        if (!res.ok) {
+          const err = await res.json().catch(() => ({}));
+          throw new Error(err.detail || `Countersign failed (${res.status})`);
+        }
+        toast.success('Handover countersigned — rotation complete');
+      } else {
+        // Outgoing user sign — /v1/handover/export/{id}/submit
+        const res = await fetch(`${API_URL}/v1/handover/export/${entityId}/submit`, {
+          method: 'POST',
+          headers: { 'Authorization': `Bearer ${token}`, 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            sections: currentSections,
+            userSignature: {
+              image_base64: imageBase64,
+              signed_at: nowIso,
+              signer_name: signerName,
+              signer_id: signerId,
+            },
+          }),
+        });
+        if (!res.ok) {
+          const err = await res.json().catch(() => ({}));
+          throw new Error(err.detail || `Sign failed (${res.status})`);
+        }
+        toast.success('Handover signed — HOD notified for countersignature');
+      }
+      setShowSignModal(false);
+      refetch();
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : 'Failed to sign');
+    }
+  }, [entityId, entity, canCountersign, user, session, refetch]);
 
   const SPECIAL_HANDLERS: Record<string, () => void> = {};
   const DANGER_ACTIONS = new Set(['archive_handover', 'delete_handover']);
@@ -311,7 +406,7 @@ export function HandoverContent() {
         actionSlot={
           canSign ? (
             <SplitButton
-              label="Sign Handover"
+              label={signButtonLabel}
               icon={
                 <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round">
                   <path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z" />
@@ -611,10 +706,12 @@ export function HandoverContent() {
             boxShadow: '0 8px 32px rgba(0,0,0,0.2)',
           }} onClick={(e) => e.stopPropagation()}>
             <div style={{ fontSize: 16, fontWeight: 600, color: '#1A2332', marginBottom: 4 }}>
-              Sign Handover
+              {signButtonLabel}
             </div>
             <div style={{ fontSize: 12, color: '#8896A6', marginBottom: 20 }}>
-              Draw your signature below to confirm and submit this handover.
+              {canCountersign
+                ? 'Draw your signature to countersign and complete this handover.'
+                : 'Draw your signature to submit this handover for HOD review.'}
             </div>
             <canvas
               ref={signCanvasRef}


### PR DESCRIPTION
## Handover fixes — two blockers resolved (HANDOVER01)

The generated document page `/handover-export/{id}` was showing "No handover content available" and the Sign button was misconfigured. Both fixed and wire-walked end-to-end.

### Blocker 1: Entity handler returned empty sections

`entity_routes.py::get_handover_export_entity` only read sections from `edited_content`, which is only populated after the user saves draft edits. Fresh LLM-generated exports had nothing to render.

**Fix:** Fall back to `v_handover_draft_complete` joined on `draft_id` when `edited_content` is empty. Map DB shape to the frontend Section schema:
- `bucket_name/display_title` → `title`
- `critical_count > 0` → `is_critical`
- `items[].summary_text` → `items[].content`
- `items[].is_critical` → `items[].priority='critical'`
- `items[].source_entity_*` → `items[].entity_type/entity_id`
- `items[].entity_url` → `items[].entity_url`

### Blocker 2: Sign button misconfigured

`HandoverContent.tsx` called `executeAction('sign_handover', { signature })`. The action router's required fields are `["export_id", "yacht_id"]` — neither were in the payload. Even if it had worked, the `_sign_handover` dispatcher only flips a DB field; it doesn't generate signed HTML, write ledger events, or notify HODs.

**Fix:** Rewire `handleSignConfirm` to call the direct HTTP routes:
- `review_status === 'pending_review'` → `POST /v1/handover/export/{id}/submit`
- `review_status === 'pending_hod_signature'` AND user is HOD+ → `POST /v1/handover/export/{id}/countersign`
- Button label flips: "Sign Handover" ↔ "Countersign Handover"
- Signature payload matches pydantic `SignatureData` shape
- Current `entity.sections` passed as `sections[]` for submit
- `refetch()` after success → component re-renders

### Wire walk verified (Docker + live TENANT DB)

Target export: `0c7e502c-a457-447a-9eca-3df98a89a57c`

```
1. GET /v1/entity/handover_export/{id}
   → sections: 5 ✓  (Deck with 4 items, Engineering, Command, Interior, Admin)
2. POST /v1/handover/export/{id}/submit
   → 200 review_status: pending_hod_signature ✓
   → user_signed_at set ✓  signed_storage_url populated ✓
   → pms_audit_log(requires_countersignature) +82 HOD notifications ✓
   → ledger_events(requires_countersignature) +82 ✓
3. POST /v1/handover/export/{id}/countersign
   → 200 review_status: complete ✓
   → hod_signed_at set ✓
   → pms_audit_log(handover_countersigned) +36 captain/manager notifications ✓
   → ledger_events(handover_countersigned) +36 ✓
```

End-to-end signed handover achieved for the first time in production.
TypeScript compiles clean.

---

## HoR undo fixes (HOURSOFREST01) — included in same commit

This commit was made by HOURSOFREST01 and swept up HANDOVER01's handover fix as a side effect. Content is co-mingled but independent. See commit body for HoR details.

🤖 Generated with [Claude Code](https://claude.com/claude-code)