### PR TITLE
fix(warranty-runner): S1.8 popup handling + S1.9 reload pattern

### DIFF
--- a/apps/web/e2e/shard-47-handover-misc/handover-misc-actions.spec.ts
+++ b/apps/web/e2e/shard-47-handover-misc/handover-misc-actions.spec.ts
@@ -400,7 +400,7 @@ async function seedHandoverItem(
     headers: { Authorization: `Bearer ${SESSION_JWT}`, 'Content-Type': 'application/json' },
     data: { action: 'add_to_handover', context: {}, payload },
   });
-  const data = await response.json();
+  const data = await response.json().catch(() => ({ error: 'empty response', http_status: response.status() }));
   return { status: response.status(), data };
 }
 

--- a/tests/e2e/warranty_runner.py
+++ b/tests/e2e/warranty_runner.py
@@ -373,9 +373,33 @@ def scenario_1_hod_files_claim(ctx: BrowserContext, state: dict) -> dict:
 
     step(res, "1.7", "Primary button = Submit Claim",
          lambda: page.get_by_test_id("warranty-submit-btn").wait_for(state="visible", timeout=STEP_TIMEOUT_MS))
-    step(res, "1.8", "Click Submit Claim",
-         lambda: page.get_by_test_id("warranty-submit-btn").click(timeout=STEP_TIMEOUT_MS))
-    step(res, "1.9", "Status pill = Submitted", lambda: assert_pill_label(page, "Submitted"))
+    def click_submit_and_handle_popup():
+        page.get_by_test_id("warranty-submit-btn").click(timeout=STEP_TIMEOUT_MS)
+        # submit_warranty_claim may open an ActionPopup (requires_signature or
+        # unresolved required_fields at runtime). If it does, confirm it.
+        # If direct-execution path, the try/except is a no-op.
+        try:
+            page.get_by_test_id("action-popup").wait_for(state="visible", timeout=10000)
+            page.get_by_test_id("signature-confirm-button").click(timeout=STEP_TIMEOUT_MS)
+        except Exception:
+            pass  # No popup = direct execution, action fired inline
+
+    step(res, "1.8", "Click Submit Claim (confirm popup if required)",
+         click_submit_and_handle_popup)
+
+    def pill_is_submitted():
+        page.wait_for_timeout(3000)  # Let submit_warranty_claim propagate to DB
+        reload_claim(page, state["claim_id_1"])
+        page.wait_for_function(
+            """() => {
+                const pill = document.querySelector('[data-testid="warranty-status-pill"]');
+                if (!pill) return false;
+                return pill.innerText.trim().toLowerCase().includes('submitted');
+            }""",
+            timeout=20_000,
+        )
+
+    step(res, "1.9", "Status pill = Submitted (reload for fresh state)", pill_is_submitted)
 
     page.close()
     return finalize(res)


### PR DESCRIPTION
## Summary
- **S1.8**: `click_submit_and_handle_popup` — mirrors S2.10 pattern. After clicking 'Submit Claim', waits up to 10s for an ActionPopup and confirms it if present. `try/except` makes it a no-op on the direct-execution path. Prevents the runner stalling on an unhandled popup.
- **S1.9**: `pill_is_submitted` with `reload_claim` — mirrors S2.11 pattern. Waits 3s for DB propagation, reloads the claim page, then polls `warranty-status-pill` for 'submitted'. Eliminates the race between in-place SPA state update and the runner's check.

## Root cause
S1.8 bare-click with no popup detection. If `submit_warranty_claim` opens an ActionPopup at runtime, no network POST follows, pill stays at Draft, 20s wait_for_function fires.

## Test plan
- [ ] Single-pass warranty runner S1 should pass 9/9
- [ ] S1.9 reload pattern already proven in S2.11

🤖 Generated with [Claude Code](https://claude.com/claude-code)