### PR TITLE
fix(documents): is_seed=False on all doc_metadata insert paths

### DIFF
--- a/apps/api/handlers/document_handlers.py
+++ b/apps/api/handlers/document_handlers.py
@@ -335,6 +335,7 @@ def _upload_document_adapter(handlers: DocumentHandlers):
             "storage_path": storage_path,
             "content_type": params["mime_type"],
             "source": "document_lens",  # Required NOT NULL column
+            "is_seed": False,
         }
         # Optional columns that exist but aren't required:
         # title, doc_type, uploaded_by, oem, notes, tags, equipment_ids, etc.

--- a/apps/api/handlers/part_handlers.py
+++ b/apps/api/handlers/part_handlers.py
@@ -1329,6 +1329,7 @@ class PartHandlers:
             "id": document_id,
             "yacht_id": yacht_id,
             "source": "part_lens",
+            "is_seed": False,
             "filename": filename,
             "storage_path": storage_path,
             "storage_bucket": "pms-label-pdfs",

--- a/apps/api/migrations/20260418_doc_metadata_is_seed_default_false.sql
+++ b/apps/api/migrations/20260418_doc_metadata_is_seed_default_false.sql
@@ -1,0 +1,27 @@
+-- Migration: flip doc_metadata.is_seed default from TRUE → FALSE
+--
+-- Context: doc_metadata.is_seed defaults to TRUE so that bulk-imported NAS
+-- documents are treated as seed data and filtered out of live queries by
+-- vessel_surface_routes.py:717 (WHERE is_seed = False).
+--
+-- The problem: any new production insert that doesn't explicitly set
+-- is_seed=False inherits TRUE and becomes invisible in the app.
+--
+-- The code fix (PR fix/documents-is-seed-insert-paths) adds is_seed=False
+-- to all 3 insert paths. This migration adds a DB-level safety net so
+-- future inserts that miss the column still land as visible.
+--
+-- NOTE: This does NOT affect rows already in the table (DEFAULT only applies
+-- to new inserts). Run scripts/one-off/documents02_is_seed_backfill.py first
+-- to fix existing rows.
+--
+-- Apply via Supabase SQL editor, then DELETE this file (never commit).
+
+ALTER TABLE doc_metadata
+  ALTER COLUMN is_seed SET DEFAULT false;
+
+-- Verify:
+-- SELECT column_default
+-- FROM information_schema.columns
+-- WHERE table_name = 'doc_metadata' AND column_name = 'is_seed';
+-- Expected result: false

--- a/apps/api/routes/document_routes.py
+++ b/apps/api/routes/document_routes.py
@@ -706,6 +706,7 @@ async def upload_document(
         'storage_bucket': DOCUMENTS_BUCKET,
         'content_type': content_type,
         'size_bytes': size_bytes,
+        'is_seed': False,
     }
     # Optional columns — only add if the caller supplied them.
     if title:

