### PR TITLE
fix(certificates): ledger safety net writes correct entity_id + response success normalization

### DIFF
--- a/apps/api/action_router/ledger_metadata.py
+++ b/apps/api/action_router/ledger_metadata.py
@@ -66,15 +66,15 @@ ACTION_METADATA: dict = {
 
     # ── Certificates ─────────────────────────────────────────────────────────
     "add_certificate_note":              {"event_type": "update",        "entity_type": "certificate",   "entity_id_field": "certificate_id"},
-    "archive_certificate":               {"event_type": "update",        "entity_type": "certificate",   "entity_id_field": "entity_id"},
+    "archive_certificate":               {"event_type": "update",        "entity_type": "certificate",   "entity_id_field": "certificate_id"},
     "assign_certificate":                {"event_type": "assignment",    "entity_type": "certificate",   "entity_id_field": "certificate_id"},
     "create_vessel_certificate":         {"event_type": "create",        "entity_type": "certificate",   "entity_id_field": "certificate_id"},
     "create_crew_certificate":           {"event_type": "create",        "entity_type": "certificate",   "entity_id_field": "certificate_id"},
     "link_document_to_certificate":      {"event_type": "update",        "entity_type": "certificate",   "entity_id_field": "certificate_id"},
     "renew_certificate":                 {"event_type": "create",        "entity_type": "certificate",   "entity_id_field": "certificate_id"},
-    "revoke_certificate":                {"event_type": "status_change", "entity_type": "certificate",   "entity_id_field": "entity_id"},
+    "revoke_certificate":                {"event_type": "status_change", "entity_type": "certificate",   "entity_id_field": "certificate_id"},
     "supersede_certificate":             {"event_type": "status_change", "entity_type": "certificate",   "entity_id_field": "certificate_id"},
-    "suspend_certificate":               {"event_type": "status_change", "entity_type": "certificate",   "entity_id_field": "entity_id"},
+    "suspend_certificate":               {"event_type": "status_change", "entity_type": "certificate",   "entity_id_field": "certificate_id"},
     "update_certificate":                {"event_type": "update",        "entity_type": "certificate",   "entity_id_field": "certificate_id"},
 
     # ── Parts / Inventory ────────────────────────────────────────────────────

--- a/apps/api/routes/p0_actions_routes.py
+++ b/apps/api/routes/p0_actions_routes.py
@@ -1177,6 +1177,11 @@ async def execute_action(
                                 f"[Ledger safety net] {action}: {_ledger_err}"
                             )
             # ─────────────────────────────────────────────────────────────
+            # Normalize: frontend expects {success: true} (boolean) but many
+            # handlers return {status: "success"} (string). Inject success=true
+            # on any non-error response so EntityLensPage.tsx:407 works.
+            if isinstance(result, dict) and result.get("status") != "error":
+                result.setdefault("success", True)
             return result
         except HTTPException:
             raise


### PR DESCRIPTION
## Summary
**Bug E (CRITICAL for HMAC01)**: suspend/revoke/archive wrote `ledger_events` with `entity_id=yacht_id` instead of the cert UUID. Safety net looked up `entity_id` in payload/result but the cert handlers use `certificate_id`. Changed `entity_id_field` in ACTION_METADATA for all three actions.

**Bug C**: Handler returns `{status: "success"}` but frontend checks `result.success` (boolean). Added response normalization in p0_actions_routes.py — all non-error results get `success: true` injected.

Both found by CERT-TESTER during live Playwright testing (Scenarios 6.5, 6.8).

## Test plan
- [ ] Suspend cert via UI → ledger_events has row with entity_id = cert UUID (not yacht_id)
- [ ] Suspend cert via UI → popup closes with success (no "Action failed" toast)
- [ ] Revoke/Archive same behavior
- [ ] Existing actions (faults, WOs) still work (response normalization is additive)

🤖 Generated with [Claude Code](https://claude.com/claude-code)