### PR TITLE
hotfix(registry): remove invalid optional_fields kwarg — P0 production fix

### DIFF
--- a/apps/api/action_router/registry.py
+++ b/apps/api/action_router/registry.py
@@ -1640,7 +1640,6 @@ ACTION_REGISTRY: Dict[str, ActionDefinition] = {
             "certificate_id",
             "document_id",
         ],
-        optional_fields=[],
         schema_file=None,
         domain="certificates",
         variant=ActionVariant.MUTATE,


### PR DESCRIPTION
## P0 Hotfix — ALL actions routes broken on Render

**Bug:** `TypeError: __init__() got an unexpected keyword argument 'optional_fields'`
- Location: `apps/api/action_router/registry.py:1643` (after #641 merge)
- Impact: ALL `/api/v1/actions/execute` routes fail to register on startup. Every domain's actions broken in production.
- CI evidence: Backend Validation run `24617023602` on SHA `5584a47` shows exact TypeError

**Root cause:** `link_document_to_certificate` ActionDefinition was constructed with `optional_fields=[]` kwarg. `ActionDefinition.__init__()` has no such parameter — `optional_fields` is computed at serialization time in `entity_actions.py:4394-4410`, not set in the constructor.

**Fix:** One-line deletion — remove `optional_fields=[]` from the registry entry.

**Verification:** `python3 -c "from action_router.registry import ACTION_REGISTRY; print(len(ACTION_REGISTRY))"` → `Registry loaded OK — 205 entries` (no TypeError)

## Change
`apps/api/action_router/registry.py` — deleted 1 line: `optional_fields=[]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)