### PR TITLE
fix(test): handover shard reliability — summary field, Node-side seeding, anon auth

### DIFF
--- a/apps/web/e2e/shard-37-hours-of-rest/hor-pr614-verify.spec.ts
+++ b/apps/web/e2e/shard-37-hours-of-rest/hor-pr614-verify.spec.ts
@@ -1,0 +1,238 @@
+/**
+ * PR #614 verification — post-deploy pass
+ * Tests: zoom removal, calendar button, month nav, day click, HOD dept tab, captain submit week
+ *
+ * Mocks backend.celeste7.ai/v1/bootstrap + all HoR API calls so tests are immune
+ * to Render free-tier hibernation. Real services not needed for PR #614 UI behaviour.
+ *
+ * Runs against app.celeste7.ai with pre-minted auth state from playwright/.auth/
+ */
+import { test, expect } from '@playwright/test';
+import * as path from 'path';
+
+const BASE_URL = 'https://app.celeste7.ai';
+const AUTH_DIR = path.join(__dirname, '../../playwright/.auth');
+const YACHT_ID = '85fe1119-b04c-41ac-80f1-829d23322598';
+
+function fakeDays(count: number, month: string) {
+  return Array.from({ length: count }, (_, i) => {
+    const d = String(i + 1).padStart(2, '0');
+    return { date: `${month}-${d}`, submitted: i >= 12 && i <= 15, is_compliant: i >= 13 && i <= 15 ? true : null };
+  });
+}
+
+async function installMocks(page: any, role = 'crew') {
+  await page.route(/backend\.celeste7\.ai\/v1\/bootstrap/, async (route: any) => {
+    await route.fulfill({
+      status: 200, contentType: 'application/json',
+      body: JSON.stringify({
+        status: 'active',  // processBootstrapData needs 'active' to update role
+        yacht_id: YACHT_ID, yacht_name: 'M/Y Test Vessel', role,
+        user_id: 'aaaaaaaa-0000-4000-8000-000000000001',
+        email: `${role}@test.com`, subscription_active: true,
+        subscription_status: 'paid', is_fleet_user: false,
+        vessel_ids: [YACHT_ID], fleet_vessels: null,
+      }),
+    });
+  });
+  await page.route(/backend\.celeste7\.ai\/email\/unread-count/, async (route: any) => {
+    await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ count: 0 }) });
+  });
+  await page.route(/\/api\/v1\/hours-of-rest\/my-week/, async (route: any) => {
+    await route.fulfill({
+      status: 200, contentType: 'application/json',
+      body: JSON.stringify({
+        status: 'success', week_start: '2026-04-13', week_end: '2026-04-19',
+        days: Array.from({ length: 7 }, (_, i) => ({
+          id: `aaaaaaaa-0000-4000-8000-00000000001${i}`,
+          record_date: `2026-04-${String(13 + i).padStart(2, '0')}`,
+          work_periods: [{ start: '10:00', end: '11:00', hours: 1 }],
+          rest_periods: [], total_rest_hours: 23, total_work_hours: 1,
+          is_daily_compliant: true, submitted: true, warnings: [],
+        })),
+        compliance: { rolling_24h_rest: 23, rolling_7day_rest: 91 },
+        pending_signoff: null, templates: [],
+      }),
+    });
+  });
+  await page.route(/\/api\/v1\/hours-of-rest\/month-status/, async (route: any) => {
+    const url = new URL(route.request().url());
+    const month = url.searchParams.get('month') || '2026-04';
+    const [y, m] = month.split('-').map(Number);
+    const daysInMonth = new Date(y, m, 0).getDate();
+    await route.fulfill({
+      status: 200, contentType: 'application/json',
+      body: JSON.stringify({ status: 'success', month, days: fakeDays(daysInMonth, month) }),
+    });
+  });
+  await page.route(/\/api\/v1\/hours-of-rest\/warnings/, async (route: any) => {
+    await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ success: true, data: { warnings: [] } }) });
+  });
+  await page.route(/\/api\/v1\/notifications/, async (route: any) => {
+    await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ status: 'success', data: [] }) });
+  });
+}
+
+// ── 1. zoom:0.8 removed — shell fills viewport ────────────────────────────────
+test('PR #614 (1) zoom removed — shell fills viewport', async ({ browser }) => {
+  const ctx = await browser.newContext({
+    storageState: path.join(AUTH_DIR, 'crew.json'),
+    viewport: { width: 1440, height: 900 },
+  });
+  const page = await ctx.newPage();
+  await installMocks(page, 'crew');
+  await page.goto(`${BASE_URL}/hours-of-rest`, { waitUntil: 'domcontentloaded', timeout: 60000 });
+  await page.waitForTimeout(5000);
+
+  const m = await page.evaluate(() => ({
+    htmlZoom: getComputedStyle(document.documentElement).zoom,
+    bodyZoom: getComputedStyle(document.body).zoom,
+    vp: { w: window.innerWidth, h: window.innerHeight },
+    sidebarBottom: document.querySelector('nav')?.getBoundingClientRect().bottom ?? 0,
+  }));
+  console.log(`[PR614-1] htmlZoom=${m.htmlZoom} vp=${m.vp.w}x${m.vp.h} sidebarBot=${m.sidebarBottom}`);
+  expect(m.htmlZoom === '1' || m.htmlZoom === 'normal' || m.htmlZoom === '').toBe(true);
+  expect(m.sidebarBottom).toBeGreaterThan(m.vp.h - 80);
+  await ctx.close();
+});
+
+// ── 2+3. CALENDAR button exists + opens month grid ────────────────────────────
+test('PR #614 (2+3) — CALENDAR button + opens calendar', async ({ browser }) => {
+  const ctx = await browser.newContext({
+    storageState: path.join(AUTH_DIR, 'crew.json'),
+    viewport: { width: 1440, height: 900 },
+  });
+  const page = await ctx.newPage();
+  await installMocks(page, 'crew');
+  const monthStatusHits: number[] = [];
+  page.on('response', r => {
+    if (r.url().includes('month-status')) monthStatusHits.push(r.status());
+  });
+
+  await page.goto(`${BASE_URL}/hours-of-rest`, { waitUntil: 'domcontentloaded', timeout: 60000 });
+  const calBtn = page.locator('main button', { hasText: /calendar/i }).first();
+  await calBtn.waitFor({ timeout: 30000 });
+
+  const btnText = ((await calBtn.textContent()) || '').trim();
+  const btnNorm = btnText.replace(/[^A-Za-z]/g, '').toUpperCase();
+  console.log(`[PR614-2] button raw="${btnText}" norm="${btnNorm}"`);
+  expect(btnNorm).toBe('CALENDAR');
+
+  await calBtn.click();
+  await page.waitForTimeout(2000);
+  console.log(`[PR614-3] month-status hits: ${JSON.stringify(monthStatusHits)}`);
+  expect(monthStatusHits.length, 'calendar open should fetch month-status').toBeGreaterThan(0);
+  expect(monthStatusHits.every(s => s < 500)).toBe(true);
+
+  const monthLabel = await page.getByText(/January|February|March|April|May|June|July|August|September|October|November|December/i).count();
+  expect(monthLabel).toBeGreaterThan(0);
+  await ctx.close();
+});
+
+// ── 4. Month navigation prev/next ─────────────────────────────────────────────
+test('PR #614 (4) — month navigation prev/next', async ({ browser }) => {
+  const ctx = await browser.newContext({
+    storageState: path.join(AUTH_DIR, 'crew.json'),
+    viewport: { width: 1440, height: 900 },
+  });
+  const page = await ctx.newPage();
+  await installMocks(page, 'crew');
+  await page.goto(`${BASE_URL}/hours-of-rest`, { waitUntil: 'domcontentloaded', timeout: 60000 });
+  await page.locator('main button', { hasText: /calendar/i }).first().waitFor({ timeout: 30000 });
+  await page.locator('main button', { hasText: /calendar/i }).first().click();
+  await page.waitForTimeout(2000);
+
+  const labelBefore = ((await page.getByText(/^(January|February|March|April|May|June|July|August|September|October|November|December)\s+\d{4}$/i).first().textContent()) || '').trim();
+  // Click ‹ (prev month) — ›  is disabled at current month (April 2026 = nowYM guard in code)
+  const prevBtns = page.locator('button').filter({ hasText: /^‹$/ });
+  await prevBtns.last().click();
+  await page.waitForTimeout(1500);
+  const labelAfter = ((await page.getByText(/^(January|February|March|April|May|June|July|August|September|October|November|December)\s+\d{4}$/i).first().textContent()) || '').trim();
+
+  console.log(`[PR614-4] "${labelBefore}" → "${labelAfter}"`);
+  expect(labelBefore).not.toBe(labelAfter);
+  await ctx.close();
+});
+
+// ── 5. Day click changes week ──────────────────────────────────────────────────
+test('PR #614 (5) — day click triggers week reload', async ({ browser }) => {
+  const ctx = await browser.newContext({
+    storageState: path.join(AUTH_DIR, 'crew.json'),
+    viewport: { width: 1440, height: 900 },
+  });
+  const page = await ctx.newPage();
+  await installMocks(page, 'crew');
+  const myWeekHits: number[] = [];
+  page.on('response', r => {
+    if (r.url().includes('/api/v1/hours-of-rest/my-week')) myWeekHits.push(r.status());
+  });
+
+  await page.goto(`${BASE_URL}/hours-of-rest`, { waitUntil: 'domcontentloaded', timeout: 60000 });
+  await page.locator('main button', { hasText: /calendar/i }).first().waitFor({ timeout: 30000 });
+  await page.locator('main button', { hasText: /calendar/i }).first().click();
+  await page.waitForTimeout(2000);
+
+  const hitsBefore = myWeekHits.length;
+  const dayData = await page.evaluate(() => {
+    // Find the calendar grid that contains actual day buttons (not the M/T/W/T/F/S/S header row)
+    const grids = Array.from(document.querySelectorAll('div[style*="grid-template-columns"]')) as HTMLElement[];
+    const calGrids = grids.filter(g => /repeat\s*\(\s*7/.test(g.getAttribute('style') || ''));
+    // The grid with buttons is the day-cell grid (the header-only grid has no buttons)
+    const cal = calGrids.find(g => g.querySelectorAll('button').length > 0);
+    if (!cal) return { err: `no grid (found ${calGrids.length} repeat-7 grids)` } as const;
+    const btns = Array.from(cal.querySelectorAll('button')).filter(b => /^\s*\d{1,2}\s*$/.test((b as HTMLElement).innerText.trim()));
+    const target = btns.find(b => (b as HTMLElement).innerText.trim() === '10') || btns[5];
+    if (!target) return { err: 'no target day' } as const;
+    const r = target.getBoundingClientRect();
+    return { text: (target as HTMLElement).innerText.trim(), x: r.x + r.width / 2, y: r.y + r.height / 2 } as const;
+  });
+  console.log(`[PR614-5] day target: ${JSON.stringify(dayData)}`);
+  if ('err' in dayData) throw new Error(dayData.err);
+
+  await page.mouse.click(dayData.x, dayData.y);
+  await page.waitForTimeout(3000);
+  const newHits = myWeekHits.slice(hitsBefore);
+  console.log(`[PR614-5] new my-week calls: ${newHits.length}`);
+  expect(newHits.length).toBeGreaterThan(0);
+  await ctx.close();
+});
+
+// ── S5. HOD sees department tab ────────────────────────────────────────────────
+test('S5 — HOD sees department tab', async ({ browser }) => {
+  const ctx = await browser.newContext({
+    storageState: path.join(AUTH_DIR, 'hod.json'),
+    viewport: { width: 1440, height: 900 },
+  });
+  const page = await ctx.newPage();
+  // isHODRole() checks ['chief_engineer','chief_officer','eto'] — NOT 'hod'
+  await installMocks(page, 'eto');
+  await page.goto(`${BASE_URL}/hours-of-rest`, { waitUntil: 'domcontentloaded', timeout: 60000 });
+  await page.waitForSelector('text=/HOURS OF REST|THIS WEEK/i', { timeout: 30000 });
+  await page.waitForTimeout(2500);
+
+  const deptTab = page.locator('main button, main [role="tab"]').filter({ hasText: /department/i });
+  const count = await deptTab.count();
+  console.log(`[S5] HOD dept-tab count: ${count}`);
+  expect(count).toBeGreaterThan(0);
+  await ctx.close();
+});
+
+// ── Positive control. Captain sees Submit Week ─────────────────────────────────
+test('Positive control — captain sees Submit Week', async ({ browser }) => {
+  const ctx = await browser.newContext({
+    storageState: path.join(AUTH_DIR, 'captain.json'),
+    viewport: { width: 1440, height: 900 },
+  });
+  const page = await ctx.newPage();
+  await installMocks(page, 'captain');
+  await page.goto(`${BASE_URL}/hours-of-rest`, { waitUntil: 'domcontentloaded', timeout: 60000 });
+  await page.waitForSelector('text=/HOURS OF REST|THIS WEEK/i', { timeout: 30000 });
+  await page.waitForTimeout(2500);
+
+  const buttons = await page.locator('main button').allTextContents();
+  const hasSubmitWeek = buttons.some(b => /submit week/i.test(b));
+  console.log(`[ctrl] captain Submit Week: ${hasSubmitWeek}`);
+  console.log(`[ctrl] captain buttons: ${JSON.stringify(buttons.slice(0, 20))}`);
+  expect(hasSubmitWeek).toBe(true);
+  await ctx.close();
+});

--- a/apps/web/e2e/shard-37-hours-of-rest/pr614.config.ts
+++ b/apps/web/e2e/shard-37-hours-of-rest/pr614.config.ts
@@ -1,0 +1,21 @@
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  testDir: '.',
+  testMatch: 'hor-pr614-verify.spec.ts',
+  timeout: 90_000,
+  expect: { timeout: 15_000 },
+  workers: 1,
+  retries: 0,
+  reporter: [['list']],
+  use: {
+    baseURL: 'https://app.celeste7.ai',
+    viewport: { width: 1440, height: 900 },
+    deviceScaleFactor: 1,
+    actionTimeout: 20_000,
+    navigationTimeout: 60_000,
+    screenshot: 'off',
+    video: 'off',
+    trace: 'off',
+  },
+});

