### PR TITLE
docs(warranty): test cheat sheet — roles, buttons, flows, gaps, HMAC01 notes

### DIFF
--- a/docs/ongoing_work/hours_of_rest/HOR_TEST_CHEATSHEET.md
+++ b/docs/ongoing_work/hours_of_rest/HOR_TEST_CHEATSHEET.md
@@ -1,0 +1,418 @@
+# Hours of Rest — Test Cheat Sheet
+
+**Last verified:** 2026-04-15 | **All 14/14 live tests PASS**
+**Legal basis:** MLC 2006 Art. A2.3 — captain-signed weekly record is legally operative. Must be immutable after sign-off.
+
+---
+
+## Quick start — who you log in as
+
+| Role | What they see | Sign chain step |
+|------|--------------|-----------------|
+| `crew` | My Time (own week, calendar, warnings) | Signs own record |
+| `chief_engineer` / `chief_officer` / `eto` / `chief_steward` / `purser` | My Time + Department grid | Counter-signs as HOD |
+| `captain` / `manager` | My Time + Department grid + Vessel overview | Finalizes (master sign) |
+
+Test users on yacht `85fe1119-b04c-41ac-80f1-829d23322598`:
+- crew: `2da12a4b-c0a1-4716-80ae-d29c90d98233`
+- chief_engineer: `89b1262c-ff59-4591-b954-757cdf3d609d`
+- captain: `5af9d61d-9b2e-4db4-a54c-a3c95eec70e5`
+
+---
+
+## Scenario 1 — Crew submits a day
+
+**Normal operation:**
+1. Log in as crew → navigate to **Hours of Rest**
+2. **My Time tab** shows current week (Mon–Sun, 7 slots)
+3. Drag the **TimeSlider** → set work blocks (black = work, white = rest)
+4. Click **Submit Day**
+
+**What to verify:**
+- [ ] Day slot turns from grey (empty) → shows work hours + rest hours
+- [ ] `total_work_hours` + `total_rest_hours` = 24.0 exactly
+- [ ] If rest < 10h: red warning badge appears on that day — Y/N: **fail = upsert handler not deriving rest correctly**
+- [ ] Ledger event row written: `action = upsert_hours_of_rest`, `entity_type = hours_of_rest`
+
+**Where to check in DB:**
+```sql
+SELECT record_date, work_periods, total_work_hours, total_rest_hours, is_daily_compliant
+FROM pms_hours_of_rest
+WHERE user_id = '<crew_user_id>'
+ORDER BY record_date DESC LIMIT 7;
+```
+
+**Fail reasons:**
+| Symptom | Why | File:Line |
+|---------|-----|-----------|
+| 422 on Submit | `yacht_id` missing from JWT | `hours_of_rest_routes.py:303` |
+| Work + rest ≠ 24 | Complement mismatch in handler | `hours_of_rest_handlers.py` — `upsert_hours_of_rest` |
+| No ledger row | Handler swallowed ledger exception | `hours_of_rest_handlers.py:427` |
+
+---
+
+## Scenario 2 — Crew edits / undoes a submitted day
+
+**Normal operation:**
+1. On a submitted day → click **Undo**
+2. TimeSlider reappears → edit → Submit again
+
+**What to verify:**
+- [ ] After Undo: day slot goes back to empty (unsubmitted) locally
+- [ ] `POST /v1/hours-of-rest/undo` called with `record_id` — row deleted from DB
+- [ ] Ledger event written: `action = undo_hours_of_rest`
+- [ ] Resubmit works normally
+
+**Edge case — undo then re-undo:**
+- Cannot undo a day that has no `record_id` (never submitted) → Submit button shows, not Undo
+- Cannot undo a day on a **finalized** week (signoff status = `finalized`) → Undo button hidden, TimeSlider hidden
+
+**Fail reasons:**
+| Symptom | Why | File:Line |
+|---------|-----|-----------|
+| Undo clears UI but DB row remains | Frontend never sent `record_id` | `MyTimeView.tsx` — `submitDay` must store `record.id` |
+| Undo restores wrong periods | Was restoring `rest_periods` not `work_periods` | Fixed PR #550 — `MyTimeView.tsx` |
+| Undo button present on finalized week | `signoff_status` not checked | `MyTimeView.tsx` — check `signoff_status === 'finalized'` |
+
+---
+
+## Scenario 3 — Crew sees calendar
+
+**Normal operation:**
+1. My Time → click **CAL** button (week section header)
+2. Monthly calendar opens: green = compliant, red = violation, grey = no record
+3. Click a day → navigates to that week
+
+**What to verify:**
+- [ ] Calendar loads correct month
+- [ ] Green cells: days where `is_daily_compliant = true` in DB
+- [ ] Red cells: days where rest < 10h
+- [ ] Grey cells: no record for that day
+- [ ] Arrow nav changes month
+- [ ] Clicking past day navigates week view
+
+**Edge case:**
+- Future days = grey (capped at today in backend: `hor_compliance_routes.py` — `month-status` endpoint)
+
+**Fail reasons:**
+| Symptom | Why |
+|---------|-----|
+| Calendar all grey | `GET /month-status` returning empty | `hor_compliance_routes.py` — check `is_daily_compliant` field |
+| Future days show red/green | Backend not capping at `today` | `hor_compliance_routes.py` month-status loop |
+
+---
+
+## Scenario 4 — Crew views warnings
+
+**Normal operation:**
+- Active compliance violations surface in **Active Warnings** section on My Time
+- Each warning shows type (e.g. `daily_rest_violation`), severity, shortfall
+
+**What to verify:**
+- [ ] `GET /v1/hours-of-rest/warnings?status=active` returns warnings array
+- [ ] Click **Acknowledge** → warning dismissed from UI
+- [ ] Ledger event written for acknowledgement
+
+**Fail reasons:**
+| Symptom | Why |
+|---------|-----|
+| 422 on warnings fetch | Old code sent `yacht_id` as required param | Fixed PR #545 — now `Optional` |
+| Warning count badge but empty list | Response mapping wrong | `MyTimeView.tsx` — `json.data?.warnings ?? []` |
+
+---
+
+## Scenario 5 — HOD reviews department (Department tab)
+
+**Who sees this:** `chief_engineer`, `chief_officer`, `eto`, `chief_steward`, `purser`, `captain`, `manager`
+
+**Normal operation:**
+1. Log in as chief_engineer → Hours of Rest → **Department tab**
+2. Shows crew × day grid (7 columns) with daily rest hours per person
+3. Missing submissions today shown by name
+4. Pending counter-signs section if crew have signed their record
+
+**What to verify:**
+- [ ] Grid loads with correct crew members for department
+- [ ] Days show actual rest hours (not null)
+- [ ] "Missing today" list names crew who haven't submitted today
+- [ ] Pending signs list shows crew who have `crew_signed` signoffs awaiting HOD
+
+**Edge case — crew member in multiple departments:**
+- `auth_users_roles` may have one user under two departments
+- HOD sees only their own department (filtered by `department` field)
+- Captain sees all departments
+
+**Fail reasons:**
+| Symptom | Why | File:Line |
+|---------|-----|-----------|
+| 403 for captain viewing dept | Captain not in `_HOD_ROLES` check | `hor_compliance_routes.py:36-40` |
+| No crew shown | `auth_users_roles` query missing department filter | `hor_compliance_routes.py:362` |
+| All rest_hours null | `dash_crew_hours_compliance` view not populated | Supabase view refresh needed |
+
+---
+
+## Scenario 6 — Captain sees vessel overview (Vessel tab)
+
+**Who sees this:** `captain`, `manager`
+
+**Normal operation:**
+1. Log in as captain → Hours of Rest → **Vessel tab**
+2. Department cards: Engineering ✓, Deck ⚠, Interior ✓
+3. Pending final signs: signoffs awaiting captain master signature
+4. Sign chain status: `all_hods_signed`, `ready_for_captain`
+
+**What to verify:**
+- [ ] All departments listed
+- [ ] Analytics: `overall_compliance_pct`, `total_violations`, `avg_work_hours`
+- [ ] Pending final signs shows signoffs in status `hod_signed` (ready for master)
+- [ ] Sign chain fields reflect actual DB state
+
+**Fail reasons:**
+| Symptom | Why |
+|---------|-----|
+| Empty departments | Captain's `department` filter stripping all | `hor_compliance_routes.py:366` — captain role bypasses dept filter |
+| Pending signs empty when they should exist | Sign chain query missing `hod_signed` filter | `hor_compliance_routes.py` — vessel-compliance |
+
+---
+
+## Scenario 7 — Full sign chain: crew → HOD → captain
+
+**This is the legally operative path. Every step must be correct.**
+
+### Step 1 — Crew creates signoff
+
+Button: **"Start Monthly Sign-Off"** (or "Sign My Record")
+- Endpoint: `POST /v1/hours-of-rest/signoffs/create`
+- Payload: `{department, month, period_type: "monthly"}`
+- Result: signoff row created, status = `draft`
+- Notification sent to HOD: `hor_signoff_opened`
+
+### Step 2 — Crew signs
+
+**Signature popup appears when:** crew clicks "Sign My Hours" button on the monthly signoff card.
+- Popup fields: name, declaration text, timestamp (auto-filled)
+- Endpoint: `POST /v1/hours-of-rest/signoffs/sign`
+- Payload: `{signoff_id, signature_level: "crew", signature_data: {name, timestamp, ip_address}, notes}`
+- Result: status = `crew_signed`
+- Notification dispatched to HOD: `hor_awaiting_countersign`
+- Ledger event: `hor_crew_signed`, `event_type = approval`
+
+### Step 3 — HOD counter-signs
+
+**Signature popup appears when:** HOD clicks "Counter-Sign" on a `crew_signed` entry in department view.
+- Same endpoint, `signature_level: "hod"`
+- Result: status = `hod_signed`
+- Notification dispatched to captain: `hor_awaiting_master_sign`
+- Ledger event: `hor_hod_signed`, `event_type = approval`
+
+### Step 4 — Captain finalizes
+
+**Signature popup appears when:** captain clicks "Finalize" on a `hod_signed` entry in vessel view.
+- Same endpoint, `signature_level: "master"`
+- Result: status = `finalized` ← **IMMUTABLE from this point**
+- Ledger event: `hor_master_signed`, `event_type = approval`
+
+### Sign chain verification queries
+
+```sql
+-- See all 4 ledger events for a signoff
+SELECT event_type, action, created_at
+FROM ledger_events
+WHERE entity_id = '<signoff_id>'
+ORDER BY created_at;
+
+-- Check final signoff state
+SELECT id, status, crew_signed_at, hod_signed_at, master_signed_at, master_signed_by
+FROM pms_hor_monthly_signoffs
+WHERE id = '<signoff_id>';
+```
+
+---
+
+## Scenario 8 — Role gates (what gets blocked and why)
+
+| Who | Tries to | Result | HTTP |
+|-----|----------|--------|------|
+| `crew` | Access `/department-status` | FORBIDDEN — "Role 'crew' cannot access department status. HOD+ required." | 403 |
+| `crew` | Sign as `hod` level | FORBIDDEN — "HOD signature requires HOD role." | 403 |
+| `crew` | Sign as `master` level | FORBIDDEN — "Master signature requires captain role." | 403 |
+| `chief_engineer` | Sign as `master` level | FORBIDDEN — "Role 'chief_engineer' cannot give master signature." | blocked in handler |
+| HOD | Sign before crew has signed | VALIDATION_ERROR — "HOD can only sign after crew. Current status: draft" | blocked |
+| captain | Sign as master before HOD | VALIDATION_ERROR — "Master can only sign after HOD. Department has a designated HOD." | blocked |
+| Same person as HOD and master | Sign both levels | FORBIDDEN — "Master cannot finalise a signoff they counter-signed as HOD. MLC requires independent verification." | blocked |
+| Anyone | Re-sign a `finalized` record | VALIDATION_ERROR — "This sign-off has been finalized by the Master and is now immutable." | blocked |
+
+**Source:** `apps/api/handlers/hours_of_rest_handlers.py:927–1030`
+
+---
+
+## Scenario 9 — HOD bypass (no HOD in department)
+
+If a department has no designated HOD (no `chief_engineer`/`chief_officer`/`eto`/`chief_steward`/`purser` in `auth_users_roles` for that department):
+
+- Captain can sign directly from `crew_signed` → `finalized` (skipping HOD step)
+- Notification fired to all vessel-wide HOD-role users: `hor_hod_step_bypassed`
+- Ledger event still written
+
+**Test:** Remove all HOD roles for a department → crew signs → captain should be able to finalize directly.
+
+---
+
+## Scenario 10 — Correction request (after signing)
+
+**Who can request:** HOD or captain (kicking back to crew)
+
+1. HOD/captain clicks "Request Correction" on a signed record
+2. Popup: enter correction note (mandatory)
+3. Endpoint: `POST /v1/hours-of-rest/request-correction`
+4. Payload: `{signoff_id, target_user_id, correction_note, role: "hod"|"captain"}`
+5. Result: `correction_requested = true`, `correction_note = "..."` on the signoff row
+6. Notification sent to crew
+7. Ledger event: `request_hor_correction`
+
+**What to verify:**
+- [ ] Crew receives notification
+- [ ] My Time shows correction badge on the week
+- [ ] Crew can re-submit → sign chain resets
+
+---
+
+## Scenario 11 — Week lock (finalized week is read-only)
+
+When a weekly signoff exists with `status = finalized`:
+- `GET /my-week` returns `signoff_status: "finalized"`
+- Frontend: TimeSlider hidden, Undo button hidden, Submit button hidden
+- Week is display-only
+
+**What to verify:**
+- [ ] `signoff_status` field present in `/my-week` response
+- [ ] TimeSlider not rendered when `signoff_status === 'finalized'`
+- [ ] History row for that week shows lock icon or "Finalized" badge
+
+**Source:** `hor_compliance_routes.py:212–221` — weekly signoff query adds `signoff_status` to response
+
+---
+
+## Edge cases and limits
+
+| Case | Expected behaviour |
+|------|-------------------|
+| Submit day with **zero work periods** | Valid — full rest day (24h rest). `total_work_hours = 0`, `total_rest_hours = 24` |
+| Submit day with **overlapping periods** e.g. `06:00–12:00` and `10:00–14:00` | Backend computes complement — overlaps collapse. Check `total_work_hours + total_rest_hours = 24` |
+| Submit day in **future** | Allowed by API. MLC doesn't prohibit pre-planning |
+| Submit day for **another user** | Blocked — `user_id` always taken from JWT, never from request body (`hours_of_rest_routes.py:303`) |
+| Create **duplicate signoff** for same month+department | Returns `CONFLICT` — handled in `create_monthly_signoff` |
+| `prior_weeks` > 8 weeks old | Not returned — query window is 8 weeks (`hor_compliance_routes.py:242`) |
+| Calendar month with **no records** | All grey — API returns `submitted: false, is_compliant: null` per day |
+| HOD with **multiple departments** | Currently shown all departments when captain role also held. Pure HOD (e.g. chief_engineer) filtered to own department |
+| `total_rest_hours` exactly 10.0 | Compliant — `is_daily_compliant = true`. MLC limit is **minimum 10h rest** |
+| `total_rest_hours` = 9.99 | Non-compliant — warning written to `pms_crew_hours_warnings` |
+| 77h weekly rest check | `prior_weeks` aggregation at `hor_compliance_routes.py:272` — `is_compliant = (total_rest >= 77)` |
+
+---
+
+## Where signature popups belong (UI contract)
+
+| Popup | Triggered by | Role required | Fields |
+|-------|-------------|---------------|--------|
+| Crew sign-off | "Sign My Hours" on monthly signoff card | any authenticated | Name (pre-filled from profile), Declaration text, Timestamp (auto) |
+| HOD counter-sign | "Counter-Sign" button on pending sign in Department view | HOD roles | Name, Notes (optional), Timestamp (auto) |
+| Captain master sign | "Finalize" button on pending sign in Vessel view | captain/manager | Name, Notes (optional), Timestamp (auto) |
+| Correction request | "Request Correction" button (HOD/captain only) | HOD+ | Target user (pre-filled), Correction note (mandatory) |
+
+**Signature data shape sent to API:**
+```json
+{
+  "name": "John Smith",
+  "timestamp": "2026-04-15T22:00:00Z",
+  "ip_address": "127.0.0.1"
+}
+```
+
+---
+
+## API endpoints — complete list
+
+| Method | Path | Who | Purpose |
+|--------|------|-----|---------|
+| GET | `/v1/hours-of-rest/my-week` | all | Own week view + compliance + templates + prior weeks |
+| POST | `/v1/hours-of-rest/upsert` | all | Submit/edit a day |
+| POST | `/v1/hours-of-rest/undo` | all | Delete a submitted day |
+| GET | `/v1/hours-of-rest/month-status` | all | Calendar grid (day-level green/red/grey) |
+| GET | `/v1/hours-of-rest/warnings` | all | Active compliance warnings |
+| POST | `/v1/hours-of-rest/warnings/acknowledge` | all | Crew acknowledges warning |
+| POST | `/v1/hours-of-rest/warnings/dismiss` | HOD+ | HOD/captain dismisses warning with justification |
+| GET | `/v1/hours-of-rest/department-status` | HOD+ | Department crew × day grid |
+| GET | `/v1/hours-of-rest/vessel-compliance` | captain/manager | Vessel overview + sign chain |
+| GET | `/v1/hours-of-rest/signoffs` | all | List signoffs |
+| GET | `/v1/hours-of-rest/signoffs/details` | all | Single signoff detail |
+| POST | `/v1/hours-of-rest/signoffs/create` | all | Initiate monthly signoff |
+| POST | `/v1/hours-of-rest/signoffs/sign` | role-gated | Sign at crew/hod/master level |
+| POST | `/v1/hours-of-rest/corrections` | all | Create correction record |
+| POST | `/v1/hours-of-rest/request-correction` | HOD+ | Request crew re-do |
+| GET | `/v1/hours-of-rest/templates` | all | List schedule templates |
+| POST | `/v1/hours-of-rest/templates/create` | all | Create template |
+| POST | `/v1/hours-of-rest/templates/apply` | all | Apply template to week |
+
+---
+
+## Quick Y/N test list — run top-to-bottom
+
+```
+[ ] 1. Log in as crew. My Time tab loads. Days = 7. Y/N
+[ ] 2. Drag TimeSlider, click Submit. work_h + rest_h = 24. Y/N
+[ ] 3. Resubmit same day. Updates without error. Y/N
+[ ] 4. Click Undo. Slot goes grey, DB row gone. Y/N
+[ ] 5. Click CAL. Calendar opens, current month. Y/N
+[ ] 6. Future days are grey. Past unsubmitted days are grey. Y/N
+[ ] 7. Submit a day with only 6h rest. Warning badge appears. Y/N
+[ ] 8. Acknowledge warning. Badge clears. Y/N
+[ ] 9. History section shows prior weeks if data exists. Y/N
+[10] Click a history row. Week view navigates to that week. Y/N
+
+[11] Log in as crew. Try /v1/hours-of-rest/department-status. 403 returned. Y/N
+[12] Log in as chief_engineer. Department tab shows crew grid. Y/N
+[13] Log in as captain. Vessel tab shows department cards + sign chain. Y/N
+
+[14] Crew: POST /signoffs/create (department=general, month=2026-04). New row, status=draft. Y/N
+[15] Crew: POST /signoffs/sign (level=crew). Status → crew_signed. Y/N
+[16] Crew: try POST /signoffs/sign (level=hod). 403 FORBIDDEN. Y/N
+[17] HOD: POST /signoffs/sign (level=hod). Status → hod_signed. Y/N
+[18] Captain: POST /signoffs/sign (level=master). Status → finalized. Y/N
+[19] Ledger: 4 rows for signoff (create + crew + hod + master). Y/N
+[20] Anyone: try signing finalized record. VALIDATION_ERROR returned. Y/N
+
+[21] Sign where captain is same person as HOD. FORBIDDEN returned. Y/N
+[22] HOD tries to sign before crew. VALIDATION_ERROR "HOD can only sign after crew". Y/N
+```
+
+**If any Y/N = N, check:**
+1. Is Docker API running? `curl http://localhost:8000/health`
+2. Is the JWT using MASTER secret? See `middleware/auth.py:567`
+3. Is `yacht_id` present in JWT `user_metadata`? Decoded via [jwt.io](https://jwt.io)
+4. Does the user exist in `auth_users_roles` with correct role + yacht_id?
+
+---
+
+## For HMAC01 — what this session built vs what's still needed
+
+### Built and verified
+- Full sign chain: crew → HOD → captain (sequential enforcement, role gates, same-person block)
+- Ledger events for every mutation: upsert, undo, create signoff, crew/hod/master sign, warn acknowledge, correction
+- Immutability after finalization (PR #557 — `handlers/hours_of_rest_handlers.py:955`)
+- Calendar view (month-level, day-level green/red/grey)
+- Department and vessel compliance views with role gating
+- Warnings surface (active warnings, acknowledge, dismiss)
+- Prior weeks history (8-week window)
+- Signoffs list with real user names (PR #551)
+- Undo correctly reverts work_periods and calls backend (PR #550)
+
+### Not built — HMAC01's work
+- PDF/A-3 sealed Period receipt (Shape 03 per receipt layer spec)
+- PAdES-B-LT signature on the sealed PDF
+- RFC 3161 timestamp
+- `export.sealed` ledger event
+- WORM-policy storage write
+- Verifier path for `domain = "hor"`
+
+**The data is clean. The sign chain is enforced. The ledger trail is written. HMAC01 can read `pms_hor_monthly_signoffs.id` and its associated `ledger_events` rows as the input to the sealing pipeline.**

--- a/docs/ongoing_work/warranty/WARRANTY_TEST_CHEATSHEET.md
+++ b/docs/ongoing_work/warranty/WARRANTY_TEST_CHEATSHEET.md
@@ -1,0 +1,365 @@
+# Warranty Domain — Test Cheat Sheet
+
+**Last verified:** 2026-04-15  
+**Commit:** `d5a5de92` (PR #558)  
+**Backend:** `https://backend.celeste7.ai`  
+**Frontend:** `https://app.celeste7.ai`  
+**Tenant DB:** `vzsohavtuotocgrfkfyd.supabase.co`
+
+---
+
+## How to navigate to a warranty claim
+
+1. Log in to `app.celeste7.ai`
+2. Sidebar → **Warranty**
+3. Click any claim row → opens `/warranty/{id}` (the warranty lens)
+4. Or: Global search → type "warranty" → select a claim
+
+---
+
+## Role map — who can do what
+
+| Role | File claim | Submit | Approve | Reject | Close | Compose email | Add note | View |
+|------|-----------|--------|---------|--------|-------|---------------|----------|------|
+| `crew` | **NO** | NO | NO | NO | NO | NO | NO | YES |
+| `chief_engineer` | YES | YES | NO | NO | NO | YES | YES | YES |
+| `chief_officer` | YES | YES | NO | NO | NO | YES | YES | YES |
+| `captain` | YES | YES | YES | YES | YES | YES | YES | YES |
+| `manager` | YES | YES | YES | YES | YES | YES | YES | YES |
+| `purser` | NO | NO | NO | NO | NO | NO | NO | YES |
+
+**Source:** `apps/api/action_router/registry.py` — `file_warranty_claim:2740`, `submit_warranty_claim:2272`, `approve_warranty_claim:2289`, `compose_warranty_email:2344`
+
+> **Gap:** `crew` cannot file a warranty claim. The system currently restricts filing to HOD and above. If a crew member needs to raise a claim they must ask their chief engineer or chief officer.
+
+---
+
+## Status lifecycle
+
+```
+draft → submitted → approved → closed
+           ↓
+        rejected → (revise) → submitted
+```
+
+| Status | DB value | Status label (UI) | Who transitions it |
+|--------|----------|------------------|--------------------|
+| Draft | `draft` | Draft | Created by filer |
+| Submitted | `submitted` | Submitted | Chief Engineer / Captain submits |
+| Approved | `approved` | Approved | Captain / Manager approves |
+| Rejected | `rejected` | Rejected | Captain / Manager rejects |
+| Closed | `closed` | Closed | Captain / Manager closes |
+
+---
+
+## Normal operation — full flow test
+
+### Flow A: File → Submit → Approve → Close
+
+| Step | Who | Button / Action | Expected result | Y/N check |
+|------|-----|-----------------|-----------------|-----------|
+| 1 | Chief Engineer | **File Warranty Claim** (sidebar or search) | Modal opens with: Title, Vendor, Description, Claim Type, Currency (USD default), Manufacturer Email, optional Part/Serial/Amount fields | Y if modal opens cleanly |
+| 2 | Chief Engineer | Fill form, click **Submit** | Claim created, lens opens, status pill = **Draft** | Y if pill shows Draft |
+| 3 | Chief Engineer | Primary button: **Submit Claim** | Status changes to **Submitted**, pill = amber Submitted | Y if pill turns amber |
+| 4 | Captain | Opens same claim | Status = Submitted, sees **Approve** as primary button | Y if Approve appears |
+| 5 | Captain | Clicks **Approve** | Popup opens with `approved_amount` and `notes` optional fields | Y if popup shows those fields |
+| 6 | Captain | Fills approved amount, submits | Status = **Approved**, pill = green | Y if pill turns green |
+| 7 | Captain | Primary button: **Close Claim** | Status = **Closed**, pill = red | Y if pill turns red |
+
+### Flow B: File → Submit → Reject → Revise → Resubmit
+
+| Step | Who | Button | Expected result | Y/N check |
+|------|-----|--------|-----------------|-----------|
+| 1–3 | Chief Engineer | As above | Claim in Submitted state | — |
+| 4 | Captain | Dropdown → **Reject Claim** | Popup opens with `rejection_reason` required field | Y if popup shows rejection_reason |
+| 5 | Captain | Enter reason, submit | Status = **Rejected**, `rejection_reason` visible in Claim Details | Y if reason appears |
+| 6 | Chief Engineer | Primary button: **Revise & Resubmit** | Status → Submitted again | Y if status resets to Submitted |
+
+### Flow C: Compose email draft
+
+| Step | Who | Button | Expected result | Y/N check |
+|------|-----|--------|-----------------|-----------|
+| 1 | Any HOD+ | Dropdown → **Compose Email Draft** | Button only visible when claim status ≠ draft | Y if not shown on Draft claims |
+| 2 | Any HOD+ | Click it | Triggers `compose_warranty_email` action | — |
+| 3 | — | Page reloads / refetches | **Email Draft** section appears at bottom of lens | Y if section visible |
+| 4 | — | Check Email Draft section | Shows: Subject line, **To** = manufacturer email (not company name) | Y if "To" is an email address |
+| 5 | DB verify | Query `pms_warranty_claims.email_draft` | `email_draft.to = manufacturer_email` from metadata | Y if address matches what was filed |
+
+---
+
+## Buttons on the warranty lens — complete list
+
+| Button | Location | Visible when | Role required | Action fired |
+|--------|----------|--------------|---------------|--------------|
+| **Submit Claim** | Primary (top right) | status = `draft` | chief_engineer, chief_officer, captain, manager | `submit_warranty_claim` |
+| **Approve** | Primary | status = `submitted` | captain, manager | `approve_warranty_claim` — popup |
+| **Close Claim** | Primary | status = `approved` | captain, manager | `close_warranty_claim` |
+| **Revise & Resubmit** | Primary | status = `rejected` | chief_engineer, chief_officer, captain, manager | `submit_warranty_claim` |
+| **Reject Claim** | Dropdown | status = `submitted` | captain, manager | `reject_warranty_claim` — popup |
+| **Compose Email Draft** | Dropdown | status ≠ `draft` | chief_engineer, chief_officer, captain, manager | `compose_warranty_email` |
+| **Add Note** | Dropdown | always | chief_engineer, chief_officer, captain, manager | opens AddNoteModal |
+| **Archive** | Dropdown | status = `draft` or `rejected` | (same as file) | `archive_warranty` |
+| **Add file** | Attachments section | always | any authenticated user | opens AttachmentUploadModal |
+
+**Source:** `apps/web/src/components/lens-v2/entity/WarrantyContent.tsx:119–213`
+
+---
+
+## Signature / confirmation popups — where they appear
+
+| Action | Has popup | Popup fields | Source |
+|--------|-----------|-------------|--------|
+| Submit Claim | **NO** — fires directly | None | `WarrantyContent.tsx:139` `actionHasFields` = false |
+| Approve | **YES** | `approved_amount` (optional), `notes` (optional) | `registry.py:2293`, `mapActionFields.ts` renders optional_fields |
+| Reject | **YES** | `rejection_reason` (required) | `registry.py:2309` |
+| Close Claim | **NO** — fires directly | None | No fields in registry |
+| Compose Email | **NO** — fires directly | None | No user fields needed |
+| Add Note | **YES** — separate modal | `note_text` textarea | `AddNoteModal` component |
+
+> **Signature level:** None of the warranty actions currently require a cryptographic signature (`requires_signature = False` on all). The Approve action has an `ActionPopup` for data input but is not a signed action in the MLC sense. This is intentional for warranty — it is an internal workflow, not a compliance document.
+
+---
+
+## Field contract — what to enter and what lands in the DB
+
+| UI field | DB column | Notes |
+|----------|-----------|-------|
+| Title | `title` | Required |
+| Vendor / Manufacturer name | `vendor_name` | Required |
+| Claim type (dropdown) | `claim_type` | Options: manufacturer_defect, premature_failure, incorrect_part, damage_in_transit, other |
+| Description | `description` | Clean — manufacturer email no longer prepended here |
+| Manufacturer email | `metadata.manufacturer_email` | Stored in JSONB metadata column, not a dedicated column |
+| Currency | `currency` | EUR/USD/GBP/AUD/SGD — defaults to USD in modal |
+| Claimed amount | `claimed_amount` | Numeric |
+| Equipment ID | `equipment_id` | Free-text UUID currently (search picker not built) |
+| Part number | `part_number` | Free text |
+| Serial number | `serial_number` | Free text |
+
+**Source:** `apps/api/action_router/dispatchers/internal_dispatcher.py:3491–3514`
+
+---
+
+## Email draft — what works and what doesn't
+
+### What works
+- `compose_warranty_email` action generates a structured email template
+- `email_draft.to` = `metadata.manufacturer_email` (the address filed with the claim), falls back to `vendor_name` if no email stored
+- `email_draft.subject` = `"Warranty Claim {claim_number} — {title}"`
+- `email_draft.body` contains: salutation, claim number, title, claim type, serial number, manufacturer, claimed amount, description
+- Email draft is stored in `pms_warranty_claims.email_draft` JSONB and returned via entity endpoint
+- Lens shows **Subject** and **To** address in the Email Draft section
+
+**Source:** `internal_dispatcher.py:3834–3890`, `WarrantyContent.tsx:382–394`
+
+### What does NOT work (gaps)
+- **Body text is NOT rendered in the UI.** It is in the DB but WarrantyContent only shows Subject and To.
+- **No edit UI.** The template cannot be modified in-app.
+- **No Bcc / CC fields.** Not in the data model or the UI. `internal_dispatcher.py:3847` only has `to`, `subject`, `body`.
+- **Does not send.** This is correct and intentional — system provides a draft template only. The user copies and sends via their own email client.
+
+---
+
+## Ledger — what gets written and where
+
+| Action | `event_type` | `entity_type` | Written by |
+|--------|-------------|---------------|-----------|
+| View claim | `view` | `warranty` | `entity_routes.py:500–518` — explicit |
+| File claim | `create` | `warranty` | `p0_actions_routes.py:1133` Phase B safety net |
+| Submit claim | `status_change` | `warranty` | Phase B safety net |
+| Approve | `approval` | `warranty` | Phase B safety net |
+| Reject | `rejection` | `warranty` | Phase B safety net |
+| Close | `status_change` | `warranty` | Phase B safety net |
+| Compose email | `update` | `warranty` | Phase B safety net |
+| Add note | `update` | `warranty` | Phase B safety net |
+
+**Source:** `apps/api/action_router/ledger_metadata.py:97–105`, `p0_actions_routes.py:1133–1177`
+
+**To verify ledger in DB:**
+```sql
+SELECT event_type, action, user_role, created_at
+FROM ledger_events
+WHERE entity_type = 'warranty'
+  AND entity_id = '<claim_id>'
+ORDER BY created_at;
+```
+
+Or via Supabase REST:
+```
+GET /rest/v1/ledger_events?entity_id=eq.<claim_id>&entity_type=eq.warranty
+```
+
+---
+
+## Notifications — what gets sent and to whom
+
+| Trigger | Recipient | Notification type | Title |
+|---------|-----------|-------------------|-------|
+| Claim submitted | All `captain` + `manager` on vessel | `warranty_submitted` | "Warranty Claim Submitted: {title}" |
+| Claim approved | Drafter of claim | `warranty_approved` | "Warranty Claim Approved" |
+| Claim approved | Submitter (if ≠ drafter) | `warranty_approved` | "Warranty Claim Approved" |
+| Claim rejected | Drafter | `warranty_rejected` | "Warranty Claim Rejected" |
+| Claim rejected | Submitter (if ≠ drafter) | `warranty_rejected` | "Warranty Claim Rejected" |
+| Claim closed | Drafter + submitter | `warranty_closed` | "Warranty Claim Closed" |
+| Email composed | All captains/managers (excl. composer) | `warranty_email_composed` | "Warranty Email Draft Ready" |
+| Note added | Drafter + submitter + approver | `warranty_note_added` | "Note Added to Warranty Claim" |
+
+Every notification row has `entity_type=warranty` and `entity_id=<claim_id>`.
+
+**Gap:** There is no frontend notification bell or inbox for warranty. Rows are written to `pms_notifications` in the DB but nothing in the app surface reads them for warranty. `apps/web/src/app/api/v1/notifications/route.ts:13` returns an empty array stub.
+
+**To verify notifications in DB:**
+```sql
+SELECT notification_type, title, user_id, is_read
+FROM pms_notifications
+WHERE entity_id = '<claim_id>'
+ORDER BY created_at;
+```
+
+---
+
+## Document attachments
+
+- Upload button is always visible in the Attachments section of the lens
+- Opens `AttachmentUploadModal` with `bucket=pms-warranty-documents`, `entityType=warranty`, `category=claim_document`
+- **Source:** `WarrantyContent.tsx:396–406`
+- Uploaded files are retrieved on entity load via `_get_attachments(supabase, "warranty", warranty_id, yacht_id)` in `entity_routes.py:~530`
+- Any authenticated user can upload (no role gate on the upload button itself)
+
+---
+
+## Edge cases and limits
+
+### is_seed trap
+All `pms_warranty_claims` rows have `is_seed DEFAULT TRUE` in the DB schema. The `v_warranty_enriched` view filters out rows where `is_seed = true`. If a claim was created before PR #558 (2026-04-15), it may have `is_seed = true` and will return 404 from the entity endpoint.
+
+**Fix:** Set `is_seed = false` directly in DB for those rows:
+```sql
+UPDATE pms_warranty_claims SET is_seed = false WHERE is_seed = true AND claim_number NOT LIKE 'WC-TEST-%';
+```
+Do NOT clear seed data rows (WC-TEST-001 through WC-TEST-005) — they are intentional test fixtures.
+
+### Status gate violations
+- Trying to submit a claim that is already `submitted` → returns `{"status": "error", "message": "Claim must be in draft or rejected status to submit"}`
+- Trying to approve a `draft` → `"Claim must be submitted to approve"`
+- Trying to close an `approved=false` claim → `"Claim must be approved to close"`
+
+These are hard guards in `internal_dispatcher.py:3553`, `3618`, `3782`.
+
+### Compose email before manufacturer email filed
+If the claim was filed without a `manufacturer_email` value, `compose_warranty_email` will set `email_draft.to = vendor_name` (the company name). This is a visual tell that no email address was captured.
+
+**Check:** look at `email_draft.to` — if it contains spaces or looks like a company name rather than an email address, no manufacturer email was supplied at filing time.
+
+### Duplicate claim numbers
+Claim numbering is `WC-{year}-{count+1}`. Count is computed as the number of existing claims for that yacht in that year. This is NOT atomic — concurrent filings could produce duplicate numbers. Low risk for single-vessel operation.
+
+**Source:** `internal_dispatcher.py:3483–3489`
+
+### No equipment search picker
+`equipment_id` and `work_order_id` in the file warranty modal are free-text UUID inputs. Entering an invalid UUID or wrong ID will store a broken FK that cannot be resolved by the entity endpoint's equipment join. The equipment name will appear blank on the lens.
+
+---
+
+## Proof checklist — run this to call it done
+
+```
+□ 1. Log in as chief_engineer
+      Navigate to Warranty → File Warranty Claim modal opens
+      Fill: Title, Vendor, Manufacturer Email (test@test.com), Currency=EUR, Amount=1000
+      Click Submit
+      PASS: status pill = "Draft", claim_number = "WC-{year}-XXX"
+
+□ 2. Same user clicks "Submit Claim" primary button
+      PASS: pill changes to amber "Submitted", no popup
+      FAIL signals: 422 error, unchanged status, spinner hangs
+
+□ 3. Log in as captain, navigate to same claim
+      PASS: primary button = "Approve" (not "Submit Claim")
+      Click Approve
+      PASS: popup appears with "approved_amount" and "notes" fields (both optional, "(optional)" suffix visible)
+      Enter approved_amount=900, submit
+      PASS: status = green "Approved"
+
+□ 4. Captain: Dropdown → Compose Email Draft
+      PASS: Email Draft section appears at bottom
+      PASS: "To" field = test@test.com (the email entered at filing, not the company name)
+      FAIL signal: "To" shows company name = manufacturer_email was not stored
+
+□ 5. Captain: Primary button = "Close Claim"
+      PASS: status = red "Closed", no popup
+      
+□ 6. Create a second claim, go through to Submitted, captain clicks Reject
+      PASS: popup appears with "rejection_reason" REQUIRED field
+      FAIL signal: popup missing field
+      Fill reason, submit
+      PASS: rejection_reason visible in Claim Details section
+
+□ 7. Rejected claim: chief_engineer clicks "Revise & Resubmit"
+      PASS: status back to Submitted
+
+□ 8. Attachments: click Add file on any claim
+      PASS: upload modal opens
+      Upload any PDF
+      PASS: attachment row appears in Attachments section after upload
+
+□ 9. Notes: Dropdown → Add Note
+      PASS: modal opens with text area
+      Submit note
+      PASS: note row appears in Notes section
+
+□ 10. DB verify (Supabase dashboard or psql):
+      SELECT currency, metadata, description FROM pms_warranty_claims WHERE id = '<claim_id>';
+      PASS: currency = 'EUR', metadata = {"manufacturer_email":"test@test.com"}, description does NOT contain the email address
+
+□ 11. Ledger verify:
+      SELECT event_type, action FROM ledger_events WHERE entity_type='warranty' AND entity_id='<claim_id>';
+      PASS: rows exist for create, status_change, approval, view
+      FAIL signal: empty result = Phase B safety net not firing
+
+□ 12. Notifications verify:
+      SELECT notification_type, user_id FROM pms_notifications WHERE entity_id='<claim_id>';
+      PASS: warranty_submitted rows exist (one per captain/manager on vessel)
+      PASS: warranty_approved row exists addressed to the drafter's user_id
+```
+
+---
+
+## Known gaps — do not claim these work
+
+| Gap | Status | Who should fix |
+|-----|--------|---------------|
+| `crew` role cannot file warranty claims | Not built | WARRANTY01 — add `crew` to `file_warranty_claim.allowed_roles` in `registry.py:2740` |
+| Email body not displayed in UI | Not built | WARRANTY01 — render `email_draft.body` in `WarrantyContent.tsx:382` |
+| Email body not editable in-app | Not built | WARRANTY01 — add textarea for email body editing |
+| Bcc / CC fields on email draft | Not built | WARRANTY01 — add to `email_draft` data model and compose handler |
+| Notification inbox / bell for warranty | Not built | WARRANTY01 — `apps/web/src/app/api/v1/notifications/route.ts` returns empty array stub |
+| Equipment / WO ref search picker | Not built | Separate feature — requires `SearchPicker` component |
+| Auto email link (NLP match) | Not built | Separate feature — manual email linking only |
+| Atomic claim number generation | Race condition risk | Low priority for single vessel |
+
+---
+
+## For HMAC01 — receipt layer adapter notes
+
+**Domain:** `warranty`  
+**Primary table:** `pms_warranty_claims`  
+**Read via view:** `v_warranty_enriched` — always use this for reads, filters `is_seed=false`  
+**Ledger entity_type:** `warranty`  
+**Ledger entity_id field:** `warranty_id` (maps to `id` on the claims table)  
+
+**Receipt trigger events:** `approval` (`approve_warranty_claim`) and `status_change:close` (`close_warranty_claim`)  
+**Receipt shape:** Single scope — one claim = one receipt  
+
+**Key fields for receipt body:** `claim_number`, `title`, `vendor_name`, `manufacturer`, `claimed_amount`, `currency`, `approved_amount`, `status`, `drafted_at`, `submitted_at`, `approved_at`, `drafted_by`, `submitted_by`, `approved_by`, `description`  
+
+**HMAC rules that apply:**
+- No raw UUIDs in sealed PDF — use HMAC refs for `drafted_by`, `submitted_by`, `approved_by`
+- `is_seed` guard: only process claims where `is_seed = false`
+- `yacht_id` scope is enforced at DB level (RLS on tenant project `vzsohavtuotocgrfkfyd`)
+- No LLM calls — `email_draft.body` is a deterministic Python f-string, no inference in the path
+
+**Audit trail for receipt:** `pms_audit_log WHERE entity_type='warranty' AND entity_id='<claim_id>'`
+
+**Adapter contract questions to answer:**
+1. What records? → rows from `v_warranty_enriched` for the given `entity_id` + `yacht_id`
+2. Which ledger events? → `approval` and/or `status_change` events from `ledger_events` for the claim


### PR DESCRIPTION
## Summary
- Adds `docs/ongoing_work/warranty/WARRANTY_TEST_CHEATSHEET.md`
- Complete warranty domain test reference: role map, status lifecycle, button inventory, popup locations, field contracts, email gaps, ledger table, notification matrix, 12-step proof checklist, known gaps, HMAC01 adapter notes

## Test plan
- [ ] Docs only — no code changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)