### PR TITLE
fix(certificates): dropdown status gating + renew duplicate-key

### DIFF
--- a/apps/api/action_router/entity_actions.py
+++ b/apps/api/action_router/entity_actions.py
@@ -298,4 +298,17 @@ def _apply_state_gate(
         if status in _RECEIVING_TERMINAL_STATUSES and action_id in _RECEIVING_TERMINAL_DISABLED:
             return True, "Receiving record is finalised"
 
+    elif entity_type == "certificate":
+        _CERT_TERMINAL = {"superseded", "revoked"}
+        _CERT_TERMINAL_DISABLED = {
+            "update_certificate", "suspend_certificate", "revoke_certificate",
+            "supersede_certificate", "renew_certificate", "assign_certificate",
+            "link_document_to_certificate",
+        }
+        _CERT_SUSPENDED_DISABLED = {"suspend_certificate"}
+        if status in _CERT_TERMINAL and action_id in _CERT_TERMINAL_DISABLED:
+            return True, f"Certificate is {status} — no further mutations allowed"
+        if status == "suspended" and action_id in _CERT_SUSPENDED_DISABLED:
+            return True, "Certificate is already suspended"
+
     return False, None

--- a/apps/api/handlers/certificate_handlers.py
+++ b/apps/api/handlers/certificate_handlers.py
@@ -1355,7 +1355,7 @@ def _renew_certificate_adapter(handlers: "CertificateHandlers"):
             "status": "valid",
             "issue_date": new_issue_date,
             "expiry_date": new_expiry_date,
-            "certificate_number": params.get("new_certificate_number") or old_cert.get("certificate_number"),
+            "certificate_number": params.get("new_certificate_number") or f"{old_cert.get('certificate_number', 'CERT')}-R{now[:10].replace('-', '')}",
             "issuing_authority": params.get("new_issuing_authority") or old_cert.get("issuing_authority"),
             "source": "manual",
             "is_seed": False,


### PR DESCRIPTION
## Summary
**Bug D**: Dropdown showed Suspend/Revoke/Update on superseded/revoked certs. Added certificate state gate — terminal certs disable mutations, suspended certs disable re-suspend.

**Bug F**: Renew with blank cert number → 500 duplicate-key. Old number reused verbatim. Now auto-generates `-R{YYYYMMDD}` suffix when field is blank.

## Test plan
- [ ] Open a superseded cert → Update/Suspend/Revoke/Supersede/Renew show as disabled with reason
- [ ] Open a suspended cert → Suspend shows as disabled ("already suspended"), Revoke still enabled
- [ ] Renew a cert without entering a new number → no 500, auto-number generated

🤖 Generated with [Claude Code](https://claude.com/claude-code)