--- a/apps/web/e2e/shard-40-purchase-handover/purchase-handover-actions.spec.ts
+++ b/apps/web/e2e/shard-40-purchase-handover/purchase-handover-actions.spec.ts
@@ -59,14 +59,12 @@ test.describe('[Captain] add_to_handover — HARD PROOF', () => {
     await captainPage.goto(`${BASE_URL}/`);
     await captainPage.waitForLoadState('domcontentloaded');
 
-    // Validation gate at p0_actions_routes.py:880 requires 'title' field (not 'summary').
-    // Route code at line 1944 then extracts: summary = payload.get("summary") or uses title as fallback.
-    // Pass 'title' (10+ chars) to satisfy the gate; route maps it to summary internally.
-    const titleText = `S40 smoke handover note: vessel status summary ${generateTestId('s')}`;
+    // Required field is 'summary' per p0_actions_routes.py:795
+    const summaryText = `S40 smoke handover note: vessel status summary ${generateTestId('s')}`;
     const result = await callActionDirect(captainPage, 'add_to_handover', {
       // entity_type='note' does not require entity_id
       entity_type: 'note',
-      title: titleText,
+      summary: summaryText,
       category: 'fyi',
       priority: 'normal',
       is_critical: false,
@@ -102,10 +100,10 @@ test.describe('[Captain] add_to_handover — HARD PROOF', () => {
     await captainPage.goto(`${BASE_URL}/`);
     await captainPage.waitForLoadState('domcontentloaded');
 
-    const titleText = `S40 critical handover: urgent engine inspection required ${generateTestId('c')}`;
+    const summaryText = `S40 critical handover: urgent engine inspection required ${generateTestId('c')}`;
     const result = await callActionDirect(captainPage, 'add_to_handover', {
       entity_type: 'note',
-      title: titleText,
+      summary: summaryText,
       category: 'urgent',
       priority: 'high',
       is_critical: true,

--- a/apps/web/e2e/shard-47-handover-misc/handover-misc-actions.spec.ts
+++ b/apps/web/e2e/shard-47-handover-misc/handover-misc-actions.spec.ts
@@ -390,6 +390,21 @@ test.describe('[Captain] sign_handover_incoming — ADVISORY', () => {
 });
 
 // ===========================================================================
+// Helper: seed a handover item via Node-side request (no CORS dependency)
+// ===========================================================================
+async function seedHandoverItem(
+  request: import('@playwright/test').APIRequestContext,
+  payload: Record<string, unknown>,
+): Promise<{ status: number; data: Record<string, unknown> }> {
+  const response = await request.post(`${API_URL}/v1/actions/execute`, {
+    headers: { Authorization: `Bearer ${SESSION_JWT}`, 'Content-Type': 'application/json' },
+    data: { action: 'add_to_handover', context: {}, payload },
+  });
+  const data = await response.json();
+  return { status: response.status(), data };
+}
+
+// ===========================================================================
 // list_handover_items — HARD PROOF (GET /v1/handover/items)
 // ===========================================================================
 
@@ -402,7 +417,7 @@ test.describe('[Captain] list_handover_items — HARD PROOF', () => {
 
     // Step 1: Create a handover item so the list is non-empty
     const tag = generateTestId('li');
-    const createResult = await callActionDirect(captainPage, 'add_to_handover', {
+    const createResult = await seedHandoverItem(captainPage.request, {
       entity_type: 'note',
       summary: `S47 list-items probe ${tag}`,
       category: 'fyi',
@@ -444,7 +459,7 @@ test.describe('[Captain] edit_handover_item — HARD PROOF', () => {
 
     // Step 1: Create a handover item
     const tag = generateTestId('ei');
-    const createResult = await callActionDirect(captainPage, 'add_to_handover', {
+    const createResult = await seedHandoverItem(captainPage.request, {
       entity_type: 'note',
       summary: `S47 edit-item seed ${tag}`,
       category: 'fyi',
@@ -530,7 +545,7 @@ test.describe('[Captain] delete_handover_item — HARD PROOF', () => {
 
     // Step 1: Create a handover item
     const tag = generateTestId('di');
-    const createResult = await callActionDirect(captainPage, 'add_to_handover', {
+    const createResult = await seedHandoverItem(captainPage.request, {
       entity_type: 'note',
       summary: `S47 delete-item seed ${tag}`,
       category: 'fyi',
@@ -616,7 +631,7 @@ test.describe('[Captain] critical item HOD ledger cascade — HARD PROOF', () =>
 
     // Step 1: Create a critical handover item
     const tag = generateTestId('cc');
-    const createResult = await callActionDirect(captainPage, 'add_to_handover', {
+    const createResult = await seedHandoverItem(captainPage.request, {
       entity_type: 'note',
       summary: `S47 critical cascade probe ${tag}`,
       category: 'critical',

--- a/apps/web/e2e/shard-49-handover-export-e2e/handover-export-e2e.spec.ts
+++ b/apps/web/e2e/shard-49-handover-export-e2e/handover-export-e2e.spec.ts
@@ -41,13 +41,19 @@ function tenantAdmin(): SupabaseClient {
 const FAKE_SIGNATURE_BASE64 =
   'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==';
 
-/** Helper: sign in as captain via MASTER auth and return session */
-async function captainSession(supabaseAdmin: any) {
-  const { data: { session }, error } = await supabaseAdmin.auth.signInWithPassword({
+/** Helper: sign in as captain via MASTER auth (anon key) and return session */
+const MASTER_URL = 'https://qvzmkaamzaqxpzbewjxe.supabase.co';
+const MASTER_ANON = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InF2em1rYWFtemFxeHB6YmV3anhlIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NjM5NzkwNDYsImV4cCI6MjA3OTU1NTA0Nn0.MMzzsRkvbug-u19GBUnD0qLDtMVWEbOf6KE8mAADaxw';
+
+async function captainSession(_supabaseAdmin?: any) {
+  const authClient = createClient(MASTER_URL, MASTER_ANON, {
+    auth: { autoRefreshToken: false, persistSession: false },
+  });
+  const { data: { session }, error } = await authClient.auth.signInWithPassword({
     email: 'x@alex-short.com',
     password: 'Password2!',
   });
-  if (error || !session) throw new Error(`Captain auth failed: ${error?.message ?? 'no session'}`);
+  if (error || !session) throw new Error(`Captain auth failed: ${error?.message ?? JSON.stringify(error) ?? 'no session'}`);
   return session;
 }
 

--- a/scripts/hor-proof/mcp02-calendar.config.ts
+++ b/scripts/hor-proof/mcp02-calendar.config.ts
@@ -1,0 +1,21 @@
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  testDir: '.',
+  testMatch: 'mcp02-calendar.spec.ts',
+  timeout: 90_000,
+  expect: { timeout: 10_000 },
+  workers: 1,
+  retries: 0,
+  reporter: [['list']],
+  use: {
+    baseURL: process.env.E2E_BASE_URL || 'https://app.celeste7.ai',
+    viewport: { width: 1440, height: 900 },
+    deviceScaleFactor: 1,
+    actionTimeout: 15_000,
+    navigationTimeout: 30_000,
+    screenshot: 'off',
+    video: 'off',
+    trace: 'off',
+  },
+});

--- a/scripts/hor-proof/mcp02-calendar.spec.ts
+++ b/scripts/hor-proof/mcp02-calendar.spec.ts
@@ -1,0 +1,315 @@
+/**
+ * HOURSOFREST_MCP02 — PR #614 calendar verification (mocked upstream)
+ * Strategy: mock backend.celeste7.ai/v1/bootstrap + /email/unread-count +
+ * app.celeste7.ai/api/v1/hours-of-rest/* so tests run fully client-side and are
+ * immune to Render hibernation oscillation.
+ */
+import { test, expect } from '@playwright/test';
+import * as fs from 'fs';
+import * as path from 'path';
+
+const BASE_URL = process.env.E2E_BASE_URL || 'https://app.celeste7.ai';
+const SUPABASE_PROJECT_REF = 'qvzmkaamzaqxpzbewjxe';
+const STORAGE_KEY = `sb-${SUPABASE_PROJECT_REF}-auth-token`;
+const PROOF_DIR = process.env.PROOF_DIR || '/tmp/hor_mcp02';
+const CREW = {
+  access: process.env.CREW_ACCESS || '',
+  refresh: process.env.CREW_REFRESH || '',
+  sub: '4a66036f-899c-40c8-9b2a-598cee24a62f',
+  email: 'engineer.test@alex-short.com',
+};
+const YACHT_ID = '85fe1119-b04c-41ac-80f1-829d23322598';
+
+function writeStorageState(): string {
+  if (!CREW.access || !CREW.refresh) throw new Error('missing CREW_ACCESS / CREW_REFRESH');
+  const session = {
+    access_token: CREW.access, token_type: 'bearer', expires_in: 3600,
+    expires_at: Math.floor(Date.now() / 1000) + 3600,
+    refresh_token: CREW.refresh,
+    user: { id: CREW.sub, email: CREW.email, aud: 'authenticated', role: 'authenticated' },
+  };
+  const state = { cookies: [], origins: [{ origin: BASE_URL, localStorage: [{ name: STORAGE_KEY, value: JSON.stringify(session) }] }] };
+  fs.mkdirSync(PROOF_DIR, { recursive: true });
+  const fp = path.join(PROOF_DIR, 'storage-crew.json');
+  fs.writeFileSync(fp, JSON.stringify(state, null, 2));
+  return fp;
+}
+
+function fakeBootstrap() {
+  return {
+    yacht_id: YACHT_ID,
+    yacht_name: 'M/Y Test Vessel',
+    tenant_key_alias: 'yTEST_YACHT_001',
+    role: 'crew',
+    status: 'active',
+    user_id: CREW.sub,
+    email: CREW.email,
+    subscription_active: true,
+    subscription_status: 'paid',
+    subscription_plan: 'none',
+    subscription_expires_at: null,
+    is_fleet_user: false,
+    vessel_ids: [YACHT_ID],
+    fleet_vessels: null,
+  };
+}
+
+function fakeMyWeek() {
+  return {
+    status: 'success',
+    week_start: '2026-04-13',
+    week_end: '2026-04-19',
+    user_id: CREW.sub,
+    department: 'general',
+    days: [
+      { id: 'd4f78a50-e628-4f1b-a9ef-2eb4863afb08', record_date: '2026-04-13', work_periods: [{start:'04:30',end:'05:30',hours:1}], rest_periods: [], total_rest_hours:22, total_work_hours:2, is_daily_compliant:false, daily_compliance_notes:null, location:null, voyage_type:null, submitted:true, warnings: [] },
+      { id: 'f3c1be63-ae4f-43f9-9fac-a8b368308bcd', record_date: '2026-04-14', work_periods: [{start:'10:30',end:'11:30',hours:1}], rest_periods: [], total_rest_hours:23, total_work_hours:1, is_daily_compliant:true, submitted:true, warnings: [] },
+      { id: '27cb17c7-611b-4d79-b311-925d7af20230', record_date: '2026-04-15', work_periods: [{start:'11:30',end:'12:30',hours:1}], rest_periods: [], total_rest_hours:23, total_work_hours:1, is_daily_compliant:true, submitted:true, warnings: [] },
+      { id: 'aaaaaaaa-0000-4000-8000-000000000016', record_date: '2026-04-16', work_periods: [{start:'10:00',end:'11:00',hours:1}], rest_periods: [], total_rest_hours:23, total_work_hours:1, is_daily_compliant:true, submitted:true, warnings: [] },
+      { id: 'aaaaaaaa-0000-4000-8000-000000000017', record_date: '2026-04-17', work_periods: [{start:'10:00',end:'11:00',hours:1}], rest_periods: [], total_rest_hours:23, total_work_hours:1, is_daily_compliant:true, submitted:true, warnings: [] },
+      { id: 'aaaaaaaa-0000-4000-8000-000000000018', record_date: '2026-04-18', work_periods: [{start:'10:00',end:'11:00',hours:1}], rest_periods: [], total_rest_hours:23, total_work_hours:1, is_daily_compliant:true, submitted:true, warnings: [] },
+      { id: 'aaaaaaaa-0000-4000-8000-000000000019', record_date: '2026-04-19', work_periods: [{start:'10:00',end:'11:00',hours:1}], rest_periods: [], total_rest_hours:23, total_work_hours:1, is_daily_compliant:true, submitted:true, warnings: [] },
+    ],
+    compliance: { rolling_24h_rest: 23, rolling_7day_rest: 91 },
+    pending_signoff: null,
+    templates: [],
+  };
+}
+
+function fakeMonthStatus(month: string) {
+  const [y, m] = month.split('-').map(Number);
+  const daysInMonth = new Date(y, m, 0).getDate();
+  return {
+    status: 'success',
+    month,
+    days: Array.from({ length: daysInMonth }, (_, i) => {
+      const d = String(i + 1).padStart(2, '0');
+      return { date: `${month}-${d}`, submitted: (i >= 12 && i <= 15), is_compliant: (i >= 13 && i <= 15) ? true : (i === 12 ? false : null) };
+    }),
+  };
+}
+
+async function installMocks(page: any) {
+  await page.route(/backend\.celeste7\.ai\/v1\/bootstrap/, async route => {
+    await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(fakeBootstrap()) });
+  });
+  await page.route(/backend\.celeste7\.ai\/email\/unread-count/, async route => {
+    await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ count: 0 }) });
+  });
+  await page.route(/\/api\/v1\/hours-of-rest\/my-week/, async route => {
+    await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(fakeMyWeek()) });
+  });
+  await page.route(/\/api\/v1\/hours-of-rest\/month-status/, async route => {
+    const url = new URL(route.request().url());
+    const month = url.searchParams.get('month') || '2026-04';
+    await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(fakeMonthStatus(month)) });
+  });
+  await page.route(/\/api\/v1\/hours-of-rest\/warnings/, async route => {
+    await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ success: true, data: { warnings: [] } }) });
+  });
+  await page.route(/\/api\/v1\/notifications/, async route => {
+    await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ status: 'success', data: [] }) });
+  });
+}
+
+// ── PR #614 (1) layout — no mocks needed, this is purely frontend CSS ───
+test('PR #614 (1) — zoom:0.8 removed, shell fills viewport height', async ({ browser }) => {
+  const context = await browser.newContext({ storageState: writeStorageState(), viewport: { width: 1440, height: 900 } });
+  const page = await context.newPage();
+  await installMocks(page);
+  await page.goto(`${BASE_URL}/hours-of-rest`, { waitUntil: 'domcontentloaded', timeout: 60000 });
+  await page.waitForTimeout(4000);
+
+  const m = await page.evaluate(() => {
+    const main = document.querySelector('main');
+    const sidebar = document.querySelector('nav');
+    return {
+      htmlZoom: getComputedStyle(document.documentElement).zoom,
+      bodyZoom: getComputedStyle(document.body).zoom,
+      vp: { w: window.innerWidth, h: window.innerHeight },
+      sidebarBottom: sidebar?.getBoundingClientRect().bottom ?? 0,
+    };
+  });
+  console.log(`[PR614-1] htmlZoom=${m.htmlZoom} vp=${m.vp.w}x${m.vp.h} sidebarBot=${m.sidebarBottom}`);
+  expect(m.htmlZoom === '1' || m.htmlZoom === 'normal' || m.htmlZoom === '').toBe(true);
+  expect(m.sidebarBottom).toBeGreaterThan(m.vp.h - 80);
+  await context.close();
+});
+
+// ── PR #614 (2+3) Calendar button + open without 502 ───────────────────
+test('PR #614 (2+3) — CALENDAR button + opens (mocked month-status)', async ({ browser }) => {
+  const context = await browser.newContext({ storageState: writeStorageState(), viewport: { width: 1440, height: 900 } });
+  const page = await context.newPage();
+  await installMocks(page);
+
+  const monthStatusHits: Array<{ status: number; url: string }> = [];
+  page.on('response', r => {
+    if (r.url().includes('month-status')) monthStatusHits.push({ status: r.status(), url: r.url() });
+  });
+
+  await page.goto(`${BASE_URL}/hours-of-rest`, { waitUntil: 'domcontentloaded', timeout: 60000 });
+  await page.locator('main button', { hasText: /calendar/i }).first().waitFor({ timeout: 30000 });
+
+  const calBtn = page.locator('main button', { hasText: /calendar/i }).first();
+  const btnText = (await calBtn.textContent() || '').trim();
+  const btnNorm = btnText.replace(/[^A-Za-z]/g, '').toUpperCase();
+  console.log(`[PR614-2] button raw="${btnText}" norm="${btnNorm}"`);
+  expect(btnNorm).toBe('CALENDAR');
+
+  await calBtn.click();
+  await page.waitForTimeout(2000);
+  await page.screenshot({ path: path.join(PROOF_DIR, 'PR614-2-open.png'), fullPage: false });
+
+  console.log(`[PR614-3] month-status hits: ${JSON.stringify(monthStatusHits)}`);
+  expect(monthStatusHits.length, 'calendar open should fetch month-status').toBeGreaterThan(0);
+  expect(monthStatusHits.every(h => h.status < 500)).toBe(true);
+  const monthLabelCount = await page.getByText(/January|February|March|April|May|June|July|August|September|October|November|December/i).count();
+  expect(monthLabelCount).toBeGreaterThan(0);
+
+  await context.close();
+});
+
+// ── PR #614 (4) Month nav ←→ ───────────────────────────────────────────
+test('PR #614 (4) — month navigation prev/next', async ({ browser }) => {
+  const context = await browser.newContext({ storageState: writeStorageState(), viewport: { width: 1440, height: 900 } });
+  const page = await context.newPage();
+  await installMocks(page);
+
+  const monthStatusUrls: string[] = [];
+  page.on('response', r => {
+    if (r.url().includes('month-status')) {
+      const m = r.url().match(/month=(\d{4}-\d{2})/);
+      if (m) monthStatusUrls.push(m[1]);
+    }
+  });
+
+  await page.goto(`${BASE_URL}/hours-of-rest`, { waitUntil: 'domcontentloaded', timeout: 60000 });
+  await page.locator('main button', { hasText: /calendar/i }).first().waitFor({ timeout: 30000 });
+  await page.locator('main button', { hasText: /calendar/i }).first().click();
+  await page.waitForTimeout(2000);
+
+  await page.screenshot({ path: path.join(PROOF_DIR, 'PR614-4-before-click.png'), fullPage: false });
+
+  // Dump all arrow-like buttons with coords for debug
+  const debug = await page.evaluate(() => {
+    const labels = Array.from(document.querySelectorAll('*')).filter(el =>
+      /^(January|February|March|April|May|June|July|August|September|October|November|December)\s+\d{4}$/i.test((el as HTMLElement).innerText?.trim() || '')
+    ).map(el => { const r = el.getBoundingClientRect(); return { text: (el as HTMLElement).innerText.trim(), x: r.x, y: r.y, w: r.width, tag: el.tagName }; });
+    const arrows = Array.from(document.querySelectorAll('button')).filter(b => /^[‹›←→]$/.test((b as HTMLElement).innerText.trim())).map(b => {
+      const r = b.getBoundingClientRect();
+      return { text: (b as HTMLElement).innerText.trim(), x: Math.round(r.x), y: Math.round(r.y), w: Math.round(r.width), h: Math.round(r.height), disabled: (b as HTMLButtonElement).disabled };
+    });
+    return { labels, arrows };
+  });
+  console.log(`[PR614-4 DEBUG] labels: ${JSON.stringify(debug.labels)}`);
+  console.log(`[PR614-4 DEBUG] arrows: ${JSON.stringify(debug.arrows)}`);
+
+  // Click the CALENDAR popover's ‹ (PREV) arrow.
+  // From DOM debug: calendar arrows are at y≈165, w=5px (narrow chevrons). The y=126 ones are topbar icons (not calendar).
+  // Pick the ‹ that is CLOSEST in y to the month-label "APRIL 2026" (which sits at y≈167 in the calendar header row).
+  const clickInfo = await page.evaluate(() => {
+    const label = Array.from(document.querySelectorAll('*')).find(el =>
+      /^(January|February|March|April|May|June|July|August|September|October|November|December)\s+\d{4}$/i.test((el as HTMLElement).innerText?.trim() || '')
+    ) as HTMLElement | undefined;
+    if (!label) return { err: 'no month label' } as const;
+    const labelRect = label.getBoundingClientRect();
+
+    const prevs = Array.from(document.querySelectorAll('button')).filter(b => {
+      const t = (b as HTMLElement).innerText.trim();
+      if (!/^[‹←]$/.test(t)) return false;
+      if ((b as HTMLButtonElement).disabled) return false;
+      const r = b.getBoundingClientRect();
+      return r.width > 0 && r.height > 0;  // just exclude invisible
+    });
+    if (prevs.length === 0) return { err: 'no prev arrow' } as const;
+    // Prefer the arrow whose y is within 30px of the label's y (same calendar row)
+    const pick = prevs.sort((a, b) => {
+      const ay = Math.abs(a.getBoundingClientRect().y - labelRect.y);
+      const by = Math.abs(b.getBoundingClientRect().y - labelRect.y);
+      return ay - by;
+    })[0];
+    const r = pick.getBoundingClientRect();
+    return {
+      pickRect: { x: r.x, y: r.y, w: r.width, h: r.height },
+      arrowCount: prevs.length,
+      labelBefore: label.innerText.trim(),
+      labelRect: { x: labelRect.x, y: labelRect.y, w: labelRect.width },
+    } as const;
+  });
+  console.log(`[PR614-4] scope-find: ${JSON.stringify(clickInfo)}`);
+  if ('err' in clickInfo) throw new Error(clickInfo.err);
+  if (!clickInfo.pickRect) throw new Error('no next-arrow in calendar popover');
+  await page.mouse.click(clickInfo.pickRect.x + clickInfo.pickRect.w/2, clickInfo.pickRect.y + clickInfo.pickRect.h/2);
+  await page.waitForTimeout(2000);
+
+  // Month nav is client-side (setCalMonth, no API fetch per HOURSOFREST01).
+  // Assert on label change via same innerText method.
+  const labelAfter = await page.evaluate(() => {
+    const el = Array.from(document.querySelectorAll('*')).find(x =>
+      /^(January|February|March|April|May|June|July|August|September|October|November|December)\s+\d{4}$/i.test((x as HTMLElement).innerText?.trim() || '')
+    ) as HTMLElement | undefined;
+    return el?.innerText.trim() || '';
+  });
+  const normBefore = (clickInfo.labelBefore.match(/^[A-Z]+\s+\d{4}$/i) || [''])[0].toUpperCase();
+  const normAfter = (labelAfter.match(/^[A-Z]+\s+\d{4}$/i) || [''])[0].toUpperCase();
+  console.log(`[PR614-4] label: "${clickInfo.labelBefore}" → "${labelAfter}"  norm: ${normBefore} → ${normAfter}`);
+  console.log(`[PR614-4] month-status URL params fired: ${JSON.stringify(monthStatusUrls)}`);
+  expect(normAfter, 'calendar month label should change after PREV click').not.toBe(normBefore);
+  await context.close();
+});
+
+// ── PR #614 (5) Day click changes week grid ────────────────────────────
+test('PR #614 (5) — day click changes week', async ({ browser }) => {
+  const context = await browser.newContext({ storageState: writeStorageState(), viewport: { width: 1440, height: 900 } });
+  const page = await context.newPage();
+  await installMocks(page);
+
+  const myWeekHits: Array<{ status: number; url: string }> = [];
+  page.on('response', r => {
+    if (r.url().includes('/api/v1/hours-of-rest/my-week')) myWeekHits.push({ status: r.status(), url: r.url() });
+  });
+
+  await page.goto(`${BASE_URL}/hours-of-rest`, { waitUntil: 'domcontentloaded', timeout: 60000 });
+  await page.locator('main button', { hasText: /calendar/i }).first().waitFor({ timeout: 30000 });
+  await page.locator('main button', { hasText: /calendar/i }).first().click();
+  await page.waitForTimeout(2000);
+
+  const weekHeaderBefore = (await page.locator('main').textContent() || '').match(/(?:THIS WEEK|Week)[^\n]*?\d{4}-\d{2}-\d{2}/)?.[0] || '';
+  const myWeekBefore = myWeekHits.length;
+
+  // Find day cell in the grid-template-columns:repeat(7,...) grid.
+  // Fallback: search any pure-numeric button inside the calendar popover if the grid selector is flaky.
+  const dayData = await page.evaluate(() => {
+    // Find month label as anchor
+    const label = Array.from(document.querySelectorAll('*')).find(el =>
+      /^(January|February|March|April|May|June|July|August|September|October|November|December)\s+\d{4}$/i.test((el as HTMLElement).innerText?.trim() || '')
+    ) as HTMLElement | undefined;
+    if (!label) return { err: 'no month label' } as const;
+    // Walk up from label until we find an ancestor that contains >= 20 numeric buttons
+    let root: HTMLElement | null = label;
+    let dayBtns: HTMLButtonElement[] = [];
+    for (let hop = 0; hop < 8 && root; hop++) {
+      dayBtns = Array.from(root.querySelectorAll('button')).filter(b => /^\s*\d{1,2}\s*$/.test((b as HTMLElement).innerText.trim())) as HTMLButtonElement[];
+      if (dayBtns.length >= 20) break;
+      root = root.parentElement;
+    }
+    if (dayBtns.length < 10) return { err: `insufficient day buttons (${dayBtns.length})` } as const;
+    const target = dayBtns.find(b => b.innerText.trim() === '21') || dayBtns[19];
+    if (!target) return { err: 'no target day' } as const;
+    const r = target.getBoundingClientRect();
+    return { text: target.innerText.trim(), totalBtns: dayBtns.length, x: r.x + r.width/2, y: r.y + r.height/2 } as const;
+  });
+  console.log(`[PR614-5] day click target: ${JSON.stringify(dayData)}`);
+  if ('err' in dayData) throw new Error(dayData.err);
+  await page.mouse.click(dayData.x, dayData.y);
+  await page.waitForTimeout(3000);
+
+  const weekHeaderAfter = (await page.locator('main').textContent() || '').match(/(?:THIS WEEK|Week)[^\n]*?\d{4}-\d{2}-\d{2}/)?.[0] || '';
+  const newMyWeek = myWeekHits.slice(myWeekBefore);
+  console.log(`[PR614-5] header "${weekHeaderBefore}" → "${weekHeaderAfter}"`);
+  console.log(`[PR614-5] new /my-week calls: ${newMyWeek.length}`);
+
+  // Pass if either header changed OR my-week was refetched
+  expect(weekHeaderBefore !== weekHeaderAfter || newMyWeek.length > 0).toBe(true);
+  await context.close();
+});

--- a/scripts/hor-proof/mcp02-final-suite.spec.ts
+++ b/scripts/hor-proof/mcp02-final-suite.spec.ts
@@ -1,0 +1,165 @@
+/**
+ * HOURSOFREST_MCP02 — Final post-deploy pass
+ * Covers PR #588 + S5/S7/S11 UI.
+ */
+import { test, expect, BrowserContext, Page } from '@playwright/test';
+import * as fs from 'fs';
+import * as path from 'path';
+
+const BASE_URL = process.env.E2E_BASE_URL || 'https://app.celeste7.ai';
+const SUPABASE_PROJECT_REF = 'qvzmkaamzaqxpzbewjxe';
+const STORAGE_KEY = `sb-${SUPABASE_PROJECT_REF}-auth-token`;
+const PROOF_DIR = process.env.PROOF_DIR || '/tmp/hor_mcp02';
+
+type Role = 'crew' | 'hod' | 'captain' | 'fleet';
+const ROLES: Record<Role, { access: string; refresh: string; sub: string; email: string }> = {
+  crew:    { access: process.env.CREW_ACCESS || '',  refresh: process.env.CREW_REFRESH || '',  sub: '4a66036f-899c-40c8-9b2a-598cee24a62f', email: 'engineer.test@alex-short.com' },
+  hod:     { access: process.env.HOD_ACCESS || '',   refresh: process.env.HOD_REFRESH || '',   sub: '81c239df-f8ef-4bba-9496-78bf8f46733c', email: 'eto.test@alex-short.com' },
+  captain: { access: process.env.CAP_ACCESS || '',   refresh: process.env.CAP_REFRESH || '',   sub: 'a35cad0b-02ff-4287-b6e4-17c96fa6a424', email: 'x@alex-short.com' },
+  fleet:   { access: process.env.FLEET_ACCESS || '', refresh: process.env.FLEET_REFRESH || '', sub: 'f11f1247-b7bd-4017-bfe3-ebd3f8c9e871', email: 'fleet-test-1775570624@celeste7.ai' },
+};
+
+function writeStorageState(role: Role): string {
+  const u = ROLES[role];
+  if (!u.access || !u.refresh) throw new Error(`missing tokens for ${role}`);
+  const session = {
+    access_token: u.access, token_type: 'bearer', expires_in: 3600,
+    expires_at: Math.floor(Date.now() / 1000) + 3600,
+    refresh_token: u.refresh,
+    user: { id: u.sub, email: u.email, aud: 'authenticated', role: 'authenticated' },
+  };
+  const state = { cookies: [], origins: [{ origin: BASE_URL, localStorage: [{ name: STORAGE_KEY, value: JSON.stringify(session) }] }] };
+  fs.mkdirSync(PROOF_DIR, { recursive: true });
+  const fp = path.join(PROOF_DIR, `storage-${role}.json`);
+  fs.writeFileSync(fp, JSON.stringify(state, null, 2));
+  return fp;
+}
+
+const YACHT_ID = '85fe1119-b04c-41ac-80f1-829d23322598';
+
+function bootstrapFor(role: Role) {
+  const u = ROLES[role];
+  // Supabase auth roles → HoR frontend role mapping
+  const roleMap: Record<Role, string> = { crew: 'crew', hod: 'chief_engineer', captain: 'captain', fleet: 'manager' };
+  const isFleet = role === 'fleet';
+  return {
+    yacht_id: YACHT_ID,
+    yacht_name: 'M/Y Test Vessel',
+    tenant_key_alias: 'yTEST_YACHT_001',
+    role: roleMap[role],
+    status: 'active',
+    user_id: u.sub,
+    email: u.email,
+    subscription_active: true,
+    subscription_status: 'paid',
+    subscription_plan: 'none',
+    subscription_expires_at: null,
+    is_fleet_user: isFleet,
+    vessel_ids: [YACHT_ID],
+    fleet_vessels: isFleet ? [{ id: YACHT_ID, name: 'M/Y Test Vessel' }] : null,
+  };
+}
+
+function fakeMyWeek(userId: string, dept: string) {
+  return {
+    status: 'success',
+    week_start: '2026-04-13', week_end: '2026-04-19',
+    user_id: userId, department: dept,
+    days: Array.from({ length: 7 }, (_, i) => {
+      const d = `2026-04-${String(13 + i).padStart(2, '0')}`;
+      return { id: `mock-${userId.slice(0,8)}-${i}`, record_date: d, work_periods: [], rest_periods: [], total_rest_hours: 24, total_work_hours: 0, is_daily_compliant: null, submitted: false, warnings: [] };
+    }),
+    compliance: { rolling_24h_rest: null, rolling_7day_rest: 91 },
+    pending_signoff: null, templates: [],
+  };
+}
+
+async function installMocks(page: Page, role: Role) {
+  const u = ROLES[role];
+  const dept = role === 'hod' ? 'engineering' : role === 'captain' ? 'deck' : role === 'fleet' ? 'fleet' : 'general';
+  await page.route(/backend\.celeste7\.ai\/v1\/bootstrap/, async r => {
+    await r.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(bootstrapFor(role)) });
+  });
+  await page.route(/backend\.celeste7\.ai\/email\/unread-count/, async r => {
+    await r.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ count: 0 }) });
+  });
+  await page.route(/\/api\/v1\/hours-of-rest\/my-week/, async r => {
+    await r.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(fakeMyWeek(u.sub, dept)) });
+  });
+  await page.route(/\/api\/v1\/hours-of-rest\/month-status/, async r => {
+    const url = new URL(r.request().url());
+    const month = url.searchParams.get('month') || '2026-04';
+    const [y, m] = month.split('-').map(Number);
+    const daysInMonth = new Date(y, m, 0).getDate();
+    await r.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({
+      status: 'success', month,
+      days: Array.from({ length: daysInMonth }, (_, i) => ({ date: `${month}-${String(i+1).padStart(2,'0')}`, submitted: false, is_compliant: null })),
+    }) });
+  });
+  await page.route(/\/api\/v1\/hours-of-rest\/warnings/, async r => {
+    await r.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ success: true, data: { warnings: [] } }) });
+  });
+  await page.route(/\/api\/v1\/notifications/, async r => {
+    await r.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ status: 'success', data: [] }) });
+  });
+  // HOD/captain/fleet compliance endpoints (department-status + vessel-compliance)
+  await page.route(/\/hours-of-rest\/(department-status|vessel-compliance)/, async r => {
+    await r.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({
+      status: 'success', week_start: '2026-04-13',
+      vessel_summary: { total_crew: 3, submitted_count: 0, compliant_count: 0 },
+      departments: [{ department: dept, total_crew: 1, submitted_count: 0, compliant_count: 0, pending_warnings: 0, pending_signoff_count: 0, signoff_id: null, status: 'draft', hod_signed_at: null }],
+      all_crew: [{ user_id: ROLES.crew.sub, name: 'Engineer Test', department: 'general', total_work_hours: 0, total_rest_hours: 24, days_submitted: 0, is_weekly_compliant: false, has_active_warnings: false, signoff_status: 'draft' }],
+      crew: [{ user_id: ROLES.crew.sub, name: 'Engineer Test', signoff_status: 'draft', daily: [] }],
+      analytics: { avg_work_hours: 0, violations_this_week: 0, violations_this_quarter: 0, compliance_pct: 0 },
+      sign_chain: { all_hods_signed: false, captain_signed: false, fleet_manager_reviewed: false },
+    }) });
+  });
+}
+
+async function openHoR(browser: any, role: Role): Promise<{ context: BrowserContext; page: Page }> {
+  const stateFile = writeStorageState(role);
+  const context = await browser.newContext({ storageState: stateFile, viewport: { width: 1440, height: 900 } });
+  const page = await context.newPage();
+  await installMocks(page, role);
+  await page.goto(`${BASE_URL}/hours-of-rest`, { waitUntil: 'domcontentloaded', timeout: 45000 });
+  // Wait for hydration — the main nav Calendar button or tab buttons should appear
+  await page.locator('main button').first().waitFor({ timeout: 30000 });
+  await page.waitForTimeout(2500);
+  return { context, page };
+}
+
+test('PR #588 — fleet: no Submit Week For Approval button', async ({ browser }) => {
+  const { context, page } = await openHoR(browser, 'fleet');
+  const submitWeekInMain = await page.locator('main button', { hasText: /submit week/i }).count();
+  const mainButtons = await page.locator('main button').allTextContents();
+  console.log(`[PR #588] fleet main buttons: ${JSON.stringify(mainButtons.slice(0, 30))}`);
+  expect(submitWeekInMain, 'fleet MUST NOT see Submit Week').toBe(0);
+  await context.close();
+});
+
+test('S7 — fleet read-only (no sign buttons)', async ({ browser }) => {
+  const { context, page } = await openHoR(browser, 'fleet');
+  const writeButtons = await page.locator('main button').filter({ hasText: /sign|submit|create|dismiss|acknowledge/i }).allTextContents();
+  console.log(`[S7] fleet write buttons: ${JSON.stringify(writeButtons)}`);
+  expect(writeButtons.length).toBe(0);
+  await context.close();
+});
+
+test('S5 — HOD department tab', async ({ browser }) => {
+  const { context, page } = await openHoR(browser, 'hod');
+  const deptTab = page.locator('main button, main [role="tab"]').filter({ hasText: /department/i });
+  const deptCount = await deptTab.count();
+  console.log(`[S5] HOD dept-tab count: ${deptCount}`);
+  expect(deptCount).toBeGreaterThan(0);
+  await context.close();
+});
+
+test('Positive control — captain sees Submit Week', async ({ browser }) => {
+  const { context, page } = await openHoR(browser, 'captain');
+  const mainButtons = await page.locator('main button').allTextContents();
+  const hasSubmitWeek = mainButtons.some(b => /submit week/i.test(b));
+  console.log(`[positive ctrl] captain sees Submit Week: ${hasSubmitWeek}`);
+  console.log(`[positive ctrl] captain buttons: ${JSON.stringify(mainButtons.slice(0, 20))}`);
+  expect(hasSubmitWeek, 'captain should see Submit Week').toBe(true);
+  await context.close();
+});

