### PR TITLE
fix(hor): BUG-HOR-5 — fleet manager RBAC gap on create_monthly_signoff

### DIFF
--- a/apps/api/handlers/hours_of_rest_handlers.py
+++ b/apps/api/handlers/hours_of_rest_handlers.py
@@ -623,14 +623,16 @@ class HoursOfRestHandlers:
 
             builder.set_pagination(offset, limit, total_count)
 
-            # Available actions
-            builder.add_available_action(AvailableAction(
-                action_id="create_monthly_signoff",
-                label="Create Sign-off",
-                variant="MUTATE",
-                icon="file-signature",
-                is_primary=True
-            ))
+            # Available actions — fleet manager (role=manager) is read-only for HoR
+            caller_role = params.get("_caller_role", "")
+            if caller_role != "manager":
+                builder.add_available_action(AvailableAction(
+                    action_id="create_monthly_signoff",
+                    label="Create Sign-off",
+                    variant="MUTATE",
+                    icon="file-signature",
+                    is_primary=True
+                ))
 
             return builder.build()
 

--- a/apps/api/routes/handlers/hours_of_rest_handler.py
+++ b/apps/api/routes/handlers/hours_of_rest_handler.py
@@ -298,10 +298,11 @@ async def list_monthly_signoffs(
 
     hor = HoursOfRestHandlers(db_client)
 
+    params_with_role = {**(payload or {}), "_caller_role": user_context.get("role", "")}
     return await hor.list_monthly_signoffs(
         entity_id=user_id,
         yacht_id=yacht_id,
-        params=payload
+        params=params_with_role
     )
 
 
@@ -317,6 +318,18 @@ async def create_monthly_signoff(
     db_client: Client,
 ) -> dict:
     logger.info(f"[HOR_SIGNOFF] Dispatching 'create_monthly_signoff' - yacht_id={yacht_id}")
+
+    # BUG-HOR-5 fix: fleet manager is read-only for HoR — block at dispatcher level
+    if user_context.get("role") == "manager":
+        return {
+            "success": False,
+            "action_id": "create_monthly_signoff",
+            "error": {
+                "code": "FORBIDDEN",
+                "message": "Fleet manager has read-only access to hours of rest. Cannot create sign-offs.",
+                "status_code": 403,
+            }
+        }
 
     hor = HoursOfRestHandlers(db_client)
 


### PR DESCRIPTION
## Summary
Fleet manager (`manager` role) could call `create_monthly_signoff` and successfully create signoff records — confirmed REAL by MCP02 API wire-walk. The action had no role check at all.

**Root cause:** `create_monthly_signoff` handler only validates payload fields, not who is calling. `list_monthly_signoffs` unconditionally advertised `create_monthly_signoff` in `available_actions` for all roles, including fleet.

**Fix:**
- Dispatcher blocks `manager` role with FORBIDDEN before reaching handler
- `list_monthly_signoffs` no longer advertises `create_monthly_signoff` in `available_actions` for manager role

**Not a bug:** `vessel-compliance` returning 200 for manager is intentional — `manager` is in `_CAPTAIN_ROLES` by design (fleet-level oversight). Guide corrected to say "captain/manager" not "captain only".

## Test plan
- [ ] Fleet manager calls `create_monthly_signoff` → FORBIDDEN (not success)
- [ ] Fleet manager calls `list_monthly_signoffs` → `available_actions` does NOT include `create_monthly_signoff`
- [ ] Crew/HOD/captain calls `create_monthly_signoff` → still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)