### PR TITLE
fix(proxy): defensive JSON parse + 25s timeout in actions/execute

### DIFF
--- a/apps/web/src/app/api/v1/actions/execute/route.ts
+++ b/apps/web/src/app/api/v1/actions/execute/route.ts
@@ -43,7 +43,7 @@ export async function POST(request: NextRequest): Promise<NextResponse<ActionRes
       renderUrl: `${RENDER_API_URL}/v1/actions/execute`,
     });
 
-    // Proxy to Render backend
+    // Proxy to Render backend (25s hard timeout — Vercel functions limit)
     const renderResponse = await fetch(`${RENDER_API_URL}/v1/actions/execute`, {
       method: 'POST',
       headers: {
@@ -51,10 +51,19 @@ export async function POST(request: NextRequest): Promise<NextResponse<ActionRes
         'Authorization': authHeader,
       },
       body: JSON.stringify(body),
+      signal: AbortSignal.timeout(25000),
     });
 
-    // Get response from Render
-    const responseData = await renderResponse.json();
+    // Get response from Render — backend may return empty body on connection drop
+    let responseData: ActionResponse;
+    try {
+      responseData = await renderResponse.json();
+    } catch {
+      return NextResponse.json(
+        { success: false, error: 'Backend returned empty response', code: 'EMPTY_RESPONSE' },
+        { status: 502 }
+      );
+    }
 
     // Log the response
     console.log('[Action Router] Render response:', {


### PR DESCRIPTION
## Summary
- **Defensive JSON parsing**: `renderResponse.json()` is now wrapped in try/catch. If the backend returns an empty or truncated body (connection drop during PostgREST warm-up, mid-stream disconnect), the proxy now returns `502 EMPTY_RESPONSE` instead of an unhandled `500 PROXY_ERROR`. This distinguishes a recoverable connection issue from a real action failure.
- **Explicit timeout**: Added `AbortSignal.timeout(25000)` to the upstream fetch to prevent the Vercel function hanging until platform timeout when the Render backend is unresponsive.

## Root cause
During RUN C (S3.1d), `file_warranty_claim` returned HTTP 500 with `{"error":"Unexpected end of JSON input","code":"PROXY_ERROR"}` because the backend closed the connection mid-response ~4 minutes after PostgREST recovery. The bare `renderResponse.json()` threw and the catch block propagated a misleading error.

## Test plan
- [ ] Happy path: action execute works unchanged (backend returns valid JSON → response forwarded)
- [ ] Error path: if backend returns empty body → `502 EMPTY_RESPONSE` returned to client

🤖 Generated with [Claude Code](https://claude.com/claude-code)