### PR TITLE
hotfix(registry): remove invalid optional_fields kwarg that breaks action bus startup

### DIFF
--- a/apps/api/action_router/registry.py
+++ b/apps/api/action_router/registry.py
@@ -1640,7 +1640,6 @@ ACTION_REGISTRY: Dict[str, ActionDefinition] = {
             "certificate_id",
             "document_id",
         ],
-        optional_fields=[],
         schema_file=None,
         domain="certificates",
         variant=ActionVariant.MUTATE,


### PR DESCRIPTION
## Root cause

`apps/api/action_router/registry.py:1643` — `link_document_to_certificate` was passing `optional_fields=[]` to `ActionDefinition(...)`. `ActionDefinition.__init__()` has no such parameter (confirmed at lines 73–92). This raises a `TypeError` at **module load time**, which prevents the entire `action_router` module from initialising.

## Blast radius

Because `action_router/registry.py` fails to load, every route group that imports from `action_router` also fails to register at startup:

- ❌ P0 Actions routes (`/api/v1/actions/execute`) — **all action bus calls dead**
- ❌ Orchestrated Search routes
- ❌ Part Lens routes
- ❌ Entity lens routes

The following still register (separate import paths):
- ✅ HoR direct REST routes (`/v1/hours-of-rest/*`)
- ✅ HoR compliance routes
- ✅ Handover Export routes
- ✅ Vessel Surface routes
- ✅ Import pipeline routes
- ✅ Notifications routes
- ✅ Attachment upload routes

## Evidence

- `d14b644c` (after PR #640, before PR #641): no `optional_fields=[]` in any `ActionDefinition()` call, Backend Validation error is only `No module named 'routes.inventory_routes'` (pre-existing)
- `5584a478` (after PR #641 merged): `optional_fields=[]` present at line 1643; Backend Validation log shows `TypeError: __init__() got an unexpected keyword argument 'optional_fields'` killing P0/Search/Part/Entity routes

## Fix

Remove the single `optional_fields=[]` line. `optional_fields` is already computed dynamically from `field_metadata` entries with `FieldClassification.OPTIONAL` in the `to_dict()` method (lines 4369–4385). This action has only CONTEXT and REQUIRED fields in its `field_metadata`, so the computed result is `[]` regardless.

**1-line deletion. No logic change. AST parse confirmed clean.**

## Test

Backend Validation CI — expect `P0 Actions routes registered` ✅ and no `TypeError` in startup log.

🤖 Generated with [Claude Code](https://claude.com/claude-code)