### PR TITLE
fix(certificates): close 6 gaps — mutation gate, created_by, crew projection, stale actions

### DIFF
--- a/apps/api/config/projection.yaml
+++ b/apps/api/config/projection.yaml
@@ -275,6 +275,33 @@ certificates:
     expiry: expiry_date
     authority: issuing_authority
 
+crew_certificates:
+  source_table: pms_crew_certificates
+  object_type: crew_certificate
+  search_text:
+    - field: person_name
+      cast: text
+    - field: certificate_type
+      cast: text
+    - field: certificate_number
+      cast: text
+    - field: issuing_authority
+      cast: text
+  filters:
+    certificate_type: certificate_type
+    status: status
+    expiry_date:
+      source: expiry_date
+      transform: "to_char(%, 'YYYY-MM-DD')"
+    issuing_authority: issuing_authority
+  payload:
+    name: person_name
+    type: certificate_type
+    number: certificate_number
+    status: status
+    expiry: expiry_date
+    authority: issuing_authority
+
 email:
   source_table: email_messages
   object_type: email
@@ -525,7 +552,7 @@ hours_of_rest_signoffs:
 
 promoted_facets:
   - key: status
-    domains: [work_orders, faults, equipment, receiving, certificates, hours_of_rest_signoffs]
+    domains: [work_orders, faults, equipment, receiving, certificates, crew_certificates, hours_of_rest_signoffs]
     index_type: btree
   - key: priority
     domains: [work_orders]
@@ -538,10 +565,10 @@ promoted_facets:
     domains: [documents]
     index_type: btree
   - key: certificate_type
-    domains: [certificates]
+    domains: [certificates, crew_certificates]
     index_type: btree
   - key: expiry_date
-    domains: [certificates]
+    domains: [certificates, crew_certificates]
     index_type: btree
     transform: to_date
   - key: equipment_id

--- a/apps/api/handlers/certificate_handlers.py
+++ b/apps/api/handlers/certificate_handlers.py
@@ -696,6 +696,60 @@ class CertificateHandlers:
                 icon="edit"
             ))
 
+        # Renew (not for terminal states)
+        if status not in ("superseded", "revoked"):
+            actions.append(AvailableAction(
+                action_id="renew_certificate",
+                label="Renew",
+                variant="MUTATE",
+                icon="refresh-cw"
+            ))
+
+        # Assign responsible officer
+        actions.append(AvailableAction(
+            action_id="assign_certificate",
+            label="Assign Officer",
+            variant="MUTATE",
+            icon="user-check"
+        ))
+
+        # Add note (always available)
+        actions.append(AvailableAction(
+            action_id="add_certificate_note",
+            label="Add Note",
+            variant="MUTATE",
+            icon="message-square"
+        ))
+
+        # Danger zone (not for terminal states)
+        if status not in ("superseded", "revoked"):
+            actions.append(AvailableAction(
+                action_id="suspend_certificate",
+                label="Suspend",
+                variant="SIGNED",
+                icon="pause-circle",
+                requires_signature=True,
+                confirmation_message="This will suspend this certificate. This action is logged."
+            ))
+            actions.append(AvailableAction(
+                action_id="revoke_certificate",
+                label="Revoke",
+                variant="SIGNED",
+                icon="x-circle",
+                requires_signature=True,
+                confirmation_message="This will permanently revoke this certificate. This action is logged and cannot be undone."
+            ))
+
+        # Archive (always available, soft-delete)
+        actions.append(AvailableAction(
+            action_id="archive_certificate",
+            label="Archive",
+            variant="SIGNED",
+            icon="archive",
+            requires_signature=True,
+            confirmation_message="This will archive this certificate record."
+        ))
+
         # Delete action (for draft or manager-only)
         if status == "draft":
             actions.append(AvailableAction(
@@ -778,6 +832,7 @@ def _create_vessel_certificate_adapter(handlers: CertificateHandlers):
             "status": "valid",
             "document_id": params.get("document_id"),
             "properties": params.get("properties") or {},
+            "created_by": user_id,
             "created_at": datetime.now(timezone.utc).isoformat(),
         }
 
@@ -847,9 +902,11 @@ def _link_document_to_certificate_adapter(handlers: CertificateHandlers):
         user_id = params["user_id"]
         cert_id = params["certificate_id"]
         document_id = params["document_id"]
-        domain = (params.get("domain") or "vessel").lower()
 
-        table = get_table("vessel_certificates" if domain == "vessel" else "crew_certificates")
+        # Auto-detect domain from the actual cert row (don't trust client)
+        domain, table_key, _cert_row = _resolve_cert_domain(db, yacht_id, cert_id)
+        _cert_mutation_gate(domain, (params.get("user_context") or {}).get("role", ""), "link_document_to_certificate")
+        table = get_table(table_key)
 
         # Basic existence checks (defensive against client return shapes)
         try:
@@ -913,16 +970,11 @@ def _update_certificate_adapter(handlers: CertificateHandlers):
         yacht_id = params["yacht_id"]
         user_id = params["user_id"]
         cert_id = params["certificate_id"]
-        domain = (params.get("domain") or "vessel").lower()
 
-        table = get_table("vessel_certificates" if domain == "vessel" else "crew_certificates")
-
-        # Get current values for audit
-        current = db.table(table).select("*").eq("yacht_id", yacht_id).eq("id", cert_id).maybe_single().execute()
-        if not current.data:
-            raise ValueError(f"Certificate not found or access denied: {cert_id}")
-
-        old_values = current.data
+        # Auto-detect domain from the actual cert row
+        domain, table_key, old_values = _resolve_cert_domain(db, yacht_id, cert_id)
+        _cert_mutation_gate(domain, (params.get("user_context") or {}).get("role", ""), "update_certificate")
+        table = get_table(table_key)
 
         # Don't allow updates to superseded/revoked certificates
         if old_values.get("status") in ("superseded", "revoked"):
@@ -1026,6 +1078,7 @@ def _create_crew_certificate_adapter(handlers: CertificateHandlers):
             "expiry_date": params.get("expiry_date"),
             "document_id": params.get("document_id"),
             "properties": params.get("properties") or {},
+            "created_by": user_id,
             "created_at": datetime.now(timezone.utc).isoformat(),
         }
 
