### PR TITLE
fix(documents): 3 frontend bugs from MCP02 browser testing

### DIFF
--- a/apps/api/handlers/document_handlers.py
+++ b/apps/api/handlers/document_handlers.py
@@ -470,8 +470,26 @@ def _add_document_tags_adapter(handlers: DocumentHandlers):
         yacht_id = params["yacht_id"]
         user_id = params["user_id"]
         doc_id = params["document_id"]
-        new_tags = params["tags"]
+        raw_tags = params["tags"]
+        # Defensive: frontend auto-modals send a string ("critical") instead of
+        # a list (["critical"]). If we iterate a bare string, each character
+        # becomes a separate tag — e.g. "critical" → ["c","r","i","t",...].
+        if isinstance(raw_tags, str):
+            # Split on comma, strip whitespace, drop empties
+            new_tags = [t.strip() for t in raw_tags.split(",") if t.strip()]
+        elif isinstance(raw_tags, list):
+            # Flatten: if the list contains comma-separated strings, split those too
+            new_tags = []
+            for item in raw_tags:
+                if isinstance(item, str):
+                    new_tags.extend(t.strip() for t in item.split(",") if t.strip())
+                else:
+                    new_tags.append(str(item))
+        else:
+            new_tags = [str(raw_tags)]
         replace_mode = params.get("replace", False)
+        if isinstance(replace_mode, str):
+            replace_mode = replace_mode.lower() in ("true", "1", "yes")
 
         # Get current document
         try:

--- a/apps/web/src/components/lens-v2/actions/AttachmentUploadModal.tsx
+++ b/apps/web/src/components/lens-v2/actions/AttachmentUploadModal.tsx
@@ -126,7 +126,9 @@ export interface AttachmentUploadModalProps {
    * (the caller is responsible for where the file lands and how it is
    * recorded).
    */
-  onUpload?: (file: File) => Promise<void>;
+  onUpload?: (file: File, metadata?: { title?: string; doc_type?: string; tags_csv?: string }) => Promise<void>;
+  /** When true, show title / doc_type / tags fields (document lens upload). */
+  showMetadataFields?: boolean;
 }
 
 // ---------------------------------------------------------------------------
