### PR TITLE
fix(handover): CEO polish — fetchItems retries, optimistic Add, export toast

### DIFF
--- a/apps/web/src/components/handover/HandoverDraftPanel.tsx
+++ b/apps/web/src/components/handover/HandoverDraftPanel.tsx
@@ -509,22 +509,39 @@ export function HandoverDraftPanel({ isOpen, onClose, variant = 'drawer' }: Hand
   const userReady = !!(user?.id);
 
   // ── Fetch — all calls go through Render API (TENANT DB, correct path) ──
+  // CORS headers occasionally disappear during Render rolling deploys
+  // (PR #565 is deployed, but transitions briefly serve without CORS). Cap
+  // retries at 3 with exponential backoff (1s / 2s / 4s) so a deploy blip
+  // doesn't produce infinite console spam.
   const fetchItems = useCallback(async () => {
     if (!user?.id) return;
     setLoading(true);
+    const MAX_RETRIES = 3;
+    const BACKOFFS = [1000, 2000, 4000];
     try {
       const { data: sessionData } = await supabase.auth.getSession();
       const token = sessionData?.session?.access_token;
       if (!token) { toast.error('Not authenticated'); return; }
 
-      const res = await fetch(`${RENDER_API_URL}/v1/handover/items`, {
-        headers: { Authorization: `Bearer ${token}` },
-      });
-      if (!res.ok) { toast.error('Failed to load handover items'); return; }
-      const { items: fetched } = await res.json();
-      setItems(fetched || []);
-      setExpandedDays(new Set([new Date().toISOString().split('T')[0]]));
-    } catch {
+      let lastError: unknown = null;
+      for (let attempt = 0; attempt < MAX_RETRIES; attempt++) {
+        try {
+          const res = await fetch(`${RENDER_API_URL}/v1/handover/items`, {
+            headers: { Authorization: `Bearer ${token}` },
+          });
+          if (!res.ok) throw new Error(`HTTP ${res.status}`);
+          const { items: fetched } = await res.json();
+          setItems(fetched || []);
+          setExpandedDays(new Set([new Date().toISOString().split('T')[0]]));
+          return;
+        } catch (err) {
+          lastError = err;
+          if (attempt < MAX_RETRIES - 1) {
+            await new Promise((r) => setTimeout(r, BACKOFFS[attempt]));
+          }
+        }
+      }
+      console.warn('[HandoverDraftPanel] fetchItems giving up after retries:', lastError);
       toast.error('Failed to load handover items');
     } finally {
       setLoading(false);
@@ -606,6 +623,13 @@ export function HandoverDraftPanel({ isOpen, onClose, variant = 'drawer' }: Hand
   const handleExport = useCallback(async () => {
     if (!user?.id || !(activeVesselId || user?.yachtId) || items.length === 0) return;
     setExporting(true);
+    // Immediate feedback: the LLM pipeline can take up to 2 minutes on a
+    // cold start. Without this toast the button just spins and the user has
+    // no indication anything is happening.
+    const pendingToastId = toast.info(
+      'Generating handover — this may take up to 2 minutes',
+      { duration: 120_000 }
+    );
     try {
       const { data: sessionData } = await supabase.auth.getSession();
       const token = sessionData?.session?.access_token;
@@ -629,11 +653,15 @@ export function HandoverDraftPanel({ isOpen, onClose, variant = 'drawer' }: Hand
         body: JSON.stringify({ item_ids: items.map(i => i.id) }),
       });
 
+      toast.dismiss(pendingToastId);
+      // 10s duration (not default 4s) so the user sees the "View" button.
       toast.success(`Handover exported — ${result.total_items} items`, {
+        duration: 10_000,
         action: { label: 'View', onClick: () => router.push(`/handover-export/${result.export_id}`) },
       });
       fetchItems();
     } catch (err) {
+      toast.dismiss(pendingToastId);
       toast.error(err instanceof Error ? err.message : 'Failed to export handover');
     } finally {
       setExporting(false);

--- a/apps/web/src/components/handover/HandoverQueueView.tsx
+++ b/apps/web/src/components/handover/HandoverQueueView.tsx
@@ -298,6 +298,11 @@ export function HandoverQueueView() {
   const handleAdd = React.useCallback(async (item: HandoverQueueItem, entityType: string, entityLabel: string) => {
     if (!user?.id || !vesselId) return;
     setAddingId(item.id);
+    // True optimistic update: flip the button to "✓ Added" immediately so the
+    // user gets instant feedback. Revert on failure. The round-trip
+    // Vercel → Render → Supabase can be slow (cold start + rolling deploy);
+    // the UI shouldn't visibly stall for that.
+    setAlreadyQueued(prev => new Set([...prev, item.id]));
     try {
       const { data: sessionData } = await supabase.auth.getSession();
       const token = sessionData?.session?.access_token;
@@ -321,10 +326,14 @@ export function HandoverQueueView() {
         const errBody = await res.json().catch(() => ({}));
         throw new Error(errBody?.message || `Failed (${res.status})`);
       }
-      // Optimistic update
-      setAlreadyQueued(prev => new Set([...prev, item.id]));
       toast.success('Added to handover draft');
     } catch (err) {
+      // Revert optimistic flip on failure
+      setAlreadyQueued(prev => {
+        const next = new Set(prev);
+        next.delete(item.id);
+        return next;
+      });
       toast.error(err instanceof Error ? err.message : 'Failed to add to draft');
     } finally {
       setAddingId(null);


### PR DESCRIPTION
## Summary

Three targeted fixes for live-site issues found by CEO during testing
on 2026-04-16.

1. **`HandoverDraftPanel.tsx` `fetchItems`** — cap retries at 3 with
   exponential backoff (1s / 2s / 4s). CORS headers disappear momentarily
   during Render rolling deploys (PR #565 is deployed but transitions
   briefly serve without CORS), which previously produced infinite
   console spam.

2. **`HandoverQueueView.tsx` `handleAdd`** — true optimistic update.
   Flip the button to "✓ Added" BEFORE the network call, revert on
   failure. The Vercel → Render → Supabase round-trip can be slow (cold
   start + rolling deploy); the UI no longer stalls waiting for it.

3. **`HandoverDraftPanel.tsx` `handleExport`** — immediate "Generating
   handover — this may take up to 2 minutes" toast on click (was
   nothing), and success toast duration bumped to 10s (was 4s default)
   so the user has time to notice and click the "View" button.

## Scope

2 files, +47/-10 lines. Behaviour-preserving on the happy path; only
affects failure / slow-network UX.

## Test plan

- [x] `npx tsc --noEmit` passes from project root
- [ ] Merge + verify on live site
- [ ] Rerun shard-47 / shard-49 / shard-54 post-merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)