### PR TITLE
feat(certs): nightly expiry cron + vessel-surface widget fixes

### DIFF
--- a/apps/api/routes/vessel_surface_routes.py
+++ b/apps/api/routes/vessel_surface_routes.py
@@ -541,36 +541,70 @@ async def get_vessel_surface(vessel_id: str, auth: dict = Depends(get_authentica
         logger.error(f"[VesselSurface] Recent activity query failed: {e}")
         result["recent_activity"] = []
 
-    # ── Certificates Expiring (within 45 days) ───────────────────────────────
+    # ── Certificates Expiring (already-expired + within 90 days) ─────────────
+    #
+    # Fixes 4 bugs in the original widget query:
+    #   1. Used `pms_vessel_certificates` → crew certs invisible. Now uses
+    #      v_certificates_enriched which UNIONs vessel + crew.
+    #   2. Backend emitted `certificate_name` but frontend reads `c.name` from
+    #      SurfaceCertItem. Widget showed empty names. Fixed: emit both, with
+    #      `name` formatted for display (person — cert_type for crew).
+    #   3. `.gte(expiry_date, today)` filtered out already-expired certs —
+    #      the most operationally urgent ones. Removed that filter.
+    #   4. Expired certs excluded via the gte filter AND only valid statuses
+    #      considered. Now: status IN ('valid','expired') only (terminal states
+    #      superseded/revoked/suspended excluded).
+    #
+    # Window: 90 days (industry standard for planning) instead of 45.
     try:
-        cutoff = (datetime.now(timezone.utc) + timedelta(days=45)).strftime("%Y-%m-%d")
-        today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+        cutoff = (datetime.now(timezone.utc) + timedelta(days=90)).strftime("%Y-%m-%d")
 
-        cert_select = "id, certificate_name, certificate_type, expiry_date, status"
+        cert_select = "id, certificate_name, certificate_type, expiry_date, status, domain, person_name"
         if is_overview:
             cert_select = "yacht_id, " + cert_select
-        cert_q = supabase.table("pms_vessel_certificates").select(cert_select)
-        cert_r = _scope_query(cert_q, yacht_ids).gte(
-            "expiry_date", today
-        ).lte(
+        cert_q = supabase.table("v_certificates_enriched").select(cert_select)
+        cert_r = _scope_query(cert_q, yacht_ids).lte(
             "expiry_date", cutoff
-        ).order("expiry_date").execute()
+        ).in_(
+            "status", ["valid", "expired"]
+        ).order("expiry_date").limit(50).execute()
 
         cert_items = cert_r.data or []
+
+        def _cert_display_name(c: dict) -> str:
+            """Build a name the frontend can render — crew certs embed the person."""
+            if c.get("domain") == "crew":
+                person = c.get("person_name") or ""
+                cert_type = c.get("certificate_type") or "Certificate"
+                return f"{person} — {cert_type}".strip(" —") if person else cert_type
+            return c.get("certificate_name") or c.get("certificate_type") or "Certificate"
+
+        def _days_remaining(expiry):
+            if not expiry:
+                return None
+            try:
+                return (
+                    datetime.strptime(expiry, "%Y-%m-%d")
+                    - datetime.now(timezone.utc).replace(
+                        hour=0, minute=0, second=0, microsecond=0, tzinfo=None
+                    )
+                ).days
+            except Exception:
+                return None
+
         result["certificates_expiring"] = {
             "count": len(cert_items),
             "items": [
                 {
                     "id": c.get("id"),
                     **({"yacht_id": c.get("yacht_id")} if is_overview else {}),
+                    # `name` matches the SurfaceCertItem contract on the frontend
+                    "name": _cert_display_name(c),
                     "certificate_name": c.get("certificate_name", ""),
                     "certificate_type": c.get("certificate_type", ""),
+                    "domain": c.get("domain", "vessel"),
                     "expiry_date": c.get("expiry_date"),
-                    "days_remaining": (
-                        datetime.strptime(c["expiry_date"], "%Y-%m-%d") - datetime.now(timezone.utc).replace(
-                            hour=0, minute=0, second=0, microsecond=0
-                        )
-                    ).days if c.get("expiry_date") else None,
+                    "days_remaining": _days_remaining(c.get("expiry_date")),
                     "status": c.get("status", "valid"),
                 }
                 for c in cert_items

--- a/apps/api/workers/nightly_certificate_expiry.py
+++ b/apps/api/workers/nightly_certificate_expiry.py
@@ -1,0 +1,152 @@
+#!/usr/bin/env python3
+"""
+Nightly Certificate Expiry Check
+=================================
+
+Runs once daily via Render cron. For every yacht in yacht_registry, calls
+the `refresh_certificate_expiry(yacht_id)` DB function, which:
+
+1. Updates `pms_vessel_certificates` and `pms_crew_certificates` rows where
+   `status = 'valid'` AND `expiry_date < CURRENT_DATE` to `status = 'expired'`.
+2. Writes a `ledger_events` row for each cert flipped, with
+   `event_type = 'status_change'`, `source_context = 'system'`, and a
+   descriptive `change_summary`.
+
+This closes the gap where a cert expiring Tuesday night stayed `valid`
+until Wednesday morning when someone next viewed the list page. With this
+worker, the flip happens at 02:15 UTC every night regardless of user activity.
+
+ENVIRONMENT
+-----------
+    DATABASE_URL  - PostgreSQL DSN for the tenant DB (port 5432 preferred
+                    for short-lived jobs; 6543 pooler also acceptable).
+
+SAFETY
+------
+- Uses SELECT … FROM yacht_registry so the script never hardcodes a yacht id
+- Calls the DB function per yacht inside its own transaction so one yacht's
+  failure cannot corrupt another's flip
+- Exits non-zero only if every yacht failed — partial success is logged
+  and the job reports success so Render's cron retry backoff does not
+  thrash on a single bad row
+- Never writes to pms_vessel_certificates / pms_crew_certificates directly
+  from Python; all mutations go through the DB function so the ledger
+  write path is identical to the lazy-eval path
+"""
+from __future__ import annotations
+
+import os
+import sys
+import logging
+from typing import List
+
+import psycopg2
+
+DB_DSN = os.getenv("DATABASE_URL")
+LOG_LEVEL = os.getenv("LOG_LEVEL", "INFO")
+
+logging.basicConfig(
+    level=getattr(logging, LOG_LEVEL.upper(), logging.INFO),
+    format="%(asctime)s [%(levelname)s] %(message)s",
+)
+logger = logging.getLogger("nightly_certificate_expiry")
+
+
+def _list_yachts(conn) -> List[tuple]:
+    """Return [(yacht_id, name), ...] for every yacht."""
+    with conn.cursor() as cur:
+        cur.execute("SELECT id, name FROM yacht_registry ORDER BY id;")
+        return cur.fetchall()
+
+
+def _refresh_one(conn, yacht_id: str, name: str) -> tuple[int, int]:
+    """
+    Call refresh_certificate_expiry(yacht_id) and return the delta counts.
+    Returns (vessel_flipped, crew_flipped).
+    """
+    with conn.cursor() as cur:
+        cur.execute(
+            "SELECT COUNT(*) FROM pms_vessel_certificates "
+            "WHERE yacht_id = %s AND status = 'valid' "
+            "AND expiry_date IS NOT NULL AND expiry_date < CURRENT_DATE "
+            "AND deleted_at IS NULL;",
+            (yacht_id,),
+        )
+        vessel_before = cur.fetchone()[0]
+
+        cur.execute(
+            "SELECT COUNT(*) FROM pms_crew_certificates "
+            "WHERE yacht_id = %s AND status = 'valid' "
+            "AND expiry_date IS NOT NULL AND expiry_date < CURRENT_DATE "
+            "AND deleted_at IS NULL;",
+            (yacht_id,),
+        )
+        crew_before = cur.fetchone()[0]
+
+        cur.execute("SELECT refresh_certificate_expiry(%s);", (yacht_id,))
+        conn.commit()
+
+    logger.info(
+        "yacht=%s name=%r: flipped vessel=%d crew=%d",
+        yacht_id, name, vessel_before, crew_before,
+    )
+    return vessel_before, crew_before
+
+
+def main() -> int:
+    if not DB_DSN:
+        logger.error("DATABASE_URL is not set — cannot run")
+        return 2
+
+    logger.info("Starting nightly certificate expiry check")
+
+    try:
+        conn = psycopg2.connect(DB_DSN)
+    except Exception as e:
+        logger.error("Failed to connect to DB: %s", e)
+        return 2
+
+    total_yachts = 0
+    total_failures = 0
+    total_vessel_flipped = 0
+    total_crew_flipped = 0
+
+    try:
+        yachts = _list_yachts(conn)
+        total_yachts = len(yachts)
+        logger.info("Found %d yacht(s) to process", total_yachts)
+
+        for yacht_id, name in yachts:
+            try:
+                v, c = _refresh_one(conn, yacht_id, name)
+                total_vessel_flipped += v
+                total_crew_flipped += c
+            except Exception as e:
+                total_failures += 1
+                logger.error(
+                    "Yacht %s (%s) failed: %s", yacht_id, name, e
+                )
+                # Roll back this one and continue with the next yacht
+                try:
+                    conn.rollback()
+                except Exception:
+                    pass
+    finally:
+        try:
+            conn.close()
+        except Exception:
+            pass
+
+    logger.info(
+        "Complete. yachts=%d failures=%d vessel_expired=%d crew_expired=%d",
+        total_yachts, total_failures, total_vessel_flipped, total_crew_flipped,
+    )
+
+    # Only return non-zero if EVERY yacht failed.
+    if total_yachts > 0 and total_failures == total_yachts:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/render.yaml
+++ b/render.yaml
@@ -188,3 +188,33 @@ services:
         value: "100"
       - key: LOG_LEVEL
         value: "INFO"
+
+  # ============================================================================
+  # Nightly Certificate Expiry Check
+  # ============================================================================
+  #
+  # Walks every yacht in yacht_registry and calls refresh_certificate_expiry()
+  # which flips vessel + crew certs from 'valid' to 'expired' when expiry_date
+  # has passed. Each flip writes a status_change ledger event with
+  # source_context=system. Closes the gap where a cert expiring overnight
+  # stayed 'valid' until someone next loaded the list page.
+  #
+  # Runs at 02:15 UTC daily — well before the feedback loop at 03:00 UTC
+  # so the two don't compete for the same worker slot.
+  #
+  - type: cron
+    name: nightly-certificate-expiry
+    runtime: python
+    plan: starter
+    region: oregon
+    branch: main
+    schedule: "15 2 * * *"  # 02:15 UTC daily
+    buildCommand: cd apps/api && pip install psycopg2-binary
+    startCommand: cd apps/api && python -m workers.nightly_certificate_expiry
+    envVars:
+      - key: PYTHON_VERSION
+        value: "3.11.6"
+      - key: DATABASE_URL
+        sync: false  # Set in Render dashboard
+      - key: LOG_LEVEL
+        value: "INFO"


### PR DESCRIPTION
## Summary

Three commits, two independent features (safe to merge together).

**1. Nightly certificate expiry worker**
- `apps/api/workers/nightly_certificate_expiry.py` — walks yacht_registry, calls `refresh_certificate_expiry()` for each yacht, writes ledger events on every flip
- `render.yaml` — new cron service at 02:15 UTC daily
- Binary verified locally: test vessel + crew certs flipped from valid→expired, ledger rows written with source_context=system

**2. Vessel-surface "Certificates expiring" widget — 4 real bugs**
The home-screen widget was partially broken. Fixed:
1. Queried `pms_vessel_certificates` directly → crew certs invisible. Now `v_certificates_enriched`.
2. Backend emitted `certificate_name` but frontend reads `c.name`. Every row showed empty titles. Now emits `name`.
3. `.gte(expiry_date, today)` hid already-expired certs — the most urgent ones. Removed.
4. 45-day hardcoded window → 90 days.

Binary verified: widget now returns 6 items on the test vessel including 3 already-expired (MSM-2025-9525 at -66 days, EPIRB -29d, Compass -10d) plus 3 upcoming.

## Test plan
- [x] Binary verified against live tenant DB (1 vessel + 1 crew test cert flipped, ledger rows written)
- [x] Widget endpoint returns correct shape with `name` field populated
- [x] Already-expired certs visible in widget

🤖 Generated with [Claude Code](https://claude.com/claude-code)