### PR TITLE
fix(hor): height layout, calendar 502, Calendar button

### DIFF
--- a/apps/web/src/app/api/v1/hours-of-rest/[...path]/route.ts
+++ b/apps/web/src/app/api/v1/hours-of-rest/[...path]/route.ts
@@ -5,17 +5,23 @@
  *   /api/v1/hours-of-rest/my-week
  *   /api/v1/hours-of-rest/department-status
  *   /api/v1/hours-of-rest/vessel-compliance
+ *   /api/v1/hours-of-rest/month-status
  *   /api/v1/hours-of-rest/upsert
  *   /api/v1/hours-of-rest/signoffs/sign
  *   /api/v1/hours-of-rest/templates
  *   /api/v1/hours-of-rest/templates/apply
+ *   /api/v1/hours-of-rest/notifications/unread
+ *   /api/v1/hours-of-rest/warnings/*
  *
  * → ${RENDER_API_URL}/v1/hours-of-rest/...
+ *
+ * Timeout: 28s — enough for a cold Render service wake-up.
  */
 
 import { NextRequest, NextResponse } from 'next/server';
 
 const RENDER_API_URL = process.env.NEXT_PUBLIC_API_URL || 'https://pipeline-core.int.celeste7.ai';
+const PROXY_TIMEOUT_MS = 28_000;
 
 async function proxy(request: NextRequest, method: 'GET' | 'POST', path: string[]): Promise<NextResponse> {
   const authHeader = request.headers.get('Authorization');
@@ -30,6 +36,7 @@ async function proxy(request: NextRequest, method: 'GET' | 'POST', path: string[
   const options: RequestInit = {
     method,
     headers: { 'Content-Type': 'application/json', 'Authorization': authHeader },
+    signal: AbortSignal.timeout(PROXY_TIMEOUT_MS),
   };
 
   if (method === 'POST') {
@@ -40,14 +47,31 @@ async function proxy(request: NextRequest, method: 'GET' | 'POST', path: string[
     }
   }
 
+  let resp: Response;
   try {
-    const resp = await fetch(upstreamUrl, options);
-    const data = await resp.json();
-    return NextResponse.json(data, { status: resp.status });
-  } catch (err) {
-    console.error('[HoR Proxy]', err);
-    return NextResponse.json({ success: false, error: 'Proxy error' }, { status: 502 });
+    resp = await fetch(upstreamUrl, options);
+  } catch (err: unknown) {
+    const isTimeout = err instanceof Error && (err.name === 'TimeoutError' || err.name === 'AbortError');
+    console.error(`[HoR Proxy] fetch failed (${segment}):`, err);
+    return NextResponse.json(
+      { success: false, error: isTimeout ? 'Upstream timeout — service may be cold-starting, retry in a moment' : 'Upstream unreachable', code: isTimeout ? 'TIMEOUT' : 'UPSTREAM_ERROR' },
+      { status: 503 },
+    );
   }
+
+  // Try JSON parse; if upstream returned HTML/empty on an error status, surface that status.
+  let data: unknown;
+  try {
+    data = await resp.json();
+  } catch {
+    console.error(`[HoR Proxy] non-JSON upstream response (${segment}) status=${resp.status}`);
+    return NextResponse.json(
+      { success: false, error: 'Upstream returned a non-JSON response', code: 'BAD_UPSTREAM', status: resp.status },
+      { status: resp.status >= 400 ? resp.status : 502 },
+    );
+  }
+
+  return NextResponse.json(data, { status: resp.status });
 }
 
 export async function GET(request: NextRequest, { params }: { params: { path: string[] } }) {

--- a/apps/web/src/components/hours-of-rest/MyTimeView.tsx
+++ b/apps/web/src/components/hours-of-rest/MyTimeView.tsx
@@ -679,15 +679,19 @@ export function MyTimeView({ targetUserId, readOnly: forceReadOnly }: MyTimeView
                 onClick={() => setCalendarOpen(o => !o)}
                 title="Month calendar"
                 style={{
-                  background: calendarOpen ? 'rgba(90,171,204,0.12)' : 'none',
-                  border: calendarOpen ? '1px solid rgba(90,171,204,0.25)' : '1px solid rgba(255,255,255,0.08)',
+                  background: calendarOpen ? 'var(--teal-bg, rgba(58,124,157,0.14))' : 'rgba(255,255,255,0.04)',
+                  border: calendarOpen ? '1px solid var(--mark, #5AABCC)' : '1px solid rgba(255,255,255,0.10)',
                   borderRadius: 4,
-                  color: calendarOpen ? 'var(--mark, #5AABCC)' : 'rgba(255,255,255,0.35)',
-                  cursor: 'pointer', padding: '2px 7px',
-                  fontFamily: 'var(--font-mono)', fontSize: 9,
-                  letterSpacing: '0.06em', marginLeft: 4,
+                  color: calendarOpen ? 'var(--mark, #5AABCC)' : 'rgba(255,255,255,0.50)',
+                  cursor: 'pointer', padding: '3px 10px',
+                  fontFamily: 'var(--font-mono)', fontSize: 10,
+                  fontWeight: 500,
+                  letterSpacing: '0.08em', marginLeft: 6,
+                  textTransform: 'uppercase',
+                  transition: 'background 0.12s, border-color 0.12s, color 0.12s',
+                  whiteSpace: 'nowrap',
                 }}
-              >CAL</button>
+              >Calendar</button>
               {/* Day-status dots — green=compliant, amber=violation, grey=not filed */}
               <div style={{ display: 'flex', gap: 3, marginLeft: 6 }}>
                 {data.days.filter(Boolean).map((day: any) => {

--- a/apps/web/src/styles/globals.css
+++ b/apps/web/src/styles/globals.css
@@ -399,7 +399,7 @@ html, body {
   font-feature-settings: "kern" 1, "liga" 1, "calt" 1;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
-  zoom: 0.8;
+  height: 100%;
 }
 
 /* Spotlight-inspired centered container */


### PR DESCRIPTION
## What

Three production bugs found during manual testing of the Hours of Rest module.

## Changes

**`globals.css`** — Remove `zoom: 0.8` from `html, body`
Root cause of the height problem. `zoom: 0.8` scales all rendered elements to 80% of their computed height, while `100vh` in AppShell still measures the physical viewport. Result: the entire layout (sidebar + content) renders to 80% of the screen height, leaving 20% blank at the bottom. Users scroll when there is ample space below. Replaced with `height: 100%` to restore natural viewport fill.

**`[...path]/route.ts`** — Fix HoR proxy swallowing all errors as 502
The proxy had a single `try/catch` wrapping both `fetch()` and `resp.json()`. A cold Render wake-up (no timeout configured) or non-JSON upstream response would throw into the same catch block and silently return 502. Now: `AbortSignal.timeout(28_000)` gives Render time to cold-start; fetch errors and JSON parse errors have separate handlers with distinct error codes (`TIMEOUT`, `UPSTREAM_ERROR`, `BAD_UPSTREAM`).

**`MyTimeView.tsx`** — CAL → Calendar, proper branded button
`CAL` is not a label. Replaced with `Calendar`, styled to match site token system: `--teal-bg`/`--mark` on active, `fontSize: 10`, `fontWeight: 500`, `textTransform: uppercase`, `transition`.

## Test plan
- [ ] Deploy preview: verify sidebar extends to full viewport bottom
- [ ] Open HoR calendar — no 502, calendar renders
- [ ] Calendar button reads "CALENDAR" with teal active state
- [ ] No regressions on other domain layouts (sidebar height on work orders, faults, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)