### PR TITLE
test(handover): shard-54 retry fixes — 150s postWithRetry + seedHandoverItem retry

### DIFF
--- a/apps/web/e2e/shard-54-handover-tester-ui/handover-ui.spec.ts
+++ b/apps/web/e2e/shard-54-handover-tester-ui/handover-ui.spec.ts
@@ -144,21 +144,30 @@ async function readErrors(page: Page): Promise<{ errors: string[]; warnings: str
  */
 async function seedHandoverItem(role: Role, summary: string, category = 'standard'): Promise<string> {
   const session = await masterSignIn(role);
-  const res = await fetch(`${API_URL}/v1/actions/execute`, {
-    method: 'POST',
-    headers: {
-      Authorization: `Bearer ${session.access_token}`,
-      'Content-Type': 'application/json',
-    },
-    body: JSON.stringify({
-      action: 'add_to_handover',
-      context: { yacht_id: '85fe1119-b04c-41ac-80f1-829d23322598' },
-      payload: { entity_type: 'note', summary, category },
-    }),
-  });
-  if (!res.ok) throw new Error(`seedHandoverItem failed: ${res.status}`);
-  const data: any = await res.json();
-  return data.result?.item_id;
+  // Retry 3× on transient 5xx from Render rolling deploys / cold starts.
+  for (let attempt = 0; attempt < 3; attempt++) {
+    const res = await fetch(`${API_URL}/v1/actions/execute`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${session.access_token}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        action: 'add_to_handover',
+        context: { yacht_id: '85fe1119-b04c-41ac-80f1-829d23322598' },
+        payload: { entity_type: 'note', summary, category },
+      }),
+    });
+    if (res.ok) {
+      const data: any = await res.json();
+      return data.result?.item_id;
+    }
+    if (res.status < 500 || attempt === 2) {
+      throw new Error(`seedHandoverItem failed: ${res.status}`);
+    }
+    await new Promise((r) => setTimeout(r, 3000));
+  }
+  throw new Error('seedHandoverItem: unreachable');
 }
 
 const API_URL = 'https://pipeline-core.int.celeste7.ai';
@@ -204,7 +213,10 @@ async function gotoWithRetry(page: Page, url: string, attempts = 3): Promise<voi
   }
 }
 
-/** Retry POST 3× on 5xx from Render rolling deploys. */
+/** Retry POST 3× on 5xx from Render rolling deploys.
+ *  Timeout is 150s per attempt — POST /v1/handover/export runs an LLM
+ *  pipeline (classify → group → merge) that can take up to 120s on a cold
+ *  Render container, and any timeout shorter than that produces false 5xx. */
 async function postWithRetry(
   page: Page,
   accessToken: string,
@@ -216,7 +228,7 @@ async function postWithRetry(
     const r = await page.request.post(url, {
       headers: { Authorization: `Bearer ${accessToken}`, 'Content-Type': 'application/json' },
       data,
-      timeout: 60_000,
+      timeout: 150_000,
     });
     if (r.status() < 500) return r;
     if (i < attempts - 1) await page.waitForTimeout(3000);


### PR DESCRIPTION
## Summary

Closes the last two intermittent-failure modes in shard-54. Proven on
v3 run post-PostgREST recovery: **19/19 effective PASS** (18 first-try
+ 1 flaky-retry-pass, 0 fail, 0 skip — up from 16/3 on the same infra
without these fixes).

## Changes

1. **`postWithRetry` timeout 60s → 150s.** `POST /v1/handover/export`
   runs an LLM pipeline (classify → group → merge) that can take up to
   120s on a cold Render container. 60s was producing false 5xx retries
   that then exhausted the 3-attempt budget even though the endpoint
   was working. Direct curl probe at 07:05Z returned 200 in ~40s with 4
   sections / 110 items for the same captain auth. 150s per attempt
   fits the true envelope comfortably.
2. **`seedHandoverItem` now retries 3× with 3s backoff on 5xx** (was
   throwing on first failure). Matches `postWithRetry` shape; eliminates
   the Render-rolling-deploy flake on scenarios 4/5/12.3/12.4 where an
   API seed precedes a UI click.

Spec-only. No product touch. `tsc --noEmit` clean.

## Test plan

- [x] Direct curl probe of `POST /v1/handover/export` confirms 200 in
  ~40s with 4 sections / 110 items
- [x] v3 run: shard-54 19/19 effective PASS
- [ ] Merge + next cron rerun to confirm stable

🤖 Generated with [Claude Code](https://claude.com/claude-code)