### PR TITLE
feat(certs): assign_certificate — responsible officer per cert

### DIFF
--- a/apps/api/action_router/dispatchers/internal_dispatcher.py
+++ b/apps/api/action_router/dispatchers/internal_dispatcher.py
@@ -451,6 +451,14 @@ async def _cert_revoke(params: Dict[str, Any]) -> Dict[str, Any]:
     return await fn(**params)
 
 
+async def _cert_assign(params: Dict[str, Any]) -> Dict[str, Any]:
+    handlers = _get_certificate_handlers(get_supabase_client())
+    fn = handlers.get("assign_certificate")
+    if not fn:
+        raise ValueError("assign_certificate handler not registered")
+    return await fn(**params)
+
+
 # ============================================================================
 # DOCUMENT WRAPPERS (bridge to document handlers - Document Lens v2)
 # ============================================================================
@@ -4193,6 +4201,7 @@ INTERNAL_HANDLERS: Dict[str, Any] = {
     "archive_certificate": _cert_archive,
     "suspend_certificate": _cert_suspend,
     "revoke_certificate": _cert_revoke,
+    "assign_certificate": _cert_assign,
     "archive_part": _soft_delete_entity,
     "delete_part": _soft_delete_entity,
     "cancel_po": _soft_delete_entity,

--- a/apps/api/action_router/ledger_metadata.py
+++ b/apps/api/action_router/ledger_metadata.py
@@ -65,6 +65,7 @@ ACTION_METADATA: dict = {
     # ── Certificates ─────────────────────────────────────────────────────────
     "add_certificate_note":              {"event_type": "update",        "entity_type": "certificate",   "entity_id_field": "certificate_id"},
     "archive_certificate":               {"event_type": "update",        "entity_type": "certificate",   "entity_id_field": "entity_id"},
+    "assign_certificate":                {"event_type": "assignment",    "entity_type": "certificate",   "entity_id_field": "certificate_id"},
     "create_vessel_certificate":         {"event_type": "create",        "entity_type": "certificate",   "entity_id_field": "certificate_id"},
     "create_crew_certificate":           {"event_type": "create",        "entity_type": "certificate",   "entity_id_field": "certificate_id"},
     "link_document_to_certificate":      {"event_type": "update",        "entity_type": "certificate",   "entity_id_field": "certificate_id"},

--- a/apps/api/action_router/registry.py
+++ b/apps/api/action_router/registry.py
@@ -1588,6 +1588,34 @@ ACTION_REGISTRY: Dict[str, ActionDefinition] = {
         search_keywords=["update", "edit", "modify", "change", "certificate", "cert", "expiry", "renewal"],
     ),
 
+    "assign_certificate": ActionDefinition(
+        action_id="assign_certificate",
+        label="Assign Responsible Officer",
+        endpoint="/v1/actions/execute",
+        handler_type=HandlerType.INTERNAL,
+        method="POST",
+        allowed_roles=["chief_engineer", "captain", "manager"],
+        required_fields=["yacht_id", "certificate_id", "assigned_to"],
+        domain="certificates",
+        variant=ActionVariant.MUTATE,
+        search_keywords=["assign", "reassign", "owner", "responsible", "officer", "certificate"],
+        field_metadata=[
+            FieldMetadata("yacht_id", FieldClassification.CONTEXT),
+            FieldMetadata("certificate_id", FieldClassification.CONTEXT),
+            FieldMetadata(
+                "assigned_to",
+                FieldClassification.REQUIRED,
+                description="Responsible Officer",
+                lookup_required=True,  # renders as entity-search (crew domain)
+            ),
+            FieldMetadata(
+                "assigned_to_name",
+                FieldClassification.OPTIONAL,
+                description="Officer Display Name",
+            ),
+        ],
+    ),
+
     "link_document_to_certificate": ActionDefinition(
         action_id="link_document_to_certificate",
         label="Link Document to Certificate",

--- a/apps/api/handlers/certificate_handlers.py
+++ b/apps/api/handlers/certificate_handlers.py
@@ -733,6 +733,7 @@ def get_certificate_handlers(supabase_client) -> Dict[str, callable]:
         "suspend_certificate": _suspend,
         "revoke_certificate": _revoke,
         "archive_certificate": _archive_certificate_adapter(handlers),
+        "assign_certificate": _assign_certificate_adapter(handlers),
     }
 
 
@@ -1444,5 +1445,80 @@ def _archive_certificate_adapter(handlers: "CertificateHandlers"):
         }
 
     return _fn
+
+
+def _assign_certificate_adapter(handlers: "CertificateHandlers"):
+    async def _fn(**params):
+        """
+        Assign a responsible officer to a certificate.
+
+        Stores assignment in `properties.assigned_to` on the cert row
+        (uses the existing jsonb column — no schema change). Writes an
+        audit log row and emits a ledger event via the safety-net path.
+
+        Expected params:
+        - yacht_id (str)
+        - user_id (str)            — actor (who is making the assignment)
+        - certificate_id (str)     — which cert to assign
+        - assigned_to (str)        — user UUID being assigned
+        - assigned_to_name (str, optional) — display name for audit trail
+        """
+        db = handlers.db
+        yacht_id = params["yacht_id"]
+        user_id = params["user_id"]
+        cert_id = params.get("certificate_id")
+        assigned_to = params.get("assigned_to")
+        assigned_to_name = params.get("assigned_to_name")
+
+        if not cert_id:
+            raise ValueError("certificate_id is required")
+        if not assigned_to:
+            raise ValueError("assigned_to is required")
+
+        # Find the cert (vessel or crew) — reuses domain resolver
+        domain, table_key, old_cert = _resolve_cert_domain(db, yacht_id, cert_id)
+        table = get_table(table_key)
+
+        now = datetime.now(timezone.utc).isoformat()
+        old_assignment = (old_cert.get("properties") or {}).get("assigned_to")
+        new_properties = {
+            **(old_cert.get("properties") or {}),
+            "assigned_to": assigned_to,
+            "assigned_to_name": assigned_to_name,
+            "assigned_at": now,
+            "assigned_by": user_id,
+        }
+
+        res = db.table(table).update({"properties": new_properties}).eq(
+            "yacht_id", yacht_id
+        ).eq("id", cert_id).execute()
+        if not res.data:
+            raise ValueError("Assignment update failed or not permitted by RLS")
+
+        try:
+            db.table("pms_audit_log").insert({
+                "yacht_id": yacht_id,
+                "entity_type": "certificate",
+                "entity_id": cert_id,
+                "action": "assign_certificate",
+                "user_id": user_id,
+                "old_values": {"assigned_to": old_assignment},
+                "new_values": {
+                    "assigned_to": assigned_to,
+                    "assigned_to_name": assigned_to_name,
+                },
+                "signature": {},
+                "metadata": {"source": "certificate_lens", "domain": domain},
+                "created_at": now,
+            }).execute()
+        except Exception:
+            pass
+
+        return {
+            "status": "success",
+            "certificate_id": cert_id,
+            "assigned_to": assigned_to,
+            "assigned_to_name": assigned_to_name,
+        }
 
     return _fn

--- a/apps/api/routes/handlers/internal_adapter.py
+++ b/apps/api/routes/handlers/internal_adapter.py
@@ -82,6 +82,7 @@ def _make_adapter(action_id: str) -> Callable:
 _ACTIONS_TO_ADAPT = [
     "accept_receiving",
     "add_certificate_note",
+    "assign_certificate",
     "renew_certificate",
     "add_document_comment",
     "add_document_note",

--- a/apps/api/routes/p0_actions_routes.py
+++ b/apps/api/routes/p0_actions_routes.py
@@ -643,6 +643,7 @@ _CERT_ACTIONS = frozenset({
     "supersede_certificate", "renew_certificate",
     "suspend_certificate", "revoke_certificate",
     "archive_certificate", "add_certificate_note",
+    "assign_certificate",
 })
 
 

--- a/apps/web/src/components/lens-v2/entity/CertificateContent.tsx
+++ b/apps/web/src/components/lens-v2/entity/CertificateContent.tsx
@@ -95,6 +95,13 @@ export function CertificateContent() {
   const vessel_name = (entity?.vessel_name ?? payload.vessel_name) as string | undefined;
   const description = (entity?.description ?? payload.description) as string | undefined;
 
+  // Responsible officer — stored in properties.assigned_to / assigned_to_name
+  // by the assign_certificate action. Read-only on the lens; writes happen
+  // through ActionPopup('assign_certificate').
+  const certProperties = (entity?.properties ?? payload.properties ?? {}) as Record<string, unknown>;
+  const assigned_to = certProperties.assigned_to as string | undefined;
+  const assigned_to_name = certProperties.assigned_to_name as string | undefined;
+
   // Coverage / scope fields (prototype "Coverage Details" section)
   const scope = (entity?.scope ?? payload.scope) as string | undefined;
   const capacity = (entity?.capacity ?? payload.capacity) as string | undefined;
@@ -177,6 +184,12 @@ export function CertificateContent() {
   }
   if (vessel_name) {
     details.push({ label: 'Vessel', value: vessel_name });
+  }
+  if (assigned_to) {
+    details.push({
+      label: 'Responsible Officer',
+      value: assigned_to_name || assigned_to,
+    });
   }
 
   // Context line


### PR DESCRIPTION
## Summary

Adds an `assign_certificate` action that lets chief_engineer / captain / manager pick a crew member as the responsible officer for a given certificate.

**No schema change.** Uses the existing `properties` jsonb column on `pms_vessel_certificates` / `pms_crew_certificates`.

- Registry entry with `field_metadata` — `assigned_to` has `lookup_required=True` which renders as `entity-search` scoped to the `crew` domain
- Handler stores assignment in `properties.assigned_to / assigned_to_name / assigned_at / assigned_by`
- Full wiring across 6 places per the cert-domain checklist: registry, handlers, dispatcher wrapper, INTERNAL_HANDLERS, ACTIONS_TO_ADAPT, _CERT_ACTIONS, ACTION_METADATA (ledger safety net, event_type=assignment)
- Frontend `CertificateContent` lens reads `properties.assigned_to` and shows a "Responsible Officer" row in the IdentityStrip

## Test plan

Binary verified 5/5 against live tenant DB:
- [x] Handler returns certificate_id + assigned_to + assigned_to_name
- [x] DB `properties.assigned_to` = captain UID
- [x] `pms_audit_log` has action=assign_certificate row
- [x] `ledger_events` has event_type=assignment, user_role=captain
- [x] Entity endpoint returns the assignment on reload

🤖 Generated with [Claude Code](https://claude.com/claude-code)