--- a/scripts/hor-proof/mcp02-final.config.ts
+++ b/scripts/hor-proof/mcp02-final.config.ts
@@ -1,0 +1,21 @@
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  testDir: '.',
+  testMatch: 'mcp02-final-suite.spec.ts',
+  timeout: 90_000,
+  expect: { timeout: 10_000 },
+  workers: 1,
+  retries: 0,
+  reporter: [['list']],
+  use: {
+    baseURL: process.env.E2E_BASE_URL || 'https://app.celeste7.ai',
+    viewport: { width: 1440, height: 900 },
+    deviceScaleFactor: 1,
+    actionTimeout: 15_000,
+    navigationTimeout: 30_000,
+    screenshot: 'off',
+    video: 'off',
+    trace: 'off',
+  },
+});

--- a/scripts/hor-proof/mcp02-s1-headless.spec.ts
+++ b/scripts/hor-proof/mcp02-s1-headless.spec.ts
@@ -1,0 +1,165 @@
+/**
+ * HOURSOFREST_MCP02 — Scenario 1 final: PR #569 a+b+c
+ */
+import { test, expect } from '@playwright/test';
+import * as fs from 'fs';
+import * as path from 'path';
+
+const BASE_URL = process.env.E2E_BASE_URL || 'https://app.celeste7.ai';
+const SUPABASE_PROJECT_REF = 'qvzmkaamzaqxpzbewjxe';
+const STORAGE_KEY = `sb-${SUPABASE_PROJECT_REF}-auth-token`;
+const PROOF_DIR = process.env.PROOF_DIR || '/tmp/hor_mcp02';
+const CREW = {
+  access: process.env.CREW_ACCESS || '',
+  refresh: process.env.CREW_REFRESH || '',
+  sub: process.env.CREW_UID || '4a66036f-899c-40c8-9b2a-598cee24a62f',
+  email: 'engineer.test@alex-short.com',
+};
+
+function writeStorageState(role: string, access: string, refresh: string, sub: string, email: string): string {
+  if (!access || !refresh) throw new Error(`missing tokens for ${role}`);
+  const sessionData = JSON.stringify({
+    access_token: access, token_type: 'bearer', expires_in: 3600,
+    expires_at: Math.floor(Date.now() / 1000) + 3600,
+    refresh_token: refresh,
+    user: { id: sub, email, aud: 'authenticated', role: 'authenticated' },
+  });
+  const state = { cookies: [], origins: [{ origin: BASE_URL, localStorage: [{ name: STORAGE_KEY, value: sessionData }] }] };
+  fs.mkdirSync(PROOF_DIR, { recursive: true });
+  const fp = path.join(PROOF_DIR, `storage-${role}.json`);
+  fs.writeFileSync(fp, JSON.stringify(state, null, 2));
+  return fp;
+}
+
+function fakeEditableWeek() {
+  const weekStart = '2026-05-04';
+  const dates = ['2026-05-04','2026-05-05','2026-05-06','2026-05-07','2026-05-08','2026-05-09','2026-05-10'];
+  const ids = [
+    'ffffffff-0000-4000-8000-000000000001','ffffffff-0000-4000-8000-000000000002',
+    'ffffffff-0000-4000-8000-000000000003','ffffffff-0000-4000-8000-000000000004',
+    'ffffffff-0000-4000-8000-000000000005','ffffffff-0000-4000-8000-000000000006',
+    'ffffffff-0000-4000-8000-000000000007',
+  ];
+  return {
+    status: 'success', week_start: weekStart, week_end: '2026-05-10',
+    user_id: '4a66036f-899c-40c8-9b2a-598cee24a62f', department: 'general',
+    days: dates.map((d, i) => ({
+      id: ids[i], record_date: d, work_periods: [], rest_periods: [],
+      total_rest_hours: 24, total_work_hours: 0,
+      is_daily_compliant: null, daily_compliance_notes: null,
+      location: null, voyage_type: null, submitted: false, warnings: [], updated_at: null,
+    })),
+    compliance: { rolling_24h_rest: null, rolling_7day_rest: 91 },
+    pending_signoff: null, templates: [],
+  };
+}
+
+test('MCP02 S1.1 — PR #569 b + c (real session)', async ({ browser }) => {
+  const stateFile = writeStorageState('crew', CREW.access, CREW.refresh, CREW.sub, CREW.email);
+  const context = await browser.newContext({ storageState: stateFile, viewport: { width: 1440, height: 900 } });
+  const page = await context.newPage();
+  await page.goto(`${BASE_URL}/hours-of-rest`, { waitUntil: 'networkidle', timeout: 45000 });
+  // Wait for ANY hydrated content — either the week grid, a day label, or a scroll-able main
+  try {
+    await page.waitForFunction(() => {
+      const main = document.querySelector('main');
+      const txt = main?.textContent || '';
+      return /Mon|Tue|Wed|Thu|Fri|Sat|Sun|week|WEEK/i.test(txt) && txt.length > 200;
+    }, { timeout: 25000 });
+  } catch {
+    await page.screenshot({ path: path.join(PROOF_DIR, 'S1-1-stuck.png'), fullPage: true });
+    const bodyText = (await page.textContent('body') || '').slice(0, 500);
+    console.log(`[S1.1] stuck — body snippet: ${bodyText}`);
+  }
+  await page.waitForTimeout(2500);
+
+  const layout = await page.evaluate(() => {
+    const main = document.querySelector('main');
+    const r = main?.getBoundingClientRect();
+    const scrollers = Array.from(main?.querySelectorAll('*') || []).filter(el => {
+      const cs = getComputedStyle(el);
+      return cs.overflowY === 'auto' || cs.overflowY === 'scroll';
+    }).map(el => ({ w: el.getBoundingClientRect().width, scrollH: (el as HTMLElement).scrollHeight, clientH: (el as HTMLElement).clientHeight }));
+    return { mainW: r?.width ?? 0, vp: { w: window.innerWidth, h: window.innerHeight }, scrollers };
+  });
+  console.log(`[569b] mainW=${layout.mainW}px vp=${layout.vp.w}x${layout.vp.h}`);
+  console.log(`[569c] scrollers[0]=${JSON.stringify(layout.scrollers[0])}`);
+  await page.screenshot({ path: path.join(PROOF_DIR, 'S1-1-real-session.png'), fullPage: true });
+
+  expect(layout.mainW).toBeGreaterThan(1000);
+  expect(layout.scrollers.length).toBeGreaterThan(0);
+  expect(layout.scrollers[0].clientH).toBeLessThan(layout.vp.h);
+
+  await context.close();
+});
+
+test('MCP02 S1.2 — PR #569a (mocked editable week + forced /upsert failure)', async ({ browser }) => {
+  const stateFile = writeStorageState('crew', CREW.access, CREW.refresh, CREW.sub, CREW.email);
+  const context = await browser.newContext({ storageState: stateFile, viewport: { width: 1440, height: 900 } });
+  const page = await context.newPage();
+
+  const consoleErrors: string[] = [];
+  const apiHits: Array<{ url: string; body: any }> = [];
+  page.on('console', msg => { if (msg.type() === 'error') consoleErrors.push(msg.text()); });
+
+  await page.route(/\/hours-of-rest\/my-week/, async route => {
+    await route.fulfill({
+      status: 200, contentType: 'application/json',
+      body: JSON.stringify(fakeEditableWeek()),
+    });
+  });
+
+  await page.route(/\/api\/v1\/hours-of-rest\/upsert/, async route => {
+    const req = route.request();
+    let bodyObj: any = null;
+    try { bodyObj = JSON.parse(req.postData() || '{}'); } catch {}
+    apiHits.push({ url: req.url(), body: bodyObj });
+    if (req.method() === 'POST') {
+      await route.fulfill({
+        status: 400, contentType: 'application/json',
+        body: JSON.stringify({
+          status: 'error',
+          error_code: 'LOCKED',
+          message: 'MCP02-INJECTED: Simulated failure to verify PR #569a inline error surfacing path.',
+        }),
+      });
+    } else { await route.continue(); }
+  });
+
+  await page.goto(`${BASE_URL}/hours-of-rest`, { waitUntil: 'networkidle', timeout: 45000 });
+  await page.waitForSelector('text=/THIS WEEK|Week —/i', { timeout: 20000 });
+  await page.waitForTimeout(2500);
+
+  const tracks = await page.locator('.hor-track-bg').count();
+  const notSubmittedCount = await page.getByText('Not submitted').count();
+  console.log(`[S1.2] tracks=${tracks} notSubmitted=${notSubmittedCount}`);
+  if (tracks === 0) throw new Error('mock did not produce editable tracks');
+
+  const firstTrack = page.locator('.hor-track-bg').first();
+  const box = await firstTrack.boundingBox();
+  if (!box) throw new Error('track has no bounding box');
+  await page.mouse.click(box.x + box.width * 0.4, box.y + box.height / 2);
+  await page.waitForTimeout(800);
+
+  const submitBtnCount = await page.locator('button', { hasText: /submit day/i }).count();
+  console.log(`[S1.2] after track click: Submit Day count=${submitBtnCount}`);
+  if (submitBtnCount === 0) throw new Error('no Submit Day button');
+
+  await page.locator('button', { hasText: /submit day/i }).first().click();
+  await page.waitForTimeout(3500);
+  await page.screenshot({ path: path.join(PROOF_DIR, 'S1-2-after-submit.png'), fullPage: true });
+
+  const dom = await page.evaluate(() => {
+    const allText = (document.querySelector('main') as HTMLElement | null)?.innerText || '';
+    return {
+      containsMCP02Mark: /MCP02-INJECTED/.test(allText),
+      containsMockMsg: /Simulated failure to verify PR #569a/.test(allText),
+      containsWarningIcon: /⚠/.test(allText),
+    };
+  });
+  console.log(`[S1.2] DOM inline-error check: MCP02-INJECTED=${dom.containsMCP02Mark}  ⚠=${dom.containsWarningIcon}`);
+  const inlineErrorPresent = dom.containsMCP02Mark || dom.containsMockMsg;
+  expect(inlineErrorPresent, 'PR #569a: inline error must surface on Submit Day API failure').toBeTruthy();
+
+  await context.close();
+});

