### PR TITLE
fix(hor): BUG-HOR-6 + BUG-HOR-7 crew sign regression + cross-user audit breach

### DIFF
--- a/apps/api/handlers/hours_of_rest_handlers.py
+++ b/apps/api/handlers/hours_of_rest_handlers.py
@@ -980,6 +980,24 @@ class HoursOfRestHandlers:
                 )
                 return builder.build()
 
+            # BUG-HOR-7 fix: crew may only sign their own signoff
+            if signature_level == "crew":
+                signoff_owner_id = signoff.get("user_id")
+                if signoff_owner_id and signoff_owner_id != user_id:
+                    builder.set_error(
+                        "FORBIDDEN",
+                        "Crew can only sign their own monthly sign-off. Cross-user signing is not permitted."
+                    )
+                    return builder.build()
+                # BUG-HOR-6 fix: crew sign only valid from draft state — prevents status regression
+                if current_status != "draft":
+                    builder.set_error(
+                        "VALIDATION_ERROR",
+                        f"Crew signature is only valid on a draft sign-off. Current status: {current_status}. "
+                        "Once a sign-off progresses past draft it cannot be re-signed at crew level."
+                    )
+                    return builder.build()
+
             if signature_level == "hod" and current_status != "crew_signed":
                 builder.set_error(
                     "VALIDATION_ERROR",


### PR DESCRIPTION
## Summary

- **BUG-HOR-6** — Status regression: `crew` sign accepted on any non-finalized signoff (including `hod_signed`, `crew_signed`), overwriting `crew_signed_at` and regressing status backwards. Fix: `VALIDATION_ERROR` returned unless `current_status == "draft"`.
- **BUG-HOR-7** — Cross-user signing: no ownership check on crew-level signs. Any crew JWT could post `sign_monthly_signoff` with `signature_level=crew` against another user's signoff and succeed. Fix: `FORBIDDEN` returned if `user_id != signoff.user_id`.

Both guards inserted in `sign_monthly_signoff` at `apps/api/handlers/hours_of_rest_handlers.py` after the existing finalized-immutability check, before the hod/master progression guards.

## Reproduction (found by HOURSOFREST_MCP02 during S2/S3 wire-walk)

- Signoff `574c7549` (hod_signed) → crew re-sign → success=true, status regressed to crew_signed, HOD signature stranded
- Signoff `2d43cdd2` (another user's, hod_signed) → foreign crew JWT crew-sign → success=true, crew_signed_by overwritten to foreign user

## Test plan

- [ ] Crew sign on `draft` signoff with matching user_id → `200 success`, status `crew_signed`
- [ ] Crew sign on `crew_signed` signoff → `VALIDATION_ERROR` (status not draft)
- [ ] Crew sign on `hod_signed` signoff → `VALIDATION_ERROR` (status not draft)
- [ ] Crew sign on another user's `draft` signoff → `FORBIDDEN` (ownership)
- [ ] HOD and master progression unchanged (existing Scenario 4/5 tests still PASS)

Manually verified code path. Wire-walk re-test by MCP02 pending Render deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)