### PR TITLE
fix(hor-ledger): populate user_role on warning ledger rows (acknowledge + dismiss)

### DIFF
--- a/apps/api/handlers/hours_of_rest_handlers.py
+++ b/apps/api/handlers/hours_of_rest_handlers.py
@@ -1666,6 +1666,14 @@ class HoursOfRestHandlers:
 
             # Write ledger event — crew acknowledgement is legally significant
             try:
+                # Resolve caller role for ledger (avoids NULL user_role — BUG-HOR-LEDGER-1 pattern)
+                try:
+                    _ack_role_r = self.db.table("auth_users_roles").select("role").eq(
+                        "user_id", user_id
+                    ).eq("yacht_id", yacht_id).limit(1).execute()
+                    _ack_role = _ack_role_r.data[0]["role"] if _ack_role_r.data else None
+                except Exception:
+                    _ack_role = None
                 self.db.table("ledger_events").insert(build_ledger_event(
                     yacht_id=yacht_id,
                     user_id=user_id,
@@ -1673,6 +1681,7 @@ class HoursOfRestHandlers:
                     entity_type="crew_warning",
                     entity_id=warning_id,
                     action="acknowledge_warning",
+                    user_role=_ack_role,
                     change_summary=f"Crew acknowledged compliance warning: {crew_reason or 'no reason given'}",
                     metadata={"status": "acknowledged", "crew_reason": crew_reason, "warning_id": warning_id},
                     event_category="write",
@@ -1819,6 +1828,7 @@ class HoursOfRestHandlers:
                     entity_type="crew_warning",
                     entity_id=warning_id,
                     action="dismiss_warning",
+                    user_role=dismissed_by_role,  # already resolved from payload + DB earlier
                     change_summary=f"{dismissed_by_role.upper()} dismissed compliance warning: {hod_justification}",
                     metadata={
                         "status": "dismissed",


### PR DESCRIPTION
## Summary

Follow-up to PR #578 (which fixed `user_role=NULL` on `sign_monthly_signoff` ledger rows).

PR #578 only covered the sign handler. `acknowledge_warning` and `dismiss_warning` both write legally significant ledger events (MLC 2006 crew compliance record) but also had `user_role=NULL`.

**Changes:**
- `acknowledge_warning`: add DB lookup against `auth_users_roles` before ledger insert — same pattern as sign handler
- `dismiss_warning`: `dismissed_by_role` already resolved in scope, pass directly as `user_role`

Both handlers in `apps/api/handlers/hours_of_rest_handlers.py`.

## Test plan

- [ ] Crew acknowledges a warning → `ledger_events` row has `user_role = 'crew'` (or crew's actual role)
- [ ] HOD dismisses a warning → `ledger_events` row has `user_role = 'chief_engineer'` (or HOD's role)
- [ ] Both actions still succeed normally (ledger failure is non-fatal, but user_role should now be populated)

Found by HOURSOFREST_MCP02 during S9/S10 wire-walk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)