### PR TITLE
infra: Vercel cron keep-warm (prevent Render hibernation)

### DIFF
--- a/apps/web/src/app/api/cron/keep-warm/route.ts
+++ b/apps/web/src/app/api/cron/keep-warm/route.ts
@@ -1,0 +1,54 @@
+/**
+ * Keep-warm cron — fires every 10 minutes via Vercel Crons.
+ *
+ * Pings both Render services to prevent free-tier hibernation.
+ * Render hibernates services after ~15 minutes of inactivity.
+ * A hibernated service returns HTML with no CORS headers, which
+ * causes CORS errors in the browser on bootstrap and a 503 from
+ * the Next.js HoR proxy.
+ *
+ * Schedule: every 10 minutes (see vercel.json crons config).
+ * No auth required — this endpoint makes no mutations and returns
+ * only service health status. Worst case abuse: someone pings our
+ * own /health endpoints.
+ */
+
+import { NextResponse } from 'next/server';
+
+const SERVICES = [
+  process.env.NEXT_PUBLIC_API_URL || 'https://pipeline-core.int.celeste7.ai',
+  'https://backend.celeste7.ai',
+  'https://pipeline-core.int.celeste7.ai',
+];
+
+// Deduplicate in case NEXT_PUBLIC_API_URL is already pipeline-core
+const UNIQUE_SERVICES = [...new Set(SERVICES)];
+
+export const runtime = 'nodejs';
+export const maxDuration = 30;
+
+export async function GET() {
+  const results: Record<string, number | string> = {};
+
+  await Promise.allSettled(
+    UNIQUE_SERVICES.map(async (url) => {
+      const target = `${url}/health`;
+      try {
+        const res = await fetch(target, {
+          signal: AbortSignal.timeout(10_000),
+          cache: 'no-store',
+        });
+        results[url] = res.status;
+      } catch (err: unknown) {
+        results[url] = err instanceof Error ? err.message : 'error';
+      }
+    }),
+  );
+
+  const allWarm = Object.values(results).every((v) => v === 200);
+
+  return NextResponse.json(
+    { ok: allWarm, services: results, ts: new Date().toISOString() },
+    { status: allWarm ? 200 : 207 },
+  );
+}

--- a/apps/web/vercel.json
+++ b/apps/web/vercel.json
@@ -3,5 +3,11 @@
   "devCommand": "npm run dev",
   "installCommand": "npm install",
   "framework": "nextjs",
-  "outputDirectory": ".next"
+  "outputDirectory": ".next",
+  "crons": [
+    {
+      "path": "/api/cron/keep-warm",
+      "schedule": "*/10 * * * *"
+    }
+  ]
 }


### PR DESCRIPTION
## Problem

Render free-tier hibernates both `backend.celeste7.ai` and `pipeline-core.int.celeste7.ai` after ~15 minutes of inactivity. When hibernated, Render returns a plain HTML "Service starting..." page with **no CORS headers**. This causes:

1. Browser's preflight OPTIONS to `backend.celeste7.ai/v1/bootstrap` gets no `Access-Control-Allow-Origin` → CORS error → auth never initialises → entire app shows Retry state
2. Next.js HoR proxy gets non-JSON from upstream → returns 503 BAD_UPSTREAM on all HoR API calls

**Both services were confirmed hibernating tonight during testing.** They wake in ~60-120s but re-hibernate within 15 minutes of no traffic, making sustained testing impossible.

## Fix

Vercel Cron fires `GET /api/cron/keep-warm` every 10 minutes. The handler pings `/health` on both Render services concurrently with a 10s timeout. Services stay warm indefinitely.

## Files

- `apps/web/vercel.json` — adds `crons` array with `*/10 * * * *` schedule
- `apps/web/src/app/api/cron/keep-warm/route.ts` — ping handler, `Promise.allSettled` on both services, returns JSON status per service

## No risk

- No mutations, no auth required on the keep-warm endpoint
- Worst case: someone triggers pings to our own `/health` endpoints
- Zero effect on any existing functionality

🤖 Generated with [Claude Code](https://claude.com/claude-code)