### PR TITLE
fix(hor): Scenario 1 — surface submit errors, remove 680px width lock, fix flex height

### DIFF
--- a/apps/web/src/app/hours-of-rest/page.tsx
+++ b/apps/web/src/app/hours-of-rest/page.tsx
@@ -199,7 +199,7 @@ function HoursOfRestContent() {
       </div>
 
       {/* ── Tab content ── */}
-      <div style={{ flex: 1, overflow: 'auto', padding: '20px' }}>
+      <div style={{ flex: 1, minHeight: 0, overflow: 'auto', padding: '20px' }}>
         {activeTab === 'my-time'    && <MyTimeView />}
         {activeTab === 'department' && showDept   && <DepartmentView />}
         {activeTab === 'vessel'     && showVessel && <VesselComplianceView />}

--- a/apps/web/src/components/hours-of-rest/MyTimeView.tsx
+++ b/apps/web/src/components/hours-of-rest/MyTimeView.tsx
@@ -444,8 +444,9 @@ export function MyTimeView({ targetUserId, readOnly: forceReadOnly }: MyTimeView
         const msg = json?.message ?? `Submit failed (${resp.status})`;
         setSubmitErrors(prev => ({ ...prev, [date]: msg }));
       }
-    } catch {
-      // handle error
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : 'Submit failed — check your connection';
+      setSubmitErrors(prev => ({ ...prev, [date]: msg }));
     } finally {
       setSubmitting(prev => ({ ...prev, [date]: false }));
     }
@@ -617,7 +618,7 @@ export function MyTimeView({ targetUserId, readOnly: forceReadOnly }: MyTimeView
   const correctionNote: string | null = (data as any).correction_note ?? null;
 
   return (
-    <div style={{ maxWidth: 680 }}>
+    <div style={{ width: '100%', minWidth: 0 }}>
 
       {/* ── Unsigned alert banner ── */}
       {unsignedAlert && (


### PR DESCRIPTION
## Summary
- **submitDay silent failure**: Empty `catch { // handle error }` swallowed all exceptions (including `getAuthHeader()` failures), button reverted silently, no console error. Replaced with real error handling — error now surfaces inline under the affected day via `setSubmitErrors`.
- **maxWidth 680px hardcoded**: `<div style={{ maxWidth: 680 }}>` at root of `MyTimeView` was artificially capping width. Replaced with `width: '100%', minWidth: 0` so component fills the shell content area. Hardcoded pixel values are forbidden per token standards.
- **Height flex chain broken**: Tab content wrapper in `page.tsx` was missing `minHeight: 0` — `flex: 1` without it cannot shrink to parent height in a flex column, causing the scroll container to be sized incorrectly. Added `minHeight: 0` per shell layout pattern.

## Test plan
- [ ] Log in as crew → Hours of Rest → My Time tab → enter work hours on a day → click Submit Day → error message appears inline (not silent revert) if auth fails
- [ ] Verify successful submit still works: hours save, cell updates, no reload required
- [ ] Confirm component fills full available width (no 680px cap)
- [ ] Confirm scroll area fills the shell height correctly (content scrolls inside the bounded area, not the whole page)

🤖 Generated with [Claude Code](https://claude.com/claude-code)