### PR TITLE
fix: notifications mark-all-read 404 + Redis connection leak

### DIFF
--- a/apps/api/cache/invalidation_listener.py
+++ b/apps/api/cache/invalidation_listener.py
@@ -51,15 +51,21 @@ async def ensure_redis_connected():
 
     if _redis is None:
         logger.info("Redis not initialized, attempting connection...")
-        _redis = await redis_async.from_url(REDIS_URL, decode_responses=True)
+        _redis = await redis_async.from_url(REDIS_URL, decode_responses=True, max_connections=3)
 
     try:
         await _redis.ping()
         return True
     except Exception as e:
         logger.warning(f"Redis ping failed: {e}, attempting reconnection...")
+        # Close old pool before creating a new one to avoid connection leaks
         try:
-            _redis = await redis_async.from_url(REDIS_URL, decode_responses=True)
+            await _redis.aclose()
+        except Exception:
+            pass
+        _redis = None
+        try:
+            _redis = await redis_async.from_url(REDIS_URL, decode_responses=True, max_connections=3)
             await _redis.ping()
             logger.info("Redis reconnected successfully")
             return True
@@ -158,7 +164,8 @@ async def listen_and_evict():
     )
 
     logger.info("Connecting to Redis...")
-    _redis = await redis_async.from_url(REDIS_URL, decode_responses=True)
+    # max_connections=3 caps this worker's pool so parallel workers don't saturate Redis
+    _redis = await redis_async.from_url(REDIS_URL, decode_responses=True, max_connections=3)
 
     # Test Redis connection
     try:
@@ -166,6 +173,11 @@ async def listen_and_evict():
         logger.info(f"Redis connected: {pong}")
     except Exception as e:
         logger.error(f"Redis ping failed: {e}")
+        try:
+            await _redis.aclose()
+        except Exception:
+            pass
+        _redis = None
         return
 
     # Register notification listener

--- a/apps/api/cortex/rewrites.py
+++ b/apps/api/cortex/rewrites.py
@@ -102,7 +102,7 @@ async def _get_redis():
         return None
     if _redis is None:
         try:
-            _redis = await redis_async.from_url(REDIS_URL, decode_responses=True)
+            _redis = await redis_async.from_url(REDIS_URL, decode_responses=True, max_connections=3)
             await _redis.ping()
             logger.info("[Cortex] Redis connected for rewrite/embedding cache")
         except Exception as e:

--- a/apps/api/routes/f1_search_streaming.py
+++ b/apps/api/routes/f1_search_streaming.py
@@ -340,7 +340,7 @@ async def get_redis() -> Optional[redis_async.Redis]:
         return None
     if _redis is None:
         try:
-            _redis = await redis_async.from_url(REDIS_URL, decode_responses=True)
+            _redis = await redis_async.from_url(REDIS_URL, decode_responses=True, max_connections=3)
             await _redis.ping()
             logger.info("[F1Search] Redis connected for result caching")
         except Exception as e:

--- a/apps/web/src/app/api/v1/notifications/mark-all-read/route.ts
+++ b/apps/web/src/app/api/v1/notifications/mark-all-read/route.ts
@@ -1,0 +1,28 @@
+/**
+ * PATCH /api/v1/notifications/mark-all-read
+ *
+ * Proxies to backend PATCH /v1/notifications/mark-all-read.
+ * Marks all unread notifications as read for the current user+yacht.
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+
+const API_BASE = process.env.NEXT_PUBLIC_API_URL || 'https://pipeline-core.int.celeste7.ai';
+
+export async function PATCH(request: NextRequest): Promise<NextResponse> {
+  const auth = request.headers.get('Authorization');
+  if (!auth) return NextResponse.json({ status: 'error', message: 'Unauthorized' }, { status: 401 });
+
+  const params = request.nextUrl.searchParams.toString();
+  const url = params
+    ? `${API_BASE}/v1/notifications/mark-all-read?${params}`
+    : `${API_BASE}/v1/notifications/mark-all-read`;
+
+  const res = await fetch(url, {
+    method: 'PATCH',
+    headers: { Authorization: auth, 'Content-Type': 'application/json' },
+  });
+
+  const data = await res.json().catch(() => ({ status: 'success' }));
+  return NextResponse.json(data, { status: res.status });
+}


### PR DESCRIPTION
## Summary

- **Add missing Next.js route** `apps/web/src/app/api/v1/notifications/mark-all-read/route.ts`  
  The frontend (`NotificationBell.tsx`) calls `PATCH /api/v1/notifications/mark-all-read` but no Next.js handler existed at that subpath — only at `/api/v1/notifications`. Every click on "Mark all as read" returned 404.

- **Fix Redis connection leak** in `cache/invalidation_listener.py`  
  On each reconnect attempt, the old connection pool was overwritten without closing it (`aclose()`). The background worker crashes and restarts repeatedly, and each restart left an orphaned pool open on the Redis server — causing "max number of clients reached" which cascades into 500s on the notifications GET, `cortex/rewrites.py`, and search streaming.

- **Cap Redis pool size** (`max_connections=3`) across all three pool sites:  
  `invalidation_listener.py`, `cortex/rewrites.py`, `f1_search_streaming.py`.  
  Prevents any single Render worker from monopolising the Redis client budget.

## Test plan

- [ ] Click "Mark all as read" in the notification bell — should return 200, badge clears
- [ ] Watch Render logs — "max number of clients reached" should stop appearing after deploy
- [ ] `GET /api/v1/notifications` should return 200 (not 500) once Redis recovers

🤖 Generated with [Claude Code](https://claude.com/claude-code)