### PR TITLE
fix(warranty-runner): warmup URL → backend.celeste7.ai

### DIFF
--- a/tests/e2e/warranty_runner.py
+++ b/tests/e2e/warranty_runner.py
@@ -57,7 +57,7 @@ from playwright.sync_api import (
 # Warming here guarantees the backend is live when tests run.
 # ---------------------------------------------------------------------------
 
-API_BASE_URL = os.environ.get("WARRANTY_API_URL", "https://pipeline-core.int.celeste7.ai")
+API_BASE_URL = os.environ.get("WARRANTY_API_URL", "https://backend.celeste7.ai")
 WARMUP_TIMEOUT_S = 90
 
 


### PR DESCRIPTION
## Summary
- `warranty_runner.py:60` default warmup URL was `pipeline-core.int.celeste7.ai` — a different service than the warranty API
- The actual warranty API that all 8 scenarios target is `backend.celeste7.ai`
- Warmup was reporting 24× 503/timeout, blocking meaningful health-check signal before test runs

## Test plan
- [ ] RUN A (`--retry-failed 3`) already in flight against prior commit — warmup hit wrong URL, tests proceeded anyway (cosmetic)
- [ ] After merge, RUN B will use `backend.celeste7.ai/health` for warmup — correct target
- [ ] One-line change, zero risk to scenario logic

🤖 Generated with [Claude Code](https://claude.com/claude-code)