### PR TITLE
fix(documents): wire ledger_events + notifications for all document CRUD

### DIFF
--- a/apps/api/action_router/ledger_metadata.py
+++ b/apps/api/action_router/ledger_metadata.py
@@ -56,10 +56,12 @@ ACTION_METADATA: dict = {
     # ── Documents ────────────────────────────────────────────────────────────
     "add_document_comment":              {"event_type": "update",        "entity_type": "document",      "entity_id_field": "document_id"},
     "add_document_note":                 {"event_type": "update",        "entity_type": "document",      "entity_id_field": "document_id"},
+    "add_document_tags":                 {"event_type": "update",        "entity_type": "document",      "entity_id_field": "document_id"},
     "add_entity_link":                   {"event_type": "update",        "entity_type": "document",      "entity_id_field": "document_id"},
     "archive_document":                  {"event_type": "update",        "entity_type": "document",      "entity_id_field": "document_id"},
     "delete_document_comment":           {"event_type": "update",        "entity_type": "document",      "entity_id_field": "document_id"},
     "link_invoice_document":             {"event_type": "update",        "entity_type": "document",      "entity_id_field": "document_id"},
+    "update_document":                   {"event_type": "update",        "entity_type": "document",      "entity_id_field": "document_id"},
     "update_document_comment":           {"event_type": "update",        "entity_type": "document",      "entity_id_field": "document_id"},
 
     # ── Certificates ─────────────────────────────────────────────────────────

--- a/apps/api/routes/document_routes.py
+++ b/apps/api/routes/document_routes.py
@@ -26,6 +26,7 @@ from middleware.auth import get_authenticated_user
 from middleware.vessel_access import resolve_yacht_id
 from supabase import create_client
 from utils.filenames import sanitize_storage_filename
+from routes.handlers.ledger_utils import build_ledger_event
 
 logger = logging.getLogger(__name__)
 
@@ -782,8 +783,50 @@ async def upload_document(
     try:
         supabase.table('pms_audit_log').insert(audit).execute()
     except Exception as audit_err:
-        # Non-fatal — the document is already uploaded and recorded.
         logger.warning(f"[documents/upload] audit log insert failed (non-fatal): {audit_err}")
+
+    # -----------------------------------------------------------------------
+    # Step 4 — ledger_events (required for receipt-layer sealing)
+    # -----------------------------------------------------------------------
+    try:
+        ledger_event = build_ledger_event(
+            yacht_id=yacht_id,
+            user_id=user_id,
+            event_type="create",
+            entity_type="document",
+            entity_id=inserted_id,
+            action="upload_document",
+            user_role=user_role,
+            change_summary=f"Document uploaded: {filename}",
+        )
+        supabase.table('ledger_events').insert(ledger_event).execute()
+    except Exception as ledger_err:
+        if "204" not in str(ledger_err):
+            logger.warning(f"[documents/upload] ledger insert failed (non-fatal): {ledger_err}")
+
+    # -----------------------------------------------------------------------
+    # Step 5 — notification (non-fatal)
+    # -----------------------------------------------------------------------
+    try:
+        notif_key = f"doc_upload_{inserted_id}"
+        supabase.table('pms_notifications').insert({
+            'yacht_id': yacht_id,
+            'user_id': user_id,
+            'notification_type': 'document_uploaded',
+            'title': 'Document uploaded',
+            'body': f'{filename} uploaded to vessel documents',
+            'priority': 'normal',
+            'entity_type': 'document',
+            'entity_id': inserted_id,
+            'cta_action_id': 'get_document_url',
+            'cta_payload': {'document_id': inserted_id},
+            'idempotency_key': notif_key,
+            'is_read': False,
+            'triggered_by': user_id,
+            'metadata': {'source': 'document_lens', 'filename': filename, 'role': user_role},
+        }).execute()
+    except Exception as notif_err:
+        logger.warning(f"[documents/upload] notification insert failed (non-fatal): {notif_err}")
 
     logger.info(
         f"[documents/upload] OK: doc_id={inserted_id[:8]} yacht={yacht_id[:8]} "

--- a/apps/api/routes/handlers/document_handler.py
+++ b/apps/api/routes/handlers/document_handler.py
@@ -11,12 +11,44 @@ Block 3 (L5037-5078): upload_document, update_document, delete_document, add_doc
     get_document_url, list_documents — delegates to handlers.document_handlers via get_document_handlers().
 """
 import logging
+import uuid
 
 from fastapi import HTTPException
 from supabase import Client
 from routes.handlers.ledger_utils import build_ledger_event
 
 logger = logging.getLogger(__name__)
+
+
+def _push_doc_notification(
+    db_client: Client,
+    yacht_id: str,
+    user_id: str,
+    action: str,
+    title: str,
+    body: str,
+    entity_id: str,
+    user_role: str = None,
+) -> None:
+    try:
+        db_client.table("pms_notifications").insert({
+            "yacht_id": yacht_id,
+            "user_id": user_id,
+            "notification_type": f"document_{action}",
+            "title": title,
+            "body": body,
+            "priority": "normal",
+            "entity_type": "document",
+            "entity_id": entity_id,
+            "cta_action_id": "get_document_url",
+            "cta_payload": {"document_id": entity_id},
+            "idempotency_key": f"doc_{action}_{entity_id}_{str(uuid.uuid4())[:8]}",
+            "is_read": False,
+            "triggered_by": user_id,
+            "metadata": {"source": "document_lens", "role": user_role or ""},
+        }).execute()
+    except Exception as notif_err:
+        logger.warning(f"[Notification] doc {action} failed (non-fatal): {notif_err}")
 
 # RBAC mapping for Document Lens v2 actions (from original L5040-5048)
 _DOC_V2_ALLOWED_ROLES = {
@@ -172,6 +204,13 @@ async def upload_document(
         except Exception as ledger_err:
             if "204" not in str(ledger_err):
                 logger.warning(f"[Ledger] Failed to record upload_document: {ledger_err}")
+        _push_doc_notification(
+            db_client, yacht_id, user_id, "uploaded",
+            "Document uploaded",
+            f"{payload.get('file_name', 'document')} uploaded to vessel documents",
+            result.get("document_id") or result.get("id") or yacht_id,
+            user_context.get("role"),
+        )
         result["_ledger_written"] = True
     return result
 
@@ -181,7 +220,33 @@ async def update_document(
     user_context: dict, db_client: Client,
 ) -> dict:
     _enforce_doc_rbac("update_document", user_context)
-    return await _delegate_to_doc_handler("update_document", db_client, yacht_id, user_id, payload)
+    document_id = payload.get("document_id")
+    result = await _delegate_to_doc_handler("update_document", db_client, yacht_id, user_id, payload)
+    if isinstance(result, dict) and result.get("status") != "error":
+        try:
+            ledger_event = build_ledger_event(
+                yacht_id=yacht_id,
+                user_id=user_id,
+                event_type="update",
+                entity_type="document",
+                entity_id=document_id or yacht_id,
+                action="update_document",
+                user_role=user_context.get("role"),
+                change_summary=f"Document metadata updated: {', '.join(result.get('updated_fields', []))}",
+            )
+            db_client.table("ledger_events").insert(ledger_event).execute()
+        except Exception as ledger_err:
+            if "204" not in str(ledger_err):
+                logger.warning(f"[Ledger] Failed to record update_document: {ledger_err}")
+        _push_doc_notification(
+            db_client, yacht_id, user_id, "updated",
+            "Document updated",
+            f"Document metadata updated: {', '.join(result.get('updated_fields', []))}",
+            document_id or yacht_id,
+            user_context.get("role"),
+        )
+        result["_ledger_written"] = True
+    return result
 
 
 async def delete_document(
@@ -207,6 +272,13 @@ async def delete_document(
         except Exception as ledger_err:
             if "204" not in str(ledger_err):
                 logger.warning(f"[Ledger] Failed to record delete_document: {ledger_err}")
+        _push_doc_notification(
+            db_client, yacht_id, user_id, "deleted",
+            "Document deleted",
+            f"Document deleted: {payload.get('reason', 'no reason given')}",
+            document_id or yacht_id,
+            user_context.get("role"),
+        )
         result["_ledger_written"] = True
     return result
 
@@ -216,7 +288,33 @@ async def add_document_tags(
     user_context: dict, db_client: Client,
 ) -> dict:
     _enforce_doc_rbac("add_document_tags", user_context)
-    return await _delegate_to_doc_handler("add_document_tags", db_client, yacht_id, user_id, payload)
+    document_id = payload.get("document_id")
+    result = await _delegate_to_doc_handler("add_document_tags", db_client, yacht_id, user_id, payload)
+    if isinstance(result, dict) and result.get("status") != "error":
+        try:
+            ledger_event = build_ledger_event(
+                yacht_id=yacht_id,
+                user_id=user_id,
+                event_type="update",
+                entity_type="document",
+                entity_id=document_id or yacht_id,
+                action="add_document_tags",
+                user_role=user_context.get("role"),
+                change_summary=f"Tags updated: {payload.get('tags', [])}",
+            )
+            db_client.table("ledger_events").insert(ledger_event).execute()
+        except Exception as ledger_err:
+            if "204" not in str(ledger_err):
+                logger.warning(f"[Ledger] Failed to record add_document_tags: {ledger_err}")
+        _push_doc_notification(
+            db_client, yacht_id, user_id, "tags_updated",
+            "Document tags updated",
+            f"Tags updated: {payload.get('tags', [])}",
+            document_id or yacht_id,
+            user_context.get("role"),
+        )
+        result["_ledger_written"] = True
+    return result
 
 
 async def get_document_url(


### PR DESCRIPTION
## Summary
- Upload, update, tags, delete now write `ledger_events` rows (was only delete before)
- Adds `pms_notifications` for all four CRUD actions via shared `_push_doc_notification()` helper
- Adds `update_document` and `add_document_tags` to `ledger_metadata.py` safety net
- 25/25 live wirewalk test passed pre-fix; ledger gaps confirmed on real tenant DB

## Files changed
- `apps/api/action_router/ledger_metadata.py` — 2 new entries
- `apps/api/routes/document_routes.py` — ledger + notification after upload
- `apps/api/routes/handlers/document_handler.py` — ledger + notification for update/tags/delete + helper

## Test plan
- [ ] Re-run `scripts/one-off/documents01_real_pass_wirewalk.py` after deploy
- [ ] Verify `ledger_events` rows present for upload, update, tags, delete
- [ ] Verify `pms_notifications` rows present for all four actions
- [ ] Confirm no regressions on crew 403 / HOD 200 / captain 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)