### PR TITLE
fix(actions): SIGNED actions send signature object, not bare pin

### DIFF
--- a/apps/web/src/components/lens-v2/ActionPopup.tsx
+++ b/apps/web/src/components/lens-v2/ActionPopup.tsx
@@ -600,8 +600,22 @@ export function ActionPopup({
   const handleSubmit = () => {
     if (computedDisabled) return;
     const result: Record<string, unknown> = { ...values };
-    if (signatureLevel === 3) result.pin = pin;
-    if (signatureLevel === 2 || signatureLevel === 4) result.signature_name = sigName;
+    // Backend SIGNED actions require `signature` (JSON object) in the payload.
+    // Map frontend signature levels to the backend contract shape.
+    if (signatureLevel === 3) {
+      result.signature = {
+        method: 'pin',
+        pin,
+        signed_at: new Date().toISOString(),
+      };
+    }
+    if (signatureLevel === 2 || signatureLevel === 4) {
+      result.signature = {
+        method: 'name',
+        name: sigName,
+        signed_at: new Date().toISOString(),
+      };
+    }
     onSubmit(result);
   };
 


### PR DESCRIPTION
## Summary
Frontend SIGNED actions sent `pin: "1234"` but backend requires `signature: {method, pin, signed_at}`. All SIGNED variant actions (delete_document, archive_document, decommission_equipment, etc.) returned 400 MISSING_REQUIRED_FIELD.

## Fix
ActionPopup.tsx handleSubmit now builds proper `signature` JSON object for L2/L3/L4 signature levels.

## Impact
Fixes every SIGNED action across all domains, not just documents.

## Test plan
- [ ] MCP02 S4: captain delete with PIN "1234" → 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)