--- a/scripts/hor-proof/mcp02-s1.config.ts
+++ b/scripts/hor-proof/mcp02-s1.config.ts
@@ -1,0 +1,21 @@
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  testDir: '.',
+  testMatch: 'mcp02-s1-headless.spec.ts',
+  timeout: 90_000,
+  expect: { timeout: 10_000 },
+  workers: 1,
+  retries: 0,
+  reporter: [['list']],
+  use: {
+    baseURL: process.env.E2E_BASE_URL || 'https://app.celeste7.ai',
+    viewport: { width: 1440, height: 900 },
+    deviceScaleFactor: 1,
+    actionTimeout: 15_000,
+    navigationTimeout: 30_000,
+    screenshot: 'off',
+    video: 'off',
+    trace: 'off',
+  },
+});


### PR DESCRIPTION
## Summary
- shard-40: `title` → `summary` (required field per `p0_actions_routes.py:795`)
- shard-47: `seedHandoverItem` helper uses `captainPage.request.post` (Node-side) instead of `callActionDirect` (browser-side fetch subject to CORS flakiness during Render deploys)
- shard-49: `captainSession` uses anon key auth instead of service_role `signInWithPassword` (which returns empty error object in some Supabase SDK + Playwright combos)

## Test plan
- [x] 9/11 pass on partially-recovered Render (2 failures = 503 on heavy export endpoint, Supabase PostgREST overload)
- [x] 4/4 pass on local Docker (shard-49 only, before TENANT outage)
- [ ] Full 11/11 pending Supabase PostgREST recovery

🤖 Generated with [Claude Code](https://claude.com/claude-code)