### PR TITLE
fix(shopping-list): wire EntityLensPage, fix DB routing, fix action 400s

### DIFF
--- a/apps/api/action_router/entity_prefill.py
+++ b/apps/api/action_router/entity_prefill.py
@@ -143,7 +143,14 @@ CONTEXT_PREFILL_MAP: Dict[Tuple[str, str], Dict[str, str]] = {
     },
 
     # ── Shopping List ─────────────────────────────────────────────────────────
-    # shopping_list prefill intentionally empty for Phase 2 — add as needed
+    # Mutation actions: prefill item_id from entity "id" so required-field
+    # validation in p0_actions_routes passes when called from EntityLensPage.
+    ("shopping_list", "approve_shopping_list_item"): {"item_id": "id"},
+    ("shopping_list", "reject_shopping_list_item"):  {"item_id": "id"},
+    ("shopping_list", "promote_candidate_to_part"):  {"item_id": "id"},
+    ("shopping_list", "view_shopping_list_history"): {"item_id": "id"},
+    ("shopping_list", "delete_shopping_item"):       {"item_id": "id"},
+    ("shopping_list", "mark_shopping_list_ordered"): {"item_id": "id"},
     # ── Hours of Rest ─────────────────────────────────────────────────────────
     # hours_of_rest prefill intentionally empty for Phase 2 — add as needed
 