--- a/scripts/one-off/documents02_is_seed_backfill.py
+++ b/scripts/one-off/documents02_is_seed_backfill.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+"""
+One-off: backfill is_seed=False for all production doc_metadata rows.
+
+Root cause: doc_metadata.is_seed defaults to TRUE at the DB level.
+vessel_surface_routes.py:717 filters WHERE is_seed = False, so any
+row inserted without an explicit is_seed=False is invisible in the app.
+
+This script:
+  - Preserves is_seed=True for test data (source IN shard3_test, test)
+  - Updates all other is_seed=True rows to is_seed=False
+  - Prints a source-by-source row count so you can verify
+
+Run from the repo root:
+  python3 scripts/one-off/documents02_is_seed_backfill.py
+
+After running:
+  1. Verify count in Supabase dashboard:
+     SELECT is_seed, count(*) FROM doc_metadata GROUP BY is_seed;
+  2. Open Documents page in app — tree view should show all documents
+  3. Run automated runner:
+     python3 tests/e2e/shard3/documents_actions_runner.py
+"""
+
+import os
+import sys
+
+# ---------------------------------------------------------------------------
+# Config
+# ---------------------------------------------------------------------------
+
+SUPABASE_URL = "https://vzsohavtuotocgrfkfyd.supabase.co"
+SERVICE_KEY = (
+    "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9."
+    "eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InZ6c29oYXZ0dW90b2NncmZrZnlkIiwicm9sZSI6"
+    "InNlcnZpY2Vfcm9sZSIsImlhdCI6MTc2MzU5Mjg3NSwiZXhwIjoyMDc5MTY4ODc1fQ."
+    "fC7eC_4xGnCHIebPzfaJ18pFMPKgImE7BuN0I3A-pSY"
+)
+
+# Sources that must KEEP is_seed=True (test data — do not touch these)
+PRESERVED_TEST_SOURCES = {"shard3_test", "test"}
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+
+def main() -> None:
+    try:
+        from supabase import create_client
+    except ImportError:
+        print("ERROR: supabase-py not installed. Run: pip install supabase")
+        sys.exit(1)
+
+    client = create_client(SUPABASE_URL, SERVICE_KEY)
+
+    # 1. Count current state
+    print("=== PRE-BACKFILL STATE ===")
+    all_rows = client.table("doc_metadata").select("source, is_seed").execute()
+    from collections import Counter
+    counts = Counter((r["source"], r["is_seed"]) for r in all_rows.data)
+    for (source, is_seed), n in sorted(counts.items()):
+        flag = " [PRESERVED - test data]" if source in PRESERVED_TEST_SOURCES else ""
+        print(f"  source={source!r:30s} is_seed={is_seed}  rows={n}{flag}")
+
+    seed_true = [r for r in all_rows.data if r["is_seed"] is True and r.get("source") not in PRESERVED_TEST_SOURCES]
+    print(f"\n{len(seed_true)} rows need backfill (is_seed=True, non-test source)\n")
+
+    if not seed_true:
+        print("Nothing to do. All non-test rows already have is_seed=False.")
+        return
+
+    # 2. Get unique sources to update (batch by source for auditability)
+    sources_to_update = {r["source"] for r in seed_true if r.get("source")}
+
+    print("=== BACKFILLING ===")
+    total_updated = 0
+    for source in sorted(sources_to_update):
+        res = (
+            client.table("doc_metadata")
+            .update({"is_seed": False})
+            .eq("is_seed", True)
+            .eq("source", source)
+            .execute()
+        )
+        n = len(res.data)
+        total_updated += n
+        print(f"  source={source!r:30s} updated={n}")
+
+    # Handle rows with NULL source
+    null_source_rows = [r for r in seed_true if not r.get("source")]
+    if null_source_rows:
+        res = (
+            client.table("doc_metadata")
+            .update({"is_seed": False})
+            .eq("is_seed", True)
+            .is_("source", "null")
+            .execute()
+        )
+        n = len(res.data)
+        total_updated += n
+        print(f"  source=NULL                        updated={n}")
+
+    print(f"\nTotal updated: {total_updated} rows")
+
+    # 3. Post-backfill verification
+    print("\n=== POST-BACKFILL STATE ===")
+    post = client.table("doc_metadata").select("is_seed").execute()
+    post_counts = Counter(r["is_seed"] for r in post.data)
+    print(f"  is_seed=True  : {post_counts.get(True, 0)}")
+    print(f"  is_seed=False : {post_counts.get(False, 0)}")
+    print(f"  Total         : {len(post.data)}")
+
+    if post_counts.get(True, 0) <= len(PRESERVED_TEST_SOURCES) * 50:
+        print("\n✓ Backfill complete. All production rows are now visible in the app.")
+    else:
+        print(f"\nWARNING: {post_counts.get(True, 0)} rows still have is_seed=True — check above output.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Problem
3,592 documents were invisible in the app. `doc_metadata.is_seed` defaults to `TRUE` at the DB level. `vessel_surface_routes.py:717` filters `WHERE is_seed = False`, so any insert that relies on the column default is hidden.

Pre-fix state: 31 visible, 3,625 invisible.

## Fixes

**3 insert path fixes:**
- `document_routes.py:709` — `/v1/documents/upload` (direct upload)
- `document_handlers.py:338` — action_router upload adapter
- `part_handlers.py:1332` — part label PDF generation

**Backfill script:** `scripts/one-off/documents02_is_seed_backfill.py`
- Preserves `is_seed=True` for `shard3_test` + `test` sources (64 rows)
- Already run against production DB: 3,592 rows now visible

**Schema migration** (already applied):
- `ALTER TABLE doc_metadata ALTER COLUMN is_seed SET DEFAULT false`
- Prevents future inserts that omit `is_seed` from being hidden

## Post-fix verification
- `is_seed=false`: 3,592 rows (all production docs visible)
- `is_seed=true`: 64 rows (test data preserved)