@@ -1236,6 +1289,26 @@ def _resolve_cert_domain(db, yacht_id: str, cert_id: str) -> tuple:
     raise ValueError(f"Certificate {cert_id} not found or access denied")
 
 
+# ── Domain-based role narrowing ──────────────────────────────────────────
+# The registry allows the full 8-HOD union so the action appears in the
+# dropdown for any HOD. This gate narrows at handler level: engineering
+# roles can only mutate vessel certs, interior roles can only mutate crew
+# certs. Captain + manager pass unconditionally.
+
+_VESSEL_CERT_ROLES = frozenset({"engineer", "eto", "chief_engineer", "chief_officer", "captain", "manager"})
+_CREW_CERT_ROLES = frozenset({"chief_engineer", "chief_officer", "purser", "chief_steward", "captain", "manager"})
+
+
+def _cert_mutation_gate(domain: str, user_role: str, action: str) -> None:
+    """Raise ValueError if user_role cannot mutate a cert in this domain."""
+    if user_role in ("captain", "manager"):
+        return  # always allowed
+    if domain == "vessel" and user_role not in _VESSEL_CERT_ROLES:
+        raise ValueError(f"Role '{user_role}' cannot modify vessel certificates")
+    if domain == "crew" and user_role not in _CREW_CERT_ROLES:
+        raise ValueError(f"Role '{user_role}' cannot modify crew certificates")
+
+
 def _renew_certificate_adapter(handlers: "CertificateHandlers"):
     async def _fn(**params):
         """
@@ -1263,6 +1336,7 @@ def _renew_certificate_adapter(handlers: "CertificateHandlers"):
             raise ValueError("new_expiry_date must be after new_issue_date")
 
         domain, table_key, old_cert = _resolve_cert_domain(db, yacht_id, cert_id)
+        _cert_mutation_gate(domain, (params.get("user_context") or {}).get("role", ""), "renew_certificate")
         table = get_table(table_key)
 
         if old_cert.get("status") in ("superseded", "revoked"):
@@ -1357,6 +1431,7 @@ def _change_certificate_status_adapter(new_status: str):
                 raise ValueError("entity_id (certificate id) is required")
 
             domain, table_key, old_cert = _resolve_cert_domain(db, yacht_id, cert_id)
+            _cert_mutation_gate(domain, (params.get("user_context") or {}).get("role", ""), f"{new_status}_certificate")
             table = get_table(table_key)
 
             current_status = old_cert.get("status")
@@ -1427,6 +1502,7 @@ def _archive_certificate_adapter(handlers: "CertificateHandlers"):
             raise ValueError("entity_id (certificate id) is required")
 
         domain, table_key, old_cert = _resolve_cert_domain(db, yacht_id, cert_id)
+        _cert_mutation_gate(domain, (params.get("user_context") or {}).get("role", ""), "archive_certificate")
         table = get_table(table_key)
 
         now = datetime.now(timezone.utc).isoformat()
@@ -1494,6 +1570,7 @@ def _assign_certificate_adapter(handlers: "CertificateHandlers"):
 
         # Find the cert (vessel or crew) — reuses domain resolver
         domain, table_key, old_cert = _resolve_cert_domain(db, yacht_id, cert_id)
+        _cert_mutation_gate(domain, (params.get("user_context") or {}).get("role", ""), "assign_certificate")
         table = get_table(table_key)
 
         now = datetime.now(timezone.utc).isoformat()

--- a/apps/api/tests/cert_binary_tests.py
+++ b/apps/api/tests/cert_binary_tests.py
@@ -21,6 +21,8 @@ TENANT_URL = "https://vzsohavtuotocgrfkfyd.supabase.co"
 TENANT_KEY = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InZ6c29oYXZ0dW90b2NncmZrZnlkIiwicm9sZSI6InNlcnZpY2Vfcm9sZSIsImlhdCI6MTc2MzU5Mjg3NSwiZXhwIjoyMDc5MTY4ODc1fQ.fC7eC_4xGnCHIebPzfaJ18pFMPKgImE7BuN0I3A-pSY"
 YACHT_ID  = "85fe1119-b04c-41ac-80f1-829d23322598"
 USER_ID   = "00000000-0000-0000-0000-000000000001"  # synthetic test user
+# _cert_mutation_gate requires user_context with role for domain-based narrowing
+USER_CTX  = {"role": "captain", "user_id": USER_ID}
 
 import os
 os.environ.setdefault("SUPABASE_URL", TENANT_URL)
@@ -126,6 +128,7 @@ try:
     result = asyncio.run(handlers["renew_certificate"](
         yacht_id=YACHT_ID,
         user_id=USER_ID,
+        user_context=USER_CTX,
         certificate_id=old_id,
         new_issue_date="2026-02-01",
         new_expiry_date="2027-02-01",
@@ -160,6 +163,7 @@ try:
     asyncio.run(handlers["suspend_certificate"](
         yacht_id=YACHT_ID,
         user_id=USER_ID,
+        user_context=USER_CTX,
         entity_id=cert_id,
         reason="Test suspension",
         signature={"signer": USER_ID, "method": "test"},
@@ -195,6 +199,7 @@ try:
     asyncio.run(handlers["revoke_certificate"](
         yacht_id=YACHT_ID,
         user_id=USER_ID,
+        user_context=USER_CTX,
         entity_id=crew_id,
         reason="Test revocation",
         signature={"signer": USER_ID, "method": "test"},
@@ -226,6 +231,7 @@ try:
     asyncio.run(handlers["archive_certificate"](
         yacht_id=YACHT_ID,
         user_id=USER_ID,
+        user_context=USER_CTX,
         entity_id=cert_id,
     ))
     row = get_vessel(cert_id)
@@ -256,6 +262,7 @@ try:
     asyncio.run(handlers["archive_certificate"](
         yacht_id=YACHT_ID,
         user_id=USER_ID,
+        user_context=USER_CTX,
         entity_id=crew_id,
     ))
     row = get_crew(crew_id)
@@ -339,6 +346,7 @@ try:
     asyncio.run(handlers["renew_certificate"](
         yacht_id=YACHT_ID,
         user_id=USER_ID,
+        user_context=USER_CTX,
         certificate_id=cert_id,
         new_issue_date="2026-01-01",
         new_expiry_date="2027-01-01",
@@ -430,6 +438,7 @@ try:
     asyncio.run(handlers["assign_certificate"](
         yacht_id=YACHT_ID,
         user_id=USER_ID,
+        user_context=USER_CTX,
         certificate_id=cert_id,
         assigned_to=USER_ID,
         assigned_to_name="Chief Engineer Test",
@@ -459,6 +468,7 @@ try:
     asyncio.run(handlers["suspend_certificate"](
         yacht_id=YACHT_ID,
         user_id=USER_ID,
+        user_context=USER_CTX,
         entity_id=cert_id,
         reason="Should not work",
     ))
@@ -478,6 +488,7 @@ try:
     asyncio.run(handlers["revoke_certificate"](
         yacht_id=YACHT_ID,
         user_id=USER_ID,
+        user_context=USER_CTX,
         entity_id=cert_id,
         reason="Should not work",
     ))
@@ -488,6 +499,44 @@ except Exception as e:
     record("T13: wrong exception type", False, str(e))
 finally:
     cleanup(("pms_crew_certificates", cert_id))
+
+
+# ─── TEST 14: mutation gate — engineer blocked from crew cert ────────────────
+print("\nT14: mutation gate — engineer cannot archive crew cert")
+crew_id = make_crew_cert()
+try:
+    asyncio.run(handlers["archive_certificate"](
+        yacht_id=YACHT_ID,
+        user_id=USER_ID,
+        user_context={"role": "engineer", "user_id": USER_ID},
+        entity_id=crew_id,
+    ))
+    record("T14: engineer should be blocked from crew cert", False, "No exception")
+except ValueError as e:
+    record("T14: engineer correctly blocked from crew cert", True, str(e))
+except Exception as e:
+    record("T14: wrong exception type", False, str(e))
+finally:
+    cleanup(("pms_crew_certificates", crew_id))
+
+
+# ─── TEST 15: mutation gate — purser blocked from vessel cert ────────────────
+print("\nT15: mutation gate — purser cannot archive vessel cert")
+cert_id = make_vessel_cert()
+try:
+    asyncio.run(handlers["archive_certificate"](
+        yacht_id=YACHT_ID,
+        user_id=USER_ID,
+        user_context={"role": "purser", "user_id": USER_ID},
+        entity_id=cert_id,
+    ))
+    record("T15: purser should be blocked from vessel cert", False, "No exception")
+except ValueError as e:
+    record("T15: purser correctly blocked from vessel cert", True, str(e))
+except Exception as e:
+    record("T15: wrong exception type", False, str(e))
+finally:
+    cleanup(("pms_vessel_certificates", cert_id))
 
 
 # ─── T-META: ACTION_METADATA coverage (ledger safety net prerequisite) ──────

--- a/docs/explanations/LENS_DOMAINS/certificates_hmac_integration.md
+++ b/docs/explanations/LENS_DOMAINS/certificates_hmac_integration.md
@@ -76,6 +76,8 @@
 | `pms_vessel_certificates` | Vessel/machinery/flag certs | id, yacht_id, certificate_name, certificate_type, certificate_number, issuing_authority, issue_date, expiry_date, status, properties, document_id, deleted_at |
 | `pms_crew_certificates` | Seafarer/crew certs | id, yacht_id, person_name, person_node_id, certificate_type, certificate_number, issuing_authority, issue_date, expiry_date, status, properties, deleted_at |
 
+> **Note**: The crew member FK column is `person_node_id` (FK to `search_graph_nodes.id`), not `person_id`. Historical naming — functionally correct.
+
 ### 2.2 Unified view
 
 `v_certificates_enriched` — `UNION ALL` of both tables with `'vessel'::text AS domain` / `'crew'::text AS domain`. Filters: `deleted_at IS NULL` and `is_seed = false` (vessel only).


### PR DESCRIPTION
## Summary
- **_cert_mutation_gate**: engineer blocked from crew certs, purser blocked from vessel certs. Wired into all 6 mutation adapters. T14+T15 binary tests prove it.
- **created_by column**: ALTER TABLE on both cert tables + wired in create handlers
- **Crew cert projection**: pms_crew_certificates added to projection.yaml + search_projection_map for F1 search indexing
- **_get_certificate_actions updated**: now emits all 11 actions (was only 5 — stale dead code)
- **person_node_id documented** in HMAC01 integration notes
- **Binary tests expanded** from 45 to 47 assertions (mutation gate tests)

## Test plan
- [x] 47/47 PASS against live tenant DB
- [x] T14: engineer correctly blocked from archiving crew cert (ValueError)
- [x] T15: purser correctly blocked from archiving vessel cert (ValueError)
- [x] All existing tests still pass after mutation gate wiring
- [x] created_by column verified in DB via information_schema

🤖 Generated with [Claude Code](https://claude.com/claude-code)