### PR TITLE
fix(test): remove stray brace in shard-49 createExport

### DIFF
--- a/apps/web/e2e/shard-49-handover-export-e2e/handover-export-e2e.spec.ts
+++ b/apps/web/e2e/shard-49-handover-export-e2e/handover-export-e2e.spec.ts
@@ -90,7 +90,6 @@ async function createExport(
   }
   throw new Error(`createExport failed after ${maxAttempts} attempts (last status: ${lastStatus})`);
 }
-}
 
 /**
  * Helper: build a minimal valid sections payload for the submit endpoint.


### PR DESCRIPTION
One-line fix — stray `}` at line 93 from merge conflict in PR #632.

🤖 Generated with [Claude Code](https://claude.com/claude-code)