### PR TITLE
fix(warranty): 5 bugs from manual test

### DIFF
--- a/apps/api/action_router/dispatchers/internal_dispatcher.py
+++ b/apps/api/action_router/dispatchers/internal_dispatcher.py
@@ -209,6 +209,7 @@ async def add_note(params: Dict[str, Any]) -> Dict[str, Any]:
         "text": note_text,
         "note_type": params.get("note_type", "observation"),
         "created_by": user_id,
+        "created_by_role": params.get("role", ""),
         "created_at": now,
         "updated_at": now,
     }

--- a/apps/api/action_router/entity_prefill.py
+++ b/apps/api/action_router/entity_prefill.py
@@ -103,12 +103,15 @@ CONTEXT_PREFILL_MAP: Dict[Tuple[str, str], Dict[str, str]] = {
     ("receiving", "link_invoice_document"):               {"receiving_id": "id"},
 
     # ── Warranty ──────────────────────────────────────────────────────────────
-    ("warranty", "submit_warranty_claim"):  {"warranty_id": "id"},
-    ("warranty", "approve_warranty_claim"): {"warranty_id": "id"},
-    ("warranty", "reject_warranty_claim"):  {"warranty_id": "id"},
-    ("warranty", "compose_warranty_email"): {"warranty_id": "id"},
+    # submit/approve/reject/compose/close use claim_id (matches required_fields in registry)
+    # draft uses warranty_id (its handler resolves by warranty_id)
+    # add_warranty_note uses warranty_id (its handler stores warranty_id FK on pms_notes)
+    ("warranty", "submit_warranty_claim"):  {"claim_id": "id"},
+    ("warranty", "approve_warranty_claim"): {"claim_id": "id"},
+    ("warranty", "reject_warranty_claim"):  {"claim_id": "id"},
+    ("warranty", "compose_warranty_email"): {"claim_id": "id"},
     ("warranty", "draft_warranty_claim"):   {"warranty_id": "id"},
-    ("warranty", "close_warranty_claim"):   {"warranty_id": "id"},
+    ("warranty", "close_warranty_claim"):   {"claim_id": "id"},
     ("warranty", "add_warranty_note"):      {"warranty_id": "id"},
     ("warranty", "add_to_handover"):        {"entity_id": "id", "title": "title"},
 

--- a/apps/api/routes/entity_routes.py
+++ b/apps/api/routes/entity_routes.py
@@ -524,7 +524,7 @@ async def get_warranty_entity(warranty_id: str, auth: dict = Depends(get_authent
 
         try:
             notes_r = supabase.table("pms_notes").select(
-                "id, text, note_type, created_by, created_at"
+                "id, text, note_type, created_by, created_by_role, created_at"
             ).eq("warranty_id", warranty_id).eq("yacht_id", yacht_id).order("created_at", desc=True).execute()
             warranty_notes = notes_r.data or []
         except Exception:

--- a/apps/web/src/app/warranties/page.tsx
+++ b/apps/web/src/app/warranties/page.tsx
@@ -24,10 +24,10 @@ interface Warranty {
 
 function warrantyAdapter(w: Warranty): EntityListResult {
   const statusVariant: EntityListResult['statusVariant'] =
-    w.status === 'rejected'     ? 'critical' :
-    w.status === 'submitted' ? 'warning' :
-    w.status === 'approved'     ? 'open' :
-    w.status === 'closed'       ? 'neutral' :
+    w.status === 'rejected'   ? 'critical' :
+    w.status === 'submitted'  ? 'warning' :
+    w.status === 'approved'   ? 'signed' :     // green pill — approved = good outcome
+    w.status === 'closed'     ? 'cancelled' :  // faint neutral — closed/archived
     'open'; // draft
 
   return {

--- a/apps/web/src/components/lens-v2/actions/AttachmentUploadModal.tsx
+++ b/apps/web/src/components/lens-v2/actions/AttachmentUploadModal.tsx
@@ -50,7 +50,9 @@ import { cn } from '@/lib/utils';
 import { PrimaryButton } from '@/components/ui/PrimaryButton';
 import { GhostButton } from '@/components/ui/GhostButton';
 import { Toast } from '@/components/ui/Toast';
-import { supabase } from '@/lib/supabaseClient';
+// Use the TENANT client for storage + pms_attachments — these live on the
+// TENANT Supabase project (vzsohavtuotocgrfkfyd), not the MASTER auth project.
+import { supabaseTenant as supabase } from '@/lib/supabaseTenantClient';
 
 // ---------------------------------------------------------------------------
 // Constants

--- a/apps/web/src/components/lens-v2/entity/WarrantyContent.tsx
+++ b/apps/web/src/components/lens-v2/entity/WarrantyContent.tsx
@@ -246,7 +246,7 @@ export function WarrantyContent() {
   // ── Notes ──
   const noteItems: NoteItem[] = notes.map((n, i) => ({
     id: (n.id as string) ?? `note-${i}`,
-    author: (n.author ?? n.created_by ?? n.user_name) as string ?? 'Unknown',
+    author: (n.created_by_role ?? n.author ?? n.user_name) as string ?? 'Unknown',
     timestamp: (n.created_at ?? n.timestamp) as string ?? '',
     body: (n.body ?? n.note_text ?? n.text) as string ?? '',
   }));

--- a/apps/web/src/components/shell/AppShell.tsx
+++ b/apps/web/src/components/shell/AppShell.tsx
@@ -43,6 +43,8 @@ import { AttachmentUploadModal } from '@/components/lens-v2/actions/AttachmentUp
 import { LedgerPanel } from '@/components/ledger';
 import { useQueryClient } from '@tanstack/react-query';
 import { getAuthHeaders, getYachtId } from '@/lib/authHelpers';
+import { useAuth } from '@/hooks/useAuth';
+import { isHOD } from '@/contexts/AuthContext';
 
 /** Map URL pathnames to domain IDs */
 const PATH_TO_DOMAIN: Record<string, DomainId> = {
@@ -137,6 +139,10 @@ export function AppShell({ children }: AppShellProps) {
 
   // Sidebar count badges from Vessel Surface endpoint
   const sidebarCounts = useSidebarCounts();
+
+  // Role-based primary action gating: crew cannot file warranty claims
+  const { user } = useAuth();
+  const primaryActionDisabled = activeDomain === 'warranties' && !isHOD(user);
 
   // Global search overlay state
   const [searchOpen, setSearchOpen] = React.useState(false);
@@ -265,6 +271,7 @@ export function AppShell({ children }: AppShellProps) {
         onLedgerClick={() => setLedgerOpen(true)}
         onSettingsClick={handleSettingsClick}
         onPrimaryAction={handlePrimaryAction}
+        primaryActionDisabled={primaryActionDisabled}
       >
         {children}
       </AppShellInner>
@@ -299,6 +306,7 @@ function AppShellInner({
   onLedgerClick,
   onSettingsClick,
   onPrimaryAction,
+  primaryActionDisabled,
   children,
 }: {
   activeDomain: DomainId;
@@ -312,6 +320,7 @@ function AppShellInner({
   onLedgerClick: () => void;
   onSettingsClick: () => void;
   onPrimaryAction: () => void;
+  primaryActionDisabled: boolean;
   children: React.ReactNode;
 }) {
   const { activeChip, setActiveChip, setSearchQuery, setActiveSort } = useShellContext();
@@ -383,6 +392,7 @@ function AppShellInner({
           onSearch={setSearchQuery}
           onSortChange={setActiveSort}
           onPrimaryAction={onPrimaryAction}
+          primaryActionDisabled={primaryActionDisabled}
         />
       )}
 

--- a/apps/web/src/components/shell/Subbar.tsx
+++ b/apps/web/src/components/shell/Subbar.tsx
@@ -123,6 +123,8 @@ interface SubbarProps {
   onSearch?: (query: string) => void;
   onSortChange?: (sort: string) => void;
   onPrimaryAction?: () => void;
+  /** When true the primary action button is rendered disabled (greyed out, not clickable) */
+  primaryActionDisabled?: boolean;
 }
 
 export function Subbar({
@@ -133,6 +135,7 @@ export function Subbar({
   onSearch,
   onSortChange,
   onPrimaryAction,
+  primaryActionDisabled = false,
 }: SubbarProps) {
   // Hide when Vessel Surface is active
   if (activeDomain === 'surface') return null;
@@ -312,23 +315,26 @@ export function Subbar({
 
       {/* Primary action button */}
       <button
-        onClick={onPrimaryAction}
+        onClick={primaryActionDisabled ? undefined : onPrimaryAction}
+        disabled={primaryActionDisabled}
+        title={primaryActionDisabled ? 'Only HOD / Captain can perform this action' : undefined}
         style={{
           height: 28,
           padding: '0 12px',
           borderRadius: 4,
-          background: 'var(--teal-bg)',
-          border: '1px solid var(--mark-hover)',
+          background: primaryActionDisabled ? 'var(--surface-raised)' : 'var(--teal-bg)',
+          border: `1px solid ${primaryActionDisabled ? 'var(--border-sub)' : 'var(--mark-hover)'}`,
           fontSize: 11,
           fontWeight: 500,
-          color: 'var(--mark)',
+          color: primaryActionDisabled ? 'var(--text-sub)' : 'var(--mark)',
           display: 'flex',
           alignItems: 'center',
           gap: 5,
-          cursor: 'pointer',
+          cursor: primaryActionDisabled ? 'not-allowed' : 'pointer',
           whiteSpace: 'nowrap',
           flexShrink: 0,
           transition: 'background 80ms',
+          opacity: primaryActionDisabled ? 0.5 : 1,
         }}
       >
         <Plus style={{ width: 11, height: 11 }} />

--- a/apps/web/src/lib/supabaseTenantClient.ts
+++ b/apps/web/src/lib/supabaseTenantClient.ts
@@ -1,0 +1,61 @@
+'use client';
+
+/**
+ * supabaseTenantClient — Supabase client scoped to the TENANT project.
+ *
+ * The main supabaseClient.ts uses NEXT_PUBLIC_SUPABASE_URL which in production
+ * Vercel points to the MASTER project (auth only). Storage buckets and
+ * operational tables (pms_attachments, etc.) live on the TENANT project.
+ *
+ * This client uses NEXT_PUBLIC_TENANT_SUPABASE_URL so uploads reach the
+ * correct bucket. In local dev the env var falls back to NEXT_PUBLIC_SUPABASE_URL
+ * which already points at TENANT.
+ *
+ * Required Vercel env vars (production):
+ *   NEXT_PUBLIC_TENANT_SUPABASE_URL      — https://vzsohavtuotocgrfkfyd.supabase.co
+ *   NEXT_PUBLIC_TENANT_SUPABASE_ANON_KEY — tenant anon key
+ */
+
+import { createClient, SupabaseClient } from '@supabase/supabase-js';
+
+const tenantUrl =
+  process.env.NEXT_PUBLIC_TENANT_SUPABASE_URL ||
+  process.env.NEXT_PUBLIC_SUPABASE_URL ||
+  '';
+
+const tenantAnonKey =
+  process.env.NEXT_PUBLIC_TENANT_SUPABASE_ANON_KEY ||
+  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY ||
+  '';
+
+let tenantInstance: SupabaseClient | null = null;
+
+function getTenantClient(): SupabaseClient {
+  if (typeof window === 'undefined') {
+    // SSR placeholder — never used for real operations
+    return createClient('https://placeholder.supabase.co', 'placeholder-key', {
+      auth: { persistSession: false, autoRefreshToken: false },
+    });
+  }
+
+  if (tenantInstance) return tenantInstance;
+
+  if (!tenantUrl || !tenantAnonKey) {
+    console.error('[supabaseTenantClient] Missing env vars — set NEXT_PUBLIC_TENANT_SUPABASE_URL and NEXT_PUBLIC_TENANT_SUPABASE_ANON_KEY in Vercel');
+    throw new Error('Tenant Supabase configuration missing');
+  }
+
+  tenantInstance = createClient(tenantUrl, tenantAnonKey, {
+    auth: { persistSession: false, autoRefreshToken: false },
+  });
+
+  return tenantInstance;
+}
+
+const handler: ProxyHandler<object> = {
+  get(_target, prop) {
+    return Reflect.get(getTenantClient(), prop);
+  },
+};
+
+export const supabaseTenant: SupabaseClient = new Proxy({}, handler) as SupabaseClient;


### PR DESCRIPTION
## Summary

- **Prefill key fix** — `entity_prefill.py`: warranty `submit/approve/reject/compose/close` actions now prefill `claim_id` (not `warranty_id`), matching registry `required_fields`. Fixes the approve popup showing an empty "Claim Id" text field instead of the amount + notes inputs.
- **List-view pill colour** — `warranties/page.tsx`: `approved → 'signed'` (green), `closed → 'cancelled'` (faint). Fixes grey pill on approved claims in the list.
- **Notes UUID display** — `internal_dispatcher.py` + `entity_routes.py` + `WarrantyContent.tsx`: store and return `created_by_role` on `pms_notes`. Frontend now shows role label (e.g. "chief_engineer") instead of raw UUID.
- **Storage tenant mismatch** — new `supabaseTenantClient.ts` using `NEXT_PUBLIC_TENANT_SUPABASE_URL`; `AttachmentUploadModal` now uses it. Fixes 400 upload errors caused by the MASTER Supabase URL being used in Vercel prod.
- **Crew button gate** — `AppShell` + `Subbar`: Add Warranty button is greyed/disabled for crew; tooltip says "Only HOD / Captain can perform this action". Prevents crew from hitting a 403.

## Pre-merge actions required

1. Apply and verify this migration on TENANT Supabase (`vzsohavtuotocgrfkfyd`), then delete the file:
   ```sql
   -- docs/ongoing_work/warranty/migration_pms_notes_created_by_role.sql
   ALTER TABLE pms_notes ADD COLUMN IF NOT EXISTS created_by_role TEXT;
   ```
2. Add these env vars to Vercel dashboard (production + preview):
   - `NEXT_PUBLIC_TENANT_SUPABASE_URL` = `https://vzsohavtuotocgrfkfyd.supabase.co`
   - `NEXT_PUBLIC_TENANT_SUPABASE_ANON_KEY` = tenant anon key (same as local `.env.local`)

## Test plan

- [ ] Approve a submitted claim — popup should show Amount + Notes fields, no "Claim Id" input
- [ ] Approved claim shows green pill in list view
- [ ] Closed claim shows faint/neutral pill in list view
- [ ] Add a warranty note — note author shows role label, not UUID
- [ ] Upload an attachment — no 400 error in console (requires Vercel env vars above)
- [ ] Log in as crew — Add Warranty button is greyed out with tooltip

🤖 Generated with [Claude Code](https://claude.com/claude-code)