### PR TITLE
fix: notification bell reads json.notifications not json.data

### DIFF
--- a/apps/web/src/components/shell/NotificationBell.tsx
+++ b/apps/web/src/components/shell/NotificationBell.tsx
@@ -34,7 +34,8 @@ interface Notification {
 
 interface NotificationsResponse {
   status: string;
-  data: Notification[];
+  unread_count: number;
+  notifications: Notification[];
 }
 
 /* ------------------------------------------------------------------ */
@@ -80,7 +81,7 @@ export function NotificationBell() {
       });
       if (!res.ok) return [];
       const json: NotificationsResponse = await res.json();
-      return json.data ?? [];
+      return json.notifications ?? [];
     },
     enabled: !!token,
     refetchInterval: 30_000,


### PR DESCRIPTION
Bug M: bell component read json.data but backend returns json.notifications. One-line naming fix. Found by CERT-TESTER.