### PR TITLE
fix(certificates): create cert form renders instead of auto-submitting

### DIFF
--- a/apps/api/action_router/registry.py
+++ b/apps/api/action_router/registry.py
@@ -4330,6 +4330,30 @@ def get_actions_for_domain(domain: str, role: str = None) -> List[Dict[str, Any]
         if role and role not in action.allowed_roles:
             continue
 
+        # Build field_schema from field_metadata so frontends can render forms
+        field_schema = []
+        if action.field_metadata:
+            for fm in action.field_metadata:
+                cls = fm.classification
+                if cls in (FieldClassification.CONTEXT, FieldClassification.BACKEND_AUTO,
+                           "CONTEXT", "BACKEND_AUTO"):
+                    continue
+                is_required = cls in (FieldClassification.REQUIRED, "REQUIRED")
+                if fm.options:
+                    ft = "select"
+                elif getattr(fm, 'lookup_required', False):
+                    ft = "entity-search"
+                elif "date" in fm.name or fm.name.endswith("_at") or fm.name.endswith("_due"):
+                    ft = "date"
+                elif "description" in fm.name or "notes" in fm.name or "reason" in fm.name:
+                    ft = "text-area"
+                else:
+                    ft = "text"
+                entry = {"name": fm.name, "type": ft, "label": fm.description or fm.name.replace("_", " ").title(), "required": is_required}
+                if fm.options:
+                    entry["options"] = [{"value": o, "label": o.replace("_", " ").title()} for o in fm.options]
+                field_schema.append(entry)
+
         results.append({
             "action_id": action.action_id,
             "label": action.label,
@@ -4339,6 +4363,7 @@ def get_actions_for_domain(domain: str, role: str = None) -> List[Dict[str, Any]
             "has_prefill": action.prefill_endpoint is not None,
             "prefill_endpoint": action.prefill_endpoint,
             "context_required": action.context_required,
+            "field_schema": field_schema,
         })
 
     return results

--- a/apps/web/src/components/lens-v2/ActionPopup.tsx
+++ b/apps/web/src/components/lens-v2/ActionPopup.tsx
@@ -438,7 +438,9 @@ export function ActionPopup({
   previewRows,
 }: ActionPopupProps) {
   // L0 = tap only — execute inline, no modal needed
-  const isL0 = mode === 'mutate' && signatureLevel === 0;
+  // L0 = fire-and-forget (no form, no signature). Only auto-submit if there
+  // are genuinely no fields to show — otherwise we'd skip the user's form.
+  const isL0 = mode === 'mutate' && signatureLevel === 0 && fields.length === 0;
 
   // Internal form state (hooks must be called unconditionally)
   const [values, setValues] = React.useState<Record<string, string>>(() => {


### PR DESCRIPTION
## Summary
- **Bug**: "Add Vessel Certificate" button auto-submitted with empty payload instead of opening form. Backend correctly returned 400 (missing fields). Found by CERT-TESTER during live Playwright testing.
- **Root cause**: ActionPopup L0 shortcut (`mode=mutate` + `signatureLevel=0`) fired `onSubmit({})` on mount, skipping form. Combined with `get_actions_for_domain` not returning `field_schema`, create actions had no fields to render.
- **Fix 1**: `ActionPopup.tsx:441` — L0 now requires `fields.length === 0`. If fields exist, form renders.
- **Fix 2**: `registry.py:get_actions_for_domain` — now builds `field_schema` from `field_metadata` so create cert forms get dropdowns + text fields.

## Test plan
- [ ] Click "Add Vessel Certificate" → ActionPopup opens with Certificate Type dropdown, Certificate Name, Issuing Authority fields
- [ ] Click "Add Crew Certificate" → ActionPopup opens with Person Name, Certificate Type dropdown, Issuing Authority fields
- [ ] Existing L0 actions (no fields, no signature) still auto-fire correctly (e.g. acknowledge_fault)

🤖 Generated with [Claude Code](https://claude.com/claude-code)