### PR TITLE
fix(documents): S6 link-to-equipment — functional entity search picker

### DIFF
--- a/apps/api/action_router/entity_prefill.py
+++ b/apps/api/action_router/entity_prefill.py
@@ -116,11 +116,12 @@ CONTEXT_PREFILL_MAP: Dict[Tuple[str, str], Dict[str, str]] = {
     ("warranty", "add_to_handover"):        {"entity_id": "id", "title": "title"},
 
     # ── Document ──────────────────────────────────────────────────────────────
-    ("document", "update_document"):         {"document_id": "id"},
-    ("document", "add_document_comment"):    {"document_id": "id"},
-    ("document", "add_document_tags"):       {"document_id": "id"},
-    ("document", "delete_document"):         {"document_id": "id"},
-    ("document", "update_document_comment"): {"document_id": "id"},
+    ("document", "update_document"):              {"document_id": "id"},
+    ("document", "add_document_comment"):         {"document_id": "id"},
+    ("document", "add_document_tags"):            {"document_id": "id"},
+    ("document", "delete_document"):              {"document_id": "id"},
+    ("document", "update_document_comment"):      {"document_id": "id"},
+    ("document", "link_document_to_equipment"):   {"document_id": "id"},
 
     # ── Shopping List ─────────────────────────────────────────────────────────
     # shopping_list prefill intentionally empty for Phase 2 — add as needed

--- a/apps/api/action_router/registry.py
+++ b/apps/api/action_router/registry.py
@@ -809,8 +809,8 @@ ACTION_REGISTRY: Dict[str, ActionDefinition] = {
         storage_path_template="{yacht_id}/equipment/{equipment_id}/{filename}",
         field_metadata=[
             FieldMetadata("yacht_id", FieldClassification.CONTEXT),
-            FieldMetadata("equipment_id", FieldClassification.CONTEXT, auto_populate_from="equipment", lookup_required=True),
-            FieldMetadata("document_id", FieldClassification.REQUIRED, description="Document metadata ID"),
+            FieldMetadata("equipment_id", FieldClassification.REQUIRED, auto_populate_from="equipment", lookup_required=True, description="Target equipment"),
+            FieldMetadata("document_id", FieldClassification.CONTEXT, auto_populate_from="document", description="Document metadata ID"),
             FieldMetadata("description", FieldClassification.OPTIONAL, description="Link description"),
         ],
     ),

--- a/apps/web/src/components/lens-v2/ActionPopup.tsx
+++ b/apps/web/src/components/lens-v2/ActionPopup.tsx
@@ -26,6 +26,7 @@ export interface ActionPopupField {
   required?: boolean;
   options?: { value: string; label: string }[];
   entityRef?: { type: string; id: string; label: string };
+  search_domain?: string;
 }
 
 export interface ActionPopupGate {
@@ -213,18 +214,134 @@ function FieldEntitySearch({
   value: string;
   onChange: (v: string) => void;
 }) {
+  const [query, setQuery] = React.useState('');
+  const [displayLabel, setDisplayLabel] = React.useState('');
+  const [results, setResults] = React.useState<Array<{ id: string; title: string; object_type: string }>>([]);
+  const [showDropdown, setShowDropdown] = React.useState(false);
+  const debounceRef = React.useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const handleSearch = React.useCallback(
+    (q: string) => {
+      setQuery(q);
+      if (debounceRef.current) clearTimeout(debounceRef.current);
+      if (!q || q.length < 2) {
+        setResults([]);
+        setShowDropdown(false);
+        return;
+      }
+      debounceRef.current = setTimeout(async () => {
+        try {
+          const yachtId =
+            typeof window !== 'undefined'
+              ? localStorage.getItem('celeste_yacht_id') || ''
+              : '';
+          const jwt =
+            typeof window !== 'undefined'
+              ? (() => {
+                  try {
+                    const raw = localStorage.getItem(
+                      Object.keys(localStorage).find((k) => k.includes('auth-token')) || ''
+                    );
+                    return raw ? JSON.parse(raw)?.access_token : '';
+                  } catch {
+                    return '';
+                  }
+                })()
+              : '';
+          const resp = await fetch('/api/search/fallback', {
+            method: 'POST',
+            headers: {
+              'Content-Type': 'application/json',
+              ...(jwt ? { Authorization: `Bearer ${jwt}` } : {}),
+            },
+            body: JSON.stringify({ query: q, yacht_id: yachtId, limit: 20 }),
+          });
+          if (resp.ok) {
+            const data = await resp.json();
+            const domain = field.search_domain || 'equipment';
+            const filtered = (data.results || []).filter(
+              (r: { object_type: string }) =>
+                r.object_type === domain || r.object_type === `pms_${domain}`
+            );
+            setResults(filtered.slice(0, 10));
+            setShowDropdown(filtered.length > 0);
+          }
+        } catch {
+          setResults([]);
+          setShowDropdown(false);
+        }
+      }, 250);
+    },
+    [field.search_domain]
+  );
+
+  const handleSelect = React.useCallback(
+    (item: { id: string; title: string }) => {
+      onChange(item.id);
+      setDisplayLabel(item.title);
+      setQuery(item.title);
+      setShowDropdown(false);
+    },
+    [onChange]
+  );
+
   return (
-    <div className={s.entitySearchWrap}>
+    <div className={s.entitySearchWrap} style={{ position: 'relative' }}>
       <svg className={s.entitySearchIcon} viewBox="0 0 16 16" fill="none">
         <circle cx="7" cy="7" r="4.5" stroke="currentColor" strokeWidth="1.3" />
         <path d="M10.5 10.5L14 14" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" />
       </svg>
       <input
         type="text"
-        value={value}
-        placeholder={field.placeholder ?? 'Search...'}
-        onChange={(e) => onChange(e.target.value)}
+        value={displayLabel || query}
+        placeholder={field.placeholder ?? `Search ${field.search_domain || 'entity'}...`}
+        onChange={(e) => {
+          setDisplayLabel('');
+          handleSearch(e.target.value);
+          if (!e.target.value) onChange('');
+        }}
+        onFocus={() => results.length > 0 && setShowDropdown(true)}
+        onBlur={() => setTimeout(() => setShowDropdown(false), 200)}
       />
+      {showDropdown && results.length > 0 && (
+        <div
+          style={{
+            position: 'absolute',
+            top: '100%',
+            left: 0,
+            right: 0,
+            maxHeight: 200,
+            overflowY: 'auto',
+            background: 'var(--surface-elevated, #1a1a2e)',
+            border: '1px solid var(--surface-border, #333)',
+            borderRadius: 6,
+            zIndex: 100,
+            marginTop: 2,
+          }}
+        >
+          {results.map((item) => (
+            <div
+              key={item.id}
+              onMouseDown={() => handleSelect(item)}
+              style={{
+                padding: '8px 12px',
+                cursor: 'pointer',
+                fontSize: 13,
+                color: 'var(--txt-primary, #eee)',
+                borderBottom: '1px solid var(--surface-border, #222)',
+              }}
+              onMouseEnter={(e) => {
+                (e.target as HTMLElement).style.background = 'var(--surface-hover, #252540)';
+              }}
+              onMouseLeave={(e) => {
+                (e.target as HTMLElement).style.background = 'transparent';
+              }}
+            >
+              {item.title || item.id}
+            </div>
+          ))}
+        </div>
+      )}
     </div>
   );
 }

--- a/apps/web/src/components/lens-v2/mapActionFields.ts
+++ b/apps/web/src/components/lens-v2/mapActionFields.ts
@@ -98,6 +98,7 @@ export function mapActionFields(action: ActionDef): ActionPopupField[] {
         options,
         placeholder: meta?.placeholder || `Enter ${f.replace(/_/g, ' ')}...`,
         value: (action.prefill[f] as string) ?? '',
+        search_domain: meta?.search_domain,
       };
     });
 }


### PR DESCRIPTION
## Summary
- Backend: equipment_id reclassified CONTEXT→REQUIRED (visible in form), document_id reclassified REQUIRED→CONTEXT (auto-prefilled from open doc)
- Frontend: FieldEntitySearch rewritten from dead-shell text input to functional debounced search-select with dropdown
- Prefill map entry added for document→link_document_to_equipment

## Bug (found by MCP02 S6)
Modal showed: empty "Enter document id..." text input + no equipment field at all. Submit returned 400 VALIDATION_ERROR.

## Fix
Modal now shows: document_id auto-prefilled, equipment_id as a search picker that queries /api/search/fallback and shows matching equipment in a dropdown.

## Test plan
- [ ] MCP02 re-runs S6 against production after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)