@@ -146,11 +148,15 @@ export function AttachmentUploadModal({
   yachtId,
   userId,
   onUpload,
+  showMetadataFields = false,
 }: AttachmentUploadModalProps) {
   const [file, setFile] = React.useState<File | null>(null);
   const [loading, setLoading] = React.useState(false);
   const [toast, setToast] = React.useState<{ type: 'success' | 'error'; message: string } | null>(null);
   const inputRef = React.useRef<HTMLInputElement>(null);
+  const [docTitle, setDocTitle] = React.useState('');
+  const [docType, setDocType] = React.useState('');
+  const [docTags, setDocTags] = React.useState('');
 
   // Reset state when modal opens
   React.useEffect(() => {
@@ -158,6 +164,9 @@ export function AttachmentUploadModal({
       setFile(null);
       setLoading(false);
       setToast(null);
+      setDocTitle('');
+      setDocType('');
+      setDocTags('');
     }
   }, [open]);
 
@@ -241,10 +250,13 @@ export function AttachmentUploadModal({
     if (!file || fileTooLarge) return;
 
     const uploader = onUpload ?? defaultPmsAttachmentUpload;
+    const metadata = showMetadataFields
+      ? { title: docTitle || undefined, doc_type: docType || undefined, tags_csv: docTags || undefined }
+      : undefined;
 
     setLoading(true);
     try {
-      await uploader(file);
+      await uploader(file, metadata);
 
       // Success — same UX regardless of which upload strategy ran.
       setToast({ type: 'success', message: 'Document uploaded successfully' });
@@ -339,6 +351,56 @@ export function AttachmentUploadModal({
                   </p>
                 )}
               </div>
+            )}
+
+            {showMetadataFields && (
+              <>
+                <div>
+                  <label htmlFor="doc-title" className="block text-label text-txt-primary mb-1">Title</label>
+                  <input
+                    id="doc-title"
+                    type="text"
+                    value={docTitle}
+                    onChange={(e) => setDocTitle(e.target.value)}
+                    placeholder="e.g. Main Engine Service Manual"
+                    disabled={loading}
+                    className="w-full px-3 py-1.5 rounded border border-surface-border bg-surface-primary text-body text-txt-primary placeholder:text-txt-tertiary"
+                  />
+                </div>
+                <div>
+                  <label htmlFor="doc-type" className="block text-label text-txt-primary mb-1">Document Type</label>
+                  <select
+                    id="doc-type"
+                    value={docType}
+                    onChange={(e) => setDocType(e.target.value)}
+                    disabled={loading}
+                    className="w-full px-3 py-1.5 rounded border border-surface-border bg-surface-primary text-body text-txt-primary"
+                  >
+                    <option value="">— Select —</option>
+                    <option value="manual">Manual</option>
+                    <option value="drawing">Drawing</option>
+                    <option value="certificate">Certificate</option>
+                    <option value="report">Report</option>
+                    <option value="photo">Photo</option>
+                    <option value="spec_sheet">Spec Sheet</option>
+                    <option value="schematic">Schematic</option>
+                    <option value="other">Other</option>
+                  </select>
+                </div>
+                <div>
+                  <label htmlFor="doc-tags" className="block text-label text-txt-primary mb-1">Tags</label>
+                  <input
+                    id="doc-tags"
+                    type="text"
+                    value={docTags}
+                    onChange={(e) => setDocTags(e.target.value)}
+                    placeholder="e.g. engine, maintenance, critical"
+                    disabled={loading}
+                    className="w-full px-3 py-1.5 rounded border border-surface-border bg-surface-primary text-body text-txt-primary placeholder:text-txt-tertiary"
+                  />
+                  <p className="mt-0.5 text-caption text-txt-tertiary">Comma-separated</p>
+                </div>
+              </>
             )}
           </div>
 

--- a/apps/web/src/components/shell/AppShell.tsx
+++ b/apps/web/src/components/shell/AppShell.tsx
@@ -140,9 +140,14 @@ export function AppShell({ children }: AppShellProps) {
   // Sidebar count badges from Vessel Surface endpoint
   const sidebarCounts = useSidebarCounts();
 
-  // Role-based primary action gating: crew cannot file warranty claims
+  // Role-based primary action gating:
+  // - warranties: crew cannot file claims (HOD+ only)
+  // - documents: crew cannot upload (HOD+ only) — backend returns 403, but
+  //   the button must also be disabled/hidden so crew don't see a broken action.
   const { user } = useAuth();
-  const primaryActionDisabled = activeDomain === 'warranties' && !isHOD(user);
+  const primaryActionDisabled =
+    (activeDomain === 'warranties' && !isHOD(user)) ||
+    (activeDomain === 'documents' && !isHOD(user));
 
   // Global search overlay state
   const [searchOpen, setSearchOpen] = React.useState(false);
@@ -214,7 +219,7 @@ export function AppShell({ children }: AppShellProps) {
   //   - 500: storage upload or doc_metadata insert failed (server-side rollback)
   // ------------------------------------------------------------------
   const handleDocumentUpload = React.useCallback(
-    async (file: File): Promise<void> => {
+    async (file: File, metadata?: { title?: string; doc_type?: string; tags_csv?: string }): Promise<void> => {
       const yachtId = await getYachtId();
       const authHeaders = await getAuthHeaders(yachtId);
 
@@ -223,6 +228,9 @@ export function AppShell({ children }: AppShellProps) {
 
       const formData = new FormData();
       formData.append('file', file);
+      if (metadata?.title) formData.append('title', metadata.title);
+      if (metadata?.doc_type) formData.append('doc_type', metadata.doc_type);
+      if (metadata?.tags_csv) formData.append('tags_csv', metadata.tags_csv);
 
       const response = await fetch(`${apiBaseUrl}/v1/documents/upload`, {
         method: 'POST',
@@ -288,6 +296,7 @@ export function AppShell({ children }: AppShellProps) {
         title="Upload Document"
         description="Add a document to the vessel library. Accepted: PDF, images, office docs; max 15 MB."
         onUpload={handleDocumentUpload}
+        showMetadataFields
       />
     </ShellProvider>
   );


### PR DESCRIPTION
## Summary
Three bugs found by DOCUMENTS_MCP02 Playwright browser testing — all invisible to backend wirewalk:

1. **Tags string-to-characters** — `"critical"` became `["c","r","i","t","i","c","a","l"]` because backend iterated a string. Now defensively splits on commas.
2. **Upload modal missing title/doc_type/tags** — Modal only had file picker. Now shows Title, Document Type (select), Tags (comma-separated) when `showMetadataFields` is set. Eliminates "Untitled" rows.
3. **Crew sees Upload button** — `primaryActionDisabled` only gated warranties, not documents. Now gates both. Crew sees disabled button with tooltip.

## Files changed
- `apps/api/handlers/document_handlers.py` — defensive string→list conversion for tags
- `apps/web/src/components/lens-v2/actions/AttachmentUploadModal.tsx` — metadata fields + extended onUpload signature
- `apps/web/src/components/shell/AppShell.tsx` — RBAC gate for documents primary action + metadata forwarding

## Test plan
- [ ] DOCUMENTS_MCP02 re-runs Scenario 1 (upload with title/tags) after deploy
- [ ] DOCUMENTS_MCP02 re-runs Scenario 3 (tags persist as array, not chars)
- [ ] DOCUMENTS_MCP02 re-runs Scenario 5 (crew cannot see upload button)

🤖 Generated with [Claude Code](https://claude.com/claude-code)