--- a/apps/api/routes/entity_routes.py
+++ b/apps/api/routes/entity_routes.py
@@ -491,6 +491,22 @@ async def get_shopping_list_entity(item_id: str, auth: dict = Depends(get_authen
             raise HTTPException(status_code=404, detail="Shopping list item not found")
 
         data = r.data
+
+        # Look up names for requester and approver in one query
+        requester_name = None
+        approver_name = None
+        requester_id = data.get("requested_by") or data.get("created_by")
+        approver_id = data.get("approved_by")
+        lookup_ids = [uid for uid in [requester_id, approver_id] if uid]
+        if lookup_ids:
+            try:
+                profiles = supabase.table("auth_users_profiles").select("id, name").in_("id", lookup_ids).execute()
+                profile_map = {p["id"]: p.get("name") for p in (profiles.data or [])}
+                requester_name = profile_map.get(requester_id)
+                approver_name = profile_map.get(approver_id)
+            except Exception:
+                pass
+
         item = {
             "id": data.get("id"),
             "part_name": data.get("part_name"),
@@ -498,23 +514,53 @@ async def get_shopping_list_entity(item_id: str, auth: dict = Depends(get_authen
             "manufacturer": data.get("manufacturer"),
             "unit": data.get("unit"),
             "quantity_requested": data.get("quantity_requested"),
+            "quantity_approved": data.get("quantity_approved"),
+            "estimated_unit_price": data.get("estimated_unit_price"),
+            "preferred_supplier": data.get("preferred_supplier"),
             "urgency": data.get("urgency"),
             "status": data.get("status"),
+            "source_type": data.get("source_type"),
+            "source_notes": data.get("source_notes"),
             "required_by_date": data.get("required_by_date"),
             "is_candidate_part": data.get("is_candidate_part", False),
+            "rejection_reason": data.get("rejection_reason"),
+            "rejection_notes": data.get("rejection_notes"),
+            "approval_notes": data.get("approval_notes"),
+            "approved_at": data.get("approved_at"),
+            "source_work_order_id": data.get("source_work_order_id"),
         }
         nav = [n for n in [
-            _nav("part", data.get("part_id"), "Part"),
+            _nav("part", data.get("part_id"), "Linked Part"),
+            _nav("work_order", data.get("source_work_order_id"), "Source Work Order"),
         ] if n]
 
         _entity_response = {
             "id": data.get("id"),
-            "title": data.get("part_name"),
-            "status": data.get("status"),
-            "requester_id": data.get("created_by"),
-            "requester_name": None,
+            "title": data.get("part_name") or "Shopping List Item",
+            "status": data.get("status", "candidate"),
+            "urgency": data.get("urgency"),
+            "priority": data.get("urgency"),
+            "requester_id": requester_id,
+            "requester_name": requester_name,
+            "created_by": requester_name,
+            "approver_name": approver_name,
+            "approved_at": data.get("approved_at"),
+            "approval_notes": data.get("approval_notes"),
+            "rejection_reason": data.get("rejection_reason"),
             "created_at": data.get("created_at"),
+            "updated_at": data.get("updated_at"),
+            "source_type": data.get("source_type"),
+            "source_notes": data.get("source_notes"),
+            "description": data.get("source_notes"),
+            "quantity_requested": data.get("quantity_requested"),
+            "quantity_approved": data.get("quantity_approved"),
+            "estimated_unit_price": data.get("estimated_unit_price"),
+            "preferred_supplier": data.get("preferred_supplier"),
+            "unit": data.get("unit"),
+            "required_by_date": data.get("required_by_date"),
+            "is_candidate_part": data.get("is_candidate_part", False),
             "items": [item],
+            "notes": [],
             "yacht_id": data.get("yacht_id"),
             "attachments": [],
             "related_entities": nav,

--- a/apps/web/src/app/shopping-list/page.tsx
+++ b/apps/web/src/app/shopping-list/page.tsx
@@ -2,186 +2,101 @@
 
 import * as React from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
-import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { useQueryClient } from '@tanstack/react-query';
 import { useAuth } from '@/hooks/useAuth';
 import { useActiveVessel } from '@/contexts/VesselContext';
 import { FilteredEntityList } from '@/features/entity-list/components/FilteredEntityList';
 import { EntityDetailOverlay } from '@/features/entity-list/components/EntityDetailOverlay';
-import { fetchShoppingListItem } from '@/features/shopping-list/api';
+import { EntityLensPage } from '@/components/lens-v2/EntityLensPage';
+import { ShoppingListContent } from '@/components/lens-v2/entity/ShoppingListContent';
+import { ActionPopup } from '@/components/lens-v2/ActionPopup';
+import lensStyles from '@/components/lens-v2/lens.module.css';
 import { shoppingListToListResult } from '@/features/shopping-list/adapter';
-import { executeAction } from '@/lib/actionClient';
 import { SHOPPING_LIST_FILTERS } from '@/features/entity-list/types/filter-config';
+import { API_BASE } from '@/lib/apiBase';
+import { supabase } from '@/lib/supabaseClient';
 import type { ShoppingListItem } from '@/features/shopping-list/types';
 
-function ShoppingListDetail({ id, onRefresh }: { id: string; onRefresh: () => void }) {
-  const { session, user } = useAuth();
+function LensContent() {
+  return <div className={lensStyles.root}><ShoppingListContent /></div>;
+}
+
+function CreateItemModal({ onClose, onSuccess }: { onClose: () => void; onSuccess: () => void }) {
+  const { session } = useAuth();
   const { vesselId: activeVesselId } = useActiveVessel();
-  const token = session?.access_token;
-  const [isActionLoading, setIsActionLoading] = React.useState(false);
+  const { user } = useAuth();
+  const yachtId = activeVesselId || user?.yachtId || '';
+  const [isSubmitting, setIsSubmitting] = React.useState(false);
+  const [error, setError] = React.useState<string | null>(null);
 
-  const { data, isLoading, error } = useQuery({
-    queryKey: ['shopping-list-item', id],
-    queryFn: () => fetchShoppingListItem(id, token || ''),
-    enabled: !!token,
-    staleTime: 30000,
-  });
-
-  // Action: Approve Item (HOD)
-  const handleApprove = React.useCallback(async () => {
-    if (!(activeVesselId || user?.yachtId) || !id) return;
-
-    setIsActionLoading(true);
+  const handleSubmit = React.useCallback(async (values: Record<string, unknown>) => {
+    if (!yachtId) { setError('No vessel selected'); return; }
+    setIsSubmitting(true);
+    setError(null);
     try {
-      await executeAction(
-        'approve_shopping_list_item',
-        { yacht_id: activeVesselId || user?.yachtId || "", shopping_list_item_id: id },
-        {}
-      );
-      onRefresh();
-    } catch (error) {
-      console.error('[ShoppingListDetail] Approve item failed:', error);
+      const { data: sessionData } = await supabase.auth.getSession();
+      const token = sessionData.session?.access_token;
+      if (!token) { setError('Not authenticated'); return; }
+
+      const res = await fetch('/api/v1/actions/execute', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+        body: JSON.stringify({
+          action: 'create_shopping_list_item',
+          context: { yacht_id: yachtId },
+          payload: {
+            part_name: values.part_name,
+            quantity_requested: Number(values.quantity_requested) || 1,
+            source_type: 'manual_add',
+            urgency: values.urgency || 'normal',
+            source_notes: values.source_notes || undefined,
+            estimated_unit_price: values.estimated_unit_price ? Number(values.estimated_unit_price) : undefined,
+            required_by_date: values.required_by_date || undefined,
+            source_work_order_id: values.source_work_order_id || undefined,
+          },
+        }),
+      });
+
+      const result = await res.json();
+      if (!res.ok || result.status === 'error') {
+        setError(result.message || 'Failed to create item');
+        return;
+      }
+      onSuccess();
+      onClose();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Network error');
     } finally {
-      setIsActionLoading(false);
+      setIsSubmitting(false);
     }
-  }, [id, activeVesselId || user?.yachtId, onRefresh]);
-
-  // Action: Reject Item (HOD)
-  const handleReject = React.useCallback(async () => {
-    if (!(activeVesselId || user?.yachtId) || !id) return;
-
-    setIsActionLoading(true);
-    try {
-      await executeAction(
-        'reject_shopping_list_item',
-        { yacht_id: activeVesselId || user?.yachtId || "", shopping_list_item_id: id },
-        {}
-      );
-      onRefresh();
-    } catch (error) {
-      console.error('[ShoppingListDetail] Reject item failed:', error);
-    } finally {
-      setIsActionLoading(false);
-    }
-  }, [id, activeVesselId || user?.yachtId, onRefresh]);
-
-  // Action: Promote to Part (engineers)
-  const handlePromoteToPart = React.useCallback(async () => {
-    if (!(activeVesselId || user?.yachtId) || !id) return;
-
-    setIsActionLoading(true);
-    try {
-      await executeAction(
-        'promote_candidate_to_part',
-        { yacht_id: activeVesselId || user?.yachtId || "", shopping_list_item_id: id },
-        {}
-      );
-      onRefresh();
-    } catch (error) {
-      console.error('[ShoppingListDetail] Promote to part failed:', error);
-    } finally {
-      setIsActionLoading(false);
-    }
-  }, [id, activeVesselId || user?.yachtId, onRefresh]);
-
-  if (isLoading) {
-    return (
-      <div className="flex items-center justify-center h-full">
-        <div style={{ width: '32px', height: '32px', border: '2px solid var(--border-sub)', borderTopColor: 'var(--mark)', borderRadius: '50%' }} className="animate-spin" />
-      </div>
-    );
-  }
-
-  if (error || !data) {
-    return (
-      <div className="flex items-center justify-center h-full">
-        <p className="text-red-400">Failed to load shopping list item</p>
-      </div>
-    );
-  }
-
-  // Determine if actions should be shown based on status
-  const canApproveReject = data.status === 'pending' || data.status === 'requested';
-  const canPromoteToPart = !data.part_id && (data.status === 'approved' || data.status === 'pending');
+  }, [yachtId, onClose, onSuccess]);
 
   return (
-    <div className="p-6 space-y-4">
-      <div>
-        {data.part_number && (
-          <p className="text-xs text-txt-tertiary font-mono">{data.part_number}</p>
-        )}
-        <h2 className="text-xl font-semibold text-txt-primary">
-          {data.part_name || `Item ${data.part_number || 'Item'}`}
-        </h2>
-      </div>
-      <div className="flex gap-2">
-        <span className="px-2 py-1 text-xs rounded bg-surface-hover text-txt-secondary">
-          {data.status?.replace(/_/g, ' ') || 'Pending'}
-        </span>
-        {data.priority && (
-          <span className="px-2 py-1 text-xs rounded bg-surface-hover text-txt-secondary">
-            {data.priority}
-          </span>
-        )}
-        <span className="px-2 py-1 text-xs rounded bg-surface-hover text-txt-secondary">
-          Qty: {data.quantity_requested}{data.unit_of_measure ? ` ${data.unit_of_measure}` : ''}
-        </span>
-      </div>
-      {data.description && (
-        <p className="text-sm text-txt-tertiary">{data.description}</p>
-      )}
-      {data.requested_by_name && (
-        <div className="text-sm">
-          <span className="text-txt-tertiary">Requested by: </span>
-          <span className="text-txt-secondary">{data.requested_by_name}</span>
-        </div>
-      )}
-      {data.approved_by_name && (
-        <div className="text-sm">
-          <span className="text-txt-tertiary">Approved by: </span>
-          <span className="text-txt-secondary">{data.approved_by_name}</span>
-        </div>
-      )}
-      {data.notes && (
-        <div className="text-sm">
-          <span className="text-txt-tertiary">Notes: </span>
-          <span className="text-txt-secondary">{data.notes}</span>
-        </div>
-      )}
-
-      {/* Action Buttons */}
-      <div className="flex gap-2 pt-4 border-t border-surface-border">
-        {canApproveReject && (
-          <>
-            <button
-              onClick={handleApprove}
-              disabled={isActionLoading}
-              className="px-3 py-1.5 text-xs rounded bg-surface-hover text-txt-secondary hover:bg-surface-hover transition-colors disabled:opacity-50"
-              data-action-id="approve_shopping_list_item"
-            >
-              {isActionLoading ? 'Processing...' : 'Approve Item'}
-            </button>
-            <button
-              onClick={handleReject}
-              disabled={isActionLoading}
-              className="px-3 py-1.5 text-xs rounded bg-surface-hover text-txt-secondary hover:bg-surface-hover transition-colors disabled:opacity-50"
-              data-action-id="reject_shopping_list_item"
-            >
-              {isActionLoading ? 'Processing...' : 'Reject Item'}
-            </button>
-          </>
-        )}
-        {canPromoteToPart && (
-          <button
-            onClick={handlePromoteToPart}
-            disabled={isActionLoading}
-            className="px-3 py-1.5 text-xs rounded bg-surface-hover text-txt-secondary hover:bg-surface-hover transition-colors disabled:opacity-50"
-            data-action-id="promote_candidate_to_part"
-          >
-            {isActionLoading ? 'Processing...' : 'Promote to Part'}
-          </button>
-        )}
-      </div>
-    </div>
+    <ActionPopup
+      mode="mutate"
+      title="Add to Shopping List"
+      subtitle="All crew can add items. HoD approves before ordering."
+      fields={[
+        { name: 'part_name', label: 'Item / Part Name', type: 'kv-edit', placeholder: 'e.g. Fuel filter, Safety harness', required: true },
+        { name: 'quantity_requested', label: 'Quantity', type: 'kv-edit', placeholder: '1', required: true },
+        { name: 'urgency', label: 'Urgency', type: 'select', options: [
+          { value: 'low', label: 'Low' },
+          { value: 'normal', label: 'Normal' },
+          { value: 'high', label: 'High' },
+          { value: 'critical', label: 'Critical' },
+        ]},
+        { name: 'estimated_unit_price', label: 'Estimated Price (per unit)', type: 'kv-edit', placeholder: '0.00' },
+        { name: 'source_notes', label: 'Reason / Notes', type: 'text-area', placeholder: 'Why is this item needed?' },
+        { name: 'required_by_date', label: 'Required By', type: 'date-pick' },
+        { name: 'source_work_order_id', label: 'Link to Work Order (optional)', type: 'entity-search', search_domain: 'work_orders', placeholder: 'Search work orders...' },
+      ]}
+      signatureLevel={1}
+      submitLabel={isSubmitting ? 'Adding...' : 'Add Item'}
+      submitDisabled={isSubmitting}
+      previewRows={error ? [{ key: 'Error', value: error }] : undefined}
+      onSubmit={handleSubmit}
+      onClose={onClose}
+    />
   );
 }
 
@@ -190,34 +105,35 @@ function ShoppingListPageContent() {
   const searchParams = useSearchParams();
   const queryClient = useQueryClient();
   const selectedId = searchParams.get('id');
+  const [showCreate, setShowCreate] = React.useState(false);
 
   const handleSelect = React.useCallback(
     (id: string, yachtId?: string) => {
-      const qs = yachtId ? `id=${id}&yacht_id=${yachtId}` : `id=${id}`;
-      router.push(`/shopping-list?${qs}`, { scroll: false });
+      const params = new URLSearchParams(searchParams.toString());
+      params.set('id', id);
+      if (yachtId) params.set('yacht_id', yachtId);
+      router.push(`/shopping-list?${params.toString()}`, { scroll: false });
     },
-    [router]
+    [router, searchParams]
   );
 
   const handleCloseDetail = React.useCallback(() => {
-    router.push('/shopping-list', { scroll: false });
-  }, [router]);
+    const params = new URLSearchParams(searchParams.toString());
+    params.delete('id');
+    const qs = params.toString();
+    router.push(`/shopping-list${qs ? `?${qs}` : ''}`, { scroll: false });
+  }, [router, searchParams]);
 
-  // Refresh handler for after actions complete
-  const handleRefresh = React.useCallback(() => {
-    // Invalidate both the list and the specific item queries
+  const handleCreated = React.useCallback(() => {
     queryClient.invalidateQueries({ queryKey: ['shopping-list'] });
-    if (selectedId) {
-      queryClient.invalidateQueries({ queryKey: ['shopping-list-item', selectedId] });
-    }
-  }, [queryClient, selectedId]);
+  }, [queryClient]);
 
   return (
-    <div className="h-full bg-surface-base">
+    <div className="h-full bg-surface-base" style={{ position: 'relative' }}>
       <FilteredEntityList<ShoppingListItem>
         domain="shopping-list"
         queryKey={['shopping-list']}
-        table="v_shopping_list_enriched"
+        table="pms_shopping_list_items"
         columns="id, part_name, part_number, manufacturer, quantity_requested, unit, status, urgency, requested_by, required_by_date, created_at, updated_at"
         adapter={shoppingListToListResult}
         filterConfig={SHOPPING_LIST_FILTERS}
@@ -226,9 +142,52 @@ function ShoppingListPageContent() {
         emptyMessage="No shopping list items found"
       />
 
+      {/* Add Item button — fixed bottom-right */}
+      <button
+        onClick={() => setShowCreate(true)}
+        aria-label="Add item to shopping list"
+        style={{
+          position: 'fixed',
+          bottom: 32,
+          right: 32,
+          zIndex: 50,
+          display: 'flex',
+          alignItems: 'center',
+          gap: 8,
+          padding: '10px 18px',
+          background: 'var(--mark)',
+          color: 'var(--surface-base)',
+          border: 'none',
+          borderRadius: 8,
+          fontSize: 13,
+          fontWeight: 600,
+          fontFamily: 'var(--font-sans)',
+          cursor: 'pointer',
+          boxShadow: '0 4px 16px rgba(0,0,0,0.3)',
+        }}
+      >
+        <svg width="14" height="14" viewBox="0 0 14 14" fill="none">
+          <path d="M7 1v12M1 7h12" stroke="currentColor" strokeWidth="2" strokeLinecap="round" />
+        </svg>
+        Add Item
+      </button>
+
       <EntityDetailOverlay isOpen={!!selectedId} onClose={handleCloseDetail}>
-        {selectedId && <ShoppingListDetail id={selectedId} onRefresh={handleRefresh} />}
+        {selectedId && (
+          <EntityLensPage
+            entityType="shopping_list"
+            entityId={selectedId}
+            content={LensContent}
+          />
+        )}
       </EntityDetailOverlay>
+
+      {showCreate && (
+        <CreateItemModal
+          onClose={() => setShowCreate(false)}
+          onSuccess={handleCreated}
+        />
+      )}
     </div>
   );
 }

--- a/apps/web/src/components/lens-v2/entity/ShoppingListContent.tsx
+++ b/apps/web/src/components/lens-v2/entity/ShoppingListContent.tsx
@@ -1,268 +1,160 @@
 'use client';
 
 /**
- * ShoppingListContent — lens-v2 entity view.
+ * ShoppingListContent — lens-v2 entity view for a single shopping list item.
  * Prototype: public/prototypes/lens-shopping-list.html
  *
- * Data flow:
- * - Entity data from useEntityLensContext() → backend /v1/entity/{type}/{id}
- * - Actions from availableActions[] → backend /v1/actions/execute
- * - ActionPopup auto-builds form fields from action.required_fields
+ * Entity data comes from /v1/entity/shopping_list/{id} via useEntityLensContext().
+ * Actions come from available_actions[] prefilled by entity_prefill.py.
  *
- * Sections: Identity → Lifecycle → Line Items → Links → Notes → History → Audit Trail → Attachments
- *
- * TODO notes for next engineer:
- * - Add Item handler not wired
- * - File upload modal not wired
+ * Sections: Identity → Lifecycle → Item Details → Links → Audit Trail
  */
 
 import * as React from 'react';
-import { useRouter } from 'next/navigation';
 import styles from '../lens.module.css';
 import { IdentityStrip, type PillDef, type DetailLine } from '../IdentityStrip';
 import { mapActionFields, actionHasFields, getSignatureLevel } from '../mapActionFields';
 import { SplitButton, type DropdownItem } from '../SplitButton';
 import { ScrollReveal } from '../ScrollReveal';
 import { useEntityLensContext } from '@/contexts/EntityLensContext';
-import { getEntityRoute } from '@/lib/entityRoutes';
 
-// Sections
 import {
-  NotesSection,
   AuditTrailSection,
-  PartsSection,
   DocRowsSection,
   KVSection,
-  AttachmentsSection,
-  HistorySection,
-  type NoteItem,
   type AuditEvent,
-  type PartItem,
   type DocRowItem,
   type KVItem,
-  type AttachmentItem,
-  type HistoryPeriod,
 } from '../sections';
 import { ActionPopup, type ActionPopupField } from '../ActionPopup';
 
-// --- Colour mapping helpers ---
-
-function statusToPillVariant(status: string): PillDef['variant'] {
-  switch (status) {
-    case 'cancelled':
-      return 'red';
-    case 'submitted':
-      return 'amber';
-    case 'approved':
-    case 'ordered':
-    case 'received':
-      return 'green';
-    default:
-      return 'neutral';
+function statusPillVariant(status: string): PillDef['variant'] {
+  switch (status?.toLowerCase()) {
+    case 'approved': return 'green';
+    case 'ordered': return 'green';
+    case 'fulfilled': return 'green';
+    case 'rejected': return 'red';
+    case 'under_review': return 'amber';
+    case 'candidate': return 'neutral';
+    default: return 'neutral';
   }
 }
 
-function priorityToPillVariant(priority: string): PillDef['variant'] {
-  switch (priority) {
-    case 'critical':
-      return 'red';
-    case 'high':
-      return 'amber';
-    default:
-      return 'neutral';
+function urgencyPillVariant(urgency: string): PillDef['variant'] {
+  switch (urgency?.toLowerCase()) {
+    case 'critical': return 'red';
+    case 'high': return 'amber';
+    default: return 'neutral';
   }
 }
 
-function formatLabel(str: string): string {
+function fmt(str?: string): string {
+  if (!str) return '';
   return str.replace(/_/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase());
 }
 
-// --- Component ---
+function formatDate(d?: string): string {
+  if (!d) return '';
+  const dt = new Date(d);
+  return dt.toLocaleDateString('en-GB', { day: '2-digit', month: 'short', year: 'numeric' });
+}
 
 export function ShoppingListContent() {
-  const router = useRouter();
-  const { entity, availableActions, executeAction, getAction, isLoading } = useEntityLensContext();
+  const { entity, availableActions, executeAction, getAction } = useEntityLensContext();
 
-  // -- Extract entity fields --
   const payload = (entity?.payload as Record<string, unknown>) ?? {};
-  const list_number = (entity?.list_number ?? payload.list_number) as string | undefined;
-  const title = ((entity?.title ?? payload.title) as string | undefined) ?? 'Shopping List';
-  const description = (entity?.description ?? payload.description) as string | undefined;
-  const status = ((entity?.status ?? payload.status) as string | undefined) ?? 'draft';
-  const priority = ((entity?.priority ?? payload.priority) as string | undefined) ?? 'normal';
-  const created_by = (entity?.created_by ?? payload.created_by ?? entity?.requester_name ?? payload.requester_name) as string | undefined;
-  const created_date = (entity?.created_date ?? payload.created_date ?? entity?.created_at ?? payload.created_at) as string | undefined;
-  const port = (entity?.port ?? payload.port ?? entity?.delivery_location ?? payload.delivery_location) as string | undefined;
-  const department = (entity?.department ?? payload.department) as string | undefined;
-  const total_items = (entity?.total_items ?? payload.total_items) as number | undefined;
-  const total_cost = (entity?.total_cost ?? payload.total_cost ?? entity?.estimated_total ?? payload.estimated_total) as number | undefined;
-  const currency = ((entity?.currency ?? payload.currency) as string | undefined) ?? 'USD';
-  const approver_name = (entity?.approver_name ?? payload.approver_name) as string | undefined;
-  const approved_at = (entity?.approved_at ?? payload.approved_at) as string | undefined;
+  const get = <T = unknown>(key: string): T | undefined =>
+    (entity?.[key] ?? payload[key]) as T | undefined;
 
-  // Section data
-  const items = ((entity?.items ?? payload.items) as Array<Record<string, unknown>> | undefined) ?? [];
-  const notes = ((entity?.notes ?? payload.notes) as Array<Record<string, unknown>> | undefined) ?? [];
-  const history = ((entity?.audit_history ?? payload.audit_history ?? entity?.history ?? payload.history) as Array<Record<string, unknown>> | undefined) ?? [];
-  const linked_entities = ((entity?.linked_entities ?? payload.linked_entities ?? entity?.documents ?? payload.documents) as Array<Record<string, unknown>> | undefined) ?? [];
+  const id = get<string>('id');
+  const title = get<string>('title') ?? get<string>('part_name') ?? 'Shopping List Item';
+  const status = get<string>('status') ?? 'candidate';
+  const urgency = get<string>('urgency') ?? get<string>('priority');
+  const requesterName = get<string>('requester_name') ?? get<string>('created_by');
+  const approverName = get<string>('approver_name');
+  const approvedAt = get<string>('approved_at');
+  const approvalNotes = get<string>('approval_notes');
+  const rejectionReason = get<string>('rejection_reason');
+  const createdAt = get<string>('created_at');
+  const updatedAt = get<string>('updated_at');
+  const sourceType = get<string>('source_type');
+  const sourceNotes = get<string>('source_notes') ?? get<string>('description');
+  const requiredByDate = get<string>('required_by_date');
+  const isCandidatePart = get<boolean>('is_candidate_part');
+  const preferredSupplier = get<string>('preferred_supplier');
 
-  // -- Action gates --
-  const submitAction = getAction('submit_list');
-  const approveAction = getAction('approve_list');
-  const convertAction = getAction('convert_to_po');
-  const addItemAction = getAction('add_list_item');
-  const archiveAction = getAction('archive_list');
+  // Items array — the entity endpoint wraps the row in items:[...] for the lens
+  const items = (get<Array<Record<string, unknown>>>('items') ?? []);
+  const item = items[0] ?? {};
+  const partNumber = (item.part_number ?? get<string>('part_number')) as string | undefined;
+  const manufacturer = (item.manufacturer ?? get<string>('manufacturer')) as string | undefined;
+  const unit = (item.unit ?? get<string>('unit')) as string | undefined;
+  const qtyRequested = (item.quantity_requested ?? get<number>('quantity_requested')) as number | undefined;
+  const qtyApproved = (item.quantity_approved ?? get<number>('quantity_approved')) as number | undefined;
+  const estimatedPrice = (item.estimated_unit_price ?? get<number>('estimated_unit_price')) as number | undefined;
 
-  const isArchivable = !['cancelled', 'archived'].includes(status);
+  const relatedEntities = (get<Array<Record<string, unknown>>>('related_entities') ?? []);
 
-  // BACKEND_AUTO moved to mapActionFields.ts
-  const [actionPopupConfig, setActionPopupConfig] = React.useState<{
-    actionId: string; title: string; fields: ActionPopupField[]; signatureLevel: 0|1|2|3|4|5;
+  // ── Action popup state ───────────────────────────────────────────────────────
+  const [popupConfig, setPopupConfig] = React.useState<{
+    actionId: string;
+    title: string;
+    fields: ActionPopupField[];
+    signatureLevel: 0 | 1 | 2 | 3 | 4 | 5;
   } | null>(null);
 
-  function openActionPopup(action: { action_id: string; label: string; required_fields: string[]; prefill: Record<string, unknown>; requires_signature: boolean }) {
-    const fields = mapActionFields(action as any);
-    const sigLevel = getSignatureLevel(action as any);
-    setActionPopupConfig({ actionId: action.action_id, title: action.label, fields, signatureLevel: sigLevel });
+  function openPopup(action: { action_id: string; label: string; required_fields: string[]; prefill: Record<string, unknown>; requires_signature: boolean }) {
+    setPopupConfig({
+      actionId: action.action_id,
+      title: action.label,
+      fields: mapActionFields(action as Parameters<typeof mapActionFields>[0]),
+      signatureLevel: getSignatureLevel(action as Parameters<typeof getSignatureLevel>[0]),
+    });
   }
 
-  // -- Derived display --
-  const statusLabel = formatLabel(status);
-  const priorityLabel = formatLabel(priority);
-  const itemCount = total_items ?? items.length;
-
+  // ── Pills & detail lines ─────────────────────────────────────────────────────
   const pills: PillDef[] = [
-    { label: statusLabel, variant: statusToPillVariant(status) },
+    { label: fmt(status), variant: statusPillVariant(status) },
   ];
-  if (itemCount > 0) {
-    pills.push({ label: `${itemCount} Item${itemCount === 1 ? '' : 's'}`, variant: 'neutral' });
+  if (urgency && urgency !== 'normal') {
+    pills.push({ label: fmt(urgency), variant: urgencyPillVariant(urgency) });
   }
-  if (priority !== 'normal' && priority !== 'medium') {
-    pills.push({ label: priorityLabel, variant: priorityToPillVariant(priority) });
+  if (isCandidatePart) {
+    pills.push({ label: 'Candidate', variant: 'neutral' });
   }
 
   const details: DetailLine[] = [];
-  if (created_by) {
-    details.push({ label: 'Requester', value: created_by });
-  }
-  if (approver_name) {
-    details.push({ label: 'Approver', value: approver_name });
-  }
-  if (created_date) {
-    details.push({ label: 'Created', value: created_date, mono: true });
-  }
-  if (approved_at) {
-    details.push({ label: 'Approved', value: approved_at, mono: true });
-  }
-  if (priority !== 'normal' && priority !== 'medium') {
-    details.push({ label: 'Priority', value: priorityLabel });
-  }
-  if (department) {
-    details.push({ label: 'Department', value: department });
-  }
-  if (port) {
-    details.push({ label: 'Delivery', value: port });
-  }
-  if (total_cost !== undefined) {
-    details.push({ label: 'Est. Total', value: `$${total_cost.toLocaleString()}`, mono: true });
-  }
+  if (requesterName) details.push({ label: 'Requested by', value: requesterName });
+  if (createdAt) details.push({ label: 'Created', value: formatDate(createdAt), mono: true });
+  if (requiredByDate) details.push({ label: 'Required by', value: formatDate(requiredByDate), mono: true });
+  if (approverName) details.push({ label: 'Approved by', value: approverName });
+  if (approvedAt) details.push({ label: 'Approved', value: formatDate(approvedAt), mono: true });
 
-  // Context line
-  const contextParts: string[] = [];
-  if (department) contextParts.push(department);
-  if (port) contextParts.push(port);
-  const contextNode = (
-    <>
-      {contextParts.join(' · ')}
-      {created_by && (
-        <>
-          {contextParts.length > 0 && ' · '}
-          Requested by <span className={styles.crewLink}>{created_by}</span>
-        </>
-      )}
-    </>
-  );
+  // ── KV section rows ──────────────────────────────────────────────────────────
+  const kvItems: KVItem[] = [];
+  if (partNumber) kvItems.push({ label: 'Part Number', value: partNumber, mono: true });
+  if (manufacturer) kvItems.push({ label: 'Manufacturer', value: manufacturer });
+  if (unit) kvItems.push({ label: 'Unit', value: unit });
+  if (qtyRequested != null) kvItems.push({ label: 'Qty Requested', value: String(qtyRequested) });
+  if (qtyApproved != null) kvItems.push({ label: 'Qty Approved', value: String(qtyApproved) });
+  if (estimatedPrice != null) kvItems.push({ label: 'Est. Unit Price', value: `$${estimatedPrice.toLocaleString()}`, mono: true });
+  if (preferredSupplier) kvItems.push({ label: 'Preferred Supplier', value: preferredSupplier });
+  if (sourceType) kvItems.push({ label: 'Source', value: fmt(sourceType) });
+  if (sourceNotes) kvItems.push({ label: 'Notes / Reason', value: sourceNotes });
+  if (approvalNotes) kvItems.push({ label: 'Approval Notes', value: approvalNotes });
+  if (rejectionReason) kvItems.push({ label: 'Rejection Reason', value: rejectionReason });
 
-  // -- Split button config --
-  const canConvert = convertAction !== null && ['approved'].includes(status);
-  const canSubmit = submitAction !== null && ['draft'].includes(status);
-
-  const primaryLabel = canConvert ? 'Convert to PO' : canSubmit ? 'Submit List' : 'Submit List';
-  const primaryDisabled = canConvert
-    ? (convertAction?.disabled ?? false)
-    : canSubmit
-      ? (submitAction?.disabled ?? false)
-      : true;
-  const primaryDisabledReason = canConvert
-    ? convertAction?.disabled_reason
-    : canSubmit
-      ? submitAction?.disabled_reason
-      : undefined;
-
-  const handlePrimary = React.useCallback(async () => {
-    if (canConvert) {
-      await executeAction('convert_to_po', {});
-    } else if (canSubmit) {
-      await executeAction('submit_list', {});
-    }
-  }, [canConvert, canSubmit, executeAction]);
-
-  const SPECIAL_HANDLERS: Record<string, () => void> = {};
-  const DANGER_ACTIONS = new Set(['archive_list', 'delete_list']);
-  const primaryActionId = canConvert ? 'convert_to_po' : 'submit_list';
-
-  const dropdownItems: DropdownItem[] = availableActions
-    .filter((a) => a.action_id !== primaryActionId)
-    .map((a) => ({
-      label: a.label,
-      onClick: SPECIAL_HANDLERS[a.action_id]
-        ? SPECIAL_HANDLERS[a.action_id]
-        : () => {
-            const hasFields = actionHasFields(a as any);
-            if (hasFields || a.requires_signature) { openActionPopup(a); } else { executeAction(a.action_id); }
-          },
-      disabled: a.disabled,
-      disabledReason: a.disabled_reason ?? undefined,
-      danger: DANGER_ACTIONS.has(a.action_id),
-    }));
-
-  // -- Map section data --
-  const partItems: PartItem[] = items.map((item, i) => ({
-    id: (item.id as string) ?? `item-${i}`,
-    name: (item.part_name ?? item.name ?? item.description) as string ?? 'Item',
-    partNumber: (item.part_number ?? item.sku) as string | undefined,
-    quantity: (item.quantity_requested ?? item.quantity) !== undefined
-      ? `x ${item.quantity_requested ?? item.quantity}`
-      : undefined,
-    stock: (item.unit_price ?? item.price) !== undefined
-      ? `$${Number(item.unit_price ?? item.price).toLocaleString()}`
-      : undefined,
-    onNavigate: item.part_id
-      ? () => router.push(getEntityRoute('parts' as Parameters<typeof getEntityRoute>[0], item.part_id as string))
-      : undefined,
+  // ── Related entity links ─────────────────────────────────────────────────────
+  const docItems: DocRowItem[] = relatedEntities.map((e, i) => ({
+    id: (e.entity_id as string) ?? `link-${i}`,
+    name: (e.label as string) ?? 'Linked Entity',
+    code: (e.entity_type as string) ?? undefined,
+    meta: undefined,
+    date: undefined,
   }));
 
-  const docItems: DocRowItem[] = linked_entities.map((d, i) => ({
-    id: (d.id as string) ?? `link-${i}`,
-    name: (d.name ?? d.title ?? d.entity_title) as string ?? 'Linked Entity',
-    code: (d.code ?? d.entity_code ?? d.reference) as string | undefined,
-    meta: (d.meta ?? d.entity_type ?? d.description) as string | undefined,
-    date: (d.date ?? d.created_at) as string | undefined,
-    onClick: d.entity_id
-      ? () => router.push(getEntityRoute(
-          (d.entity_type as Parameters<typeof getEntityRoute>[0]) ?? 'work-orders',
-          d.entity_id as string
-        ))
-      : undefined,
-  }));
-
-  const noteItems: NoteItem[] = notes.map((n, i) => ({
-    id: (n.id as string) ?? `note-${i}`,
-    author: (n.author ?? n.created_by ?? n.user_name) as string ?? 'Unknown',
-    timestamp: (n.created_at ?? n.timestamp) as string ?? '',
-    body: (n.body ?? n.note_text ?? n.text) as string ?? '',
-  }));
-
+  // ── Audit events ─────────────────────────────────────────────────────────────
+  const history = (get<Array<Record<string, unknown>>>('audit_history') ?? []);
   const auditEvents: AuditEvent[] = history.map((h, i) => ({
     id: (h.id as string) ?? `audit-${i}`,
     action: (h.action ?? h.description ?? h.event) as string ?? '',
@@ -270,112 +162,108 @@ export function ShoppingListContent() {
     timestamp: (h.created_at ?? h.timestamp) as string ?? '',
   }));
 
-  const attachments = ((entity?.attachments ?? payload.attachments) as Array<Record<string, unknown>> | undefined) ?? [];
-  const priorPeriods = ((entity?.prior_periods ?? payload.prior_periods ?? entity?.history_periods ?? payload.history_periods) as Array<Record<string, unknown>> | undefined) ?? [];
+  // ── SplitButton — primary action + dropdown ──────────────────────────────────
+  const approveAction = getAction('approve_shopping_list_item');
+  const rejectAction = getAction('reject_shopping_list_item');
+  const promoteAction = getAction('promote_candidate_to_part');
+  const orderAction = getAction('mark_shopping_list_ordered');
 
-  const attachmentItems: AttachmentItem[] = attachments.map((a, i) => ({
-    id: (a.id as string) ?? `att-${i}`,
-    name: (a.name ?? a.file_name ?? a.filename) as string ?? 'File',
-    caption: (a.caption ?? a.description) as string | undefined,
-    size: (a.size ?? a.file_size) as string | undefined,
-    kind: (((a.mime_type ?? a.content_type) as string) ?? '').startsWith('image') ? 'image' as const : 'document' as const,
-  }));
+  // Primary: approve if available, else first non-approve action
+  const primaryAction = approveAction ?? orderAction;
+  const primaryLabel = primaryAction?.label ?? 'No Actions';
+  const primaryDisabled = !primaryAction || (primaryAction.disabled ?? false);
 
-  const historyPeriods: HistoryPeriod[] = priorPeriods.map((p, i) => ({
-    id: (p.id as string) ?? `period-${i}`,
-    year: (p.year ?? p.period_year) as string ?? '',
-    label: (p.label ?? p.period_label ?? p.description) as string ?? '',
-    status: ((p.status as string) === 'active' || (p.status as string) === 'current') ? 'active' as const : 'closed' as const,
-    summary: (p.summary ?? p.period_summary) as string ?? '',
-  }));
+  const handlePrimary = React.useCallback(async () => {
+    if (!primaryAction) return;
+    const hasFields = actionHasFields(primaryAction as Parameters<typeof actionHasFields>[0]);
+    if (hasFields || primaryAction.requires_signature) {
+      openPopup(primaryAction as Parameters<typeof openPopup>[0]);
+    } else {
+      await executeAction(primaryAction.action_id);
+    }
+  }, [primaryAction, executeAction]);
 
+  const DANGER_ACTIONS = new Set(['delete_shopping_item']);
+  const dropdownItems: DropdownItem[] = availableActions
+    .filter((a) => a.action_id !== primaryAction?.action_id)
+    .map((a) => ({
+      label: a.label,
+      disabled: a.disabled,
+      disabledReason: a.disabled_reason ?? undefined,
+      danger: DANGER_ACTIONS.has(a.action_id),
+      onClick: () => {
+        const hasFields = actionHasFields(a as Parameters<typeof actionHasFields>[0]);
+        if (hasFields || a.requires_signature) {
+          openPopup(a as Parameters<typeof openPopup>[0]);
+        } else {
+          executeAction(a.action_id);
+        }
+      },
+    }));
 
-  const handleAddPart = React.useCallback(
-    () => {},
-    []
-  );
+  // ── Lifecycle steps ──────────────────────────────────────────────────────────
+  const LIFECYCLE = ['candidate', 'under_review', 'approved', 'ordered', 'fulfilled'] as const;
+  const currentIdx = LIFECYCLE.indexOf(status as typeof LIFECYCLE[number]);
 
   return (
     <>
-      {/* Identity Strip */}
       <IdentityStrip
-        overline={list_number}
+        overline={partNumber ? `#${partNumber}` : undefined}
         title={title}
-        context={contextNode}
+        context={requesterName ? <>Requested by <span className={styles.crewLink}>{requesterName}</span></> : undefined}
         pills={pills}
         details={details}
-        description={description}
+        description={sourceNotes}
         actionSlot={
-          (submitAction || convertAction) ? (
+          availableActions.length > 0 ? (
             <SplitButton
               label={primaryLabel}
               onClick={handlePrimary}
               disabled={primaryDisabled}
-              disabledReason={primaryDisabledReason ?? undefined}
               items={dropdownItems}
             />
           ) : undefined
         }
       />
 
-      {/* Lifecycle Progress */}
+      {/* Lifecycle progress */}
       <ScrollReveal>
         <div style={{ display: 'flex', alignItems: 'flex-start', gap: 0, padding: '16px 0', marginBottom: 8 }}>
-          {(['draft', 'submitted', 'approved', 'ordered', 'received', 'archived'] as const).map((step, i, arr) => {
-            const stepIndex = arr.indexOf(step);
-            const currentIndex = arr.indexOf(status as typeof step);
-            const isCompleted = currentIndex >= 0 && stepIndex < currentIndex;
-            const isActive = stepIndex === currentIndex;
-            const isFuture = currentIndex < 0 ? stepIndex > 0 : stepIndex > currentIndex;
+          {LIFECYCLE.map((step, i) => {
+            const isCompleted = currentIdx >= 0 && i < currentIdx;
+            const isActive = i === currentIdx;
 
             return (
               <React.Fragment key={step}>
                 <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', flex: 1, minWidth: 0 }}>
-                  <div
-                    style={{
-                      width: isActive ? 12 : 10,
-                      height: isActive ? 12 : 10,
-                      borderRadius: '50%',
-                      background: isCompleted || isActive ? 'var(--green, #4caf50)' : 'none',
-                      border: `2px solid ${isCompleted || isActive ? 'var(--green, #4caf50)' : 'var(--txt-ghost, #666)'}`,
-                      boxShadow: isActive ? '0 0 0 4px var(--green-bg, rgba(76,175,80,0.15))' : 'none',
-                      position: 'relative',
-                      display: 'flex',
-                      alignItems: 'center',
-                      justifyContent: 'center',
-                    }}
-                  >
+                  <div style={{
+                    width: isActive ? 12 : 10, height: isActive ? 12 : 10, borderRadius: '50%',
+                    background: isCompleted || isActive ? 'var(--green, #4caf50)' : 'none',
+                    border: `2px solid ${isCompleted || isActive ? 'var(--green, #4caf50)' : 'var(--txt-ghost, #666)'}`,
+                    boxShadow: isActive ? '0 0 0 4px var(--green-bg, rgba(76,175,80,0.15))' : 'none',
+                    display: 'flex', alignItems: 'center', justifyContent: 'center',
+                  }}>
                     {isCompleted && (
                       <svg width="8" height="8" viewBox="0 0 12 12" fill="none" stroke="#fff" strokeWidth="2" strokeLinecap="round">
                         <polyline points="2.5 6 5 8.5 9.5 3.5" />
                       </svg>
                     )}
                   </div>
-                  <span
-                    style={{
-                      fontSize: 10,
-                      fontWeight: isActive ? 600 : 500,
-                      letterSpacing: '0.03em',
-                      color: isActive ? 'var(--green, #4caf50)' : isCompleted ? 'var(--txt3, #999)' : 'var(--txt-ghost, #666)',
-                      marginTop: 8,
-                      textTransform: 'uppercase',
-                      whiteSpace: 'nowrap',
-                    }}
-                  >
-                    {formatLabel(step)}
+                  <span style={{
+                    fontSize: 10, fontWeight: isActive ? 600 : 500,
+                    letterSpacing: '0.03em',
+                    color: isActive ? 'var(--green, #4caf50)' : isCompleted ? 'var(--txt3, #999)' : 'var(--txt-ghost, #666)',
+                    marginTop: 8, textTransform: 'uppercase', whiteSpace: 'nowrap',
+                  }}>
+                    {fmt(step)}
                   </span>
                 </div>
-                {i < arr.length - 1 && (
-                  <div
-                    style={{
-                      flex: 1,
-                      height: 2,
-                      background: isCompleted ? 'var(--green, #4caf50)' : 'var(--border-sub, #444)',
-                      alignSelf: 'flex-start',
-                      marginTop: isActive ? 6 : 5,
-                      minWidth: 8,
-                    }}
-                  />
+                {i < LIFECYCLE.length - 1 && (
+                  <div style={{
+                    flex: 1, height: 2,
+                    background: isCompleted ? 'var(--green, #4caf50)' : 'var(--border-sub, #444)',
+                    alignSelf: 'flex-start', marginTop: isActive ? 6 : 5, minWidth: 8,
+                  }} />
                 )}
               </React.Fragment>
             );
@@ -383,53 +271,37 @@ export function ShoppingListContent() {
         </div>
       </ScrollReveal>
 
-      {/* Line Items */}
-      <ScrollReveal>
-        <PartsSection
-          parts={partItems}
-          onAddPart={handleAddPart}
-          canAddPart
-        />
-      </ScrollReveal>
+      {/* Item detail KV rows */}
+      {kvItems.length > 0 && (
+        <ScrollReveal>
+          <KVSection title="Item Details" items={kvItems} />
+        </ScrollReveal>
+      )}
 
-      {/* Cross-Entity Links */}
+      {/* Linked entities (part, work order) */}
       {docItems.length > 0 && (
         <ScrollReveal>
           <DocRowsSection title="Linked Entities" docs={docItems} />
         </ScrollReveal>
       )}
 
-      {/* Notes */}
-      <ScrollReveal>
-        <NotesSection
-          notes={noteItems}
-          onAddNote={undefined}
-          canAddNote={false}
-        />
-      </ScrollReveal>
-
-      {/* History */}
-      <ScrollReveal><HistorySection periods={historyPeriods} defaultCollapsed /></ScrollReveal>
-
-      {/* Audit Trail */}
+      {/* Audit trail */}
       <ScrollReveal>
         <AuditTrailSection events={auditEvents} defaultCollapsed />
       </ScrollReveal>
 
-      {/* Attachments */}
-      <ScrollReveal>
-        <AttachmentsSection
-          attachments={attachmentItems}
-          onAddFile={() => {/* TODO: file upload modal (no component exists yet) */}}
-          canAddFile
+      {popupConfig && (
+        <ActionPopup
+          mode="mutate"
+          title={popupConfig.title}
+          fields={popupConfig.fields}
+          signatureLevel={popupConfig.signatureLevel}
+          onSubmit={async (values) => {
+            await executeAction(popupConfig.actionId, values);
+            setPopupConfig(null);
+          }}
+          onClose={() => setPopupConfig(null)}
         />
-      </ScrollReveal>
-
-      {actionPopupConfig && (
-        <ActionPopup mode="mutate" title={actionPopupConfig.title} fields={actionPopupConfig.fields}
-          signatureLevel={actionPopupConfig.signatureLevel}
-          onSubmit={async (values) => { await executeAction(actionPopupConfig.actionId, values); setActionPopupConfig(null); }}
-          onClose={() => setActionPopupConfig(null)} />
       )}
     </>
   );

--- a/apps/web/src/features/shopping-list/hooks/useShoppingListActions.ts
+++ b/apps/web/src/features/shopping-list/hooks/useShoppingListActions.ts
@@ -37,7 +37,7 @@ export function useShoppingListActions(options: UseShoppingListActionsOptions = 
   // Action: Create Shopping List Item (All crew)
   const createItem = useCallback(
     async (payload: CreateShoppingListItemPayload) => {
-      if (!activeVesselId || user?.yachtId) {
+      if (!activeVesselId && !user?.yachtId) {
         const error = new Error('No yacht context available');
         onError?.(error);
         throw error;


### PR DESCRIPTION
## Summary

- **DB routing fix**: replaced direct Supabase client calls in detail view (which hit MASTER DB on Vercel → 404) with `EntityLensPage` pattern routing through Render API → TENANT DB
- **Action 400 fix**: added `shopping_list` prefill entries to `entity_prefill.py` so `item_id` is injected into payload before the REQUIRED_FIELDS check in `p0_actions_routes.py` (line 903); previously approve/reject always returned 400
- **Enriched entity endpoint**: `/v1/entity/shopping_list/{id}` now returns requester_name + approver_name (joined from auth_users_profiles), all item fields (urgency, price, notes, dates, rejection/approval metadata) and related_entities for linked part + source work order
- **New ShoppingListContent**: lifecycle stepper (candidate→fulfilled), KV section, linked entities, audit trail, SplitButton with primary=approve
- **Add Item button + modal**: floating button opens ActionPopup with 7 fields; POSTs to `/api/v1/actions/execute` via Next.js proxy
- **Logic bug fix** in `useShoppingListActions.ts`: `!activeVesselId || user?.yachtId` changed to `&&` — prevents create from being blocked when `user.yachtId` is truthy

## Test plan

- [ ] `/shopping-list` list view loads (uses Render API, not Supabase direct)
- [ ] "Add Item" button opens modal; submit creates item without 400
- [ ] Clicking an item opens detail panel with full data (requester name, urgency, price, notes)
- [ ] Lifecycle stepper reflects correct status
- [ ] Approve button works for HoD role (no 400)
- [ ] Reject button works for HoD role (no 400)
- [ ] KV section shows item details; audit trail shows history

🤖 Generated with [Claude Code](https://claude.com/claude-code)