### PR TITLE
fix(shopping-list): execute 4 follow-ups from SHOPPING_LIST_AUDIT

### DIFF
--- a/apps/api/action_router/entity_actions.py
+++ b/apps/api/action_router/entity_actions.py
@@ -50,6 +50,25 @@ _RECEIVING_TERMINAL_DISABLED = {
     "reject_receiving", "attach_receiving_image_with_comment", "update_receiving_fields",
 }
 
+# ── Shopping-list legacy action hide-list ──────────────────────────────────────
+# These 6 actions date back to an abandoned parent-list design (there was going
+# to be a `pms_shopping_lists` header row with items underneath). That table
+# never existed in production — every action now operates on a single
+# pms_shopping_list_items row. Their registry entries and handlers still work
+# for programmatic callers, but their labels ("Approve Shopping List Item",
+# "Archive Shopping List", etc.) overlap and duplicate the canonical 5
+# per-item actions, so surfacing them in the UI confuses users.
+# Hiding them here is the least-disruptive fix — reversible, no cross-domain
+# fallout, and no registry/handler deletions required.
+_SHOPPING_LIST_HIDDEN_ACTIONS = {
+    "approve_list",
+    "add_list_item",
+    "archive_list",
+    "delete_list",
+    "convert_to_po",
+    "submit_list",
+}
+
 
 def get_available_actions(
     entity_type: str,
@@ -77,6 +96,10 @@ def get_available_actions(
         # Full ActionDefinition — use .get() to safely skip missing IDs
         action_def = ACTION_REGISTRY.get(action_id)
         if not action_def:
+            continue
+
+        # Hide legacy/shadowed actions for specific entity types
+        if entity_type == "shopping_list" and action_id in _SHOPPING_LIST_HIDDEN_ACTIONS:
             continue
 
         # Role gate: omit entirely if not permitted
@@ -312,6 +335,19 @@ def _apply_state_gate(
         _PO_DRAFT_ONLY = {"add_item_to_purchase"}
         if status not in ("draft", "") and action_id in _PO_DRAFT_ONLY:
             return True, f"Cannot add items to a PO with status '{status}'"
+
+    elif entity_type == "shopping_list":
+        # mark_shopping_list_ordered requires the item to be approved first.
+        # approve/reject/promote_candidate_to_part become no-ops on terminal states.
+        _SL_TERMINAL_STATUSES = {"rejected", "fulfilled", "installed"}
+        _SL_TERMINAL_DISABLED = {
+            "approve_shopping_list_item", "reject_shopping_list_item",
+            "promote_candidate_to_part", "mark_shopping_list_ordered",
+        }
+        if status in _SL_TERMINAL_STATUSES and action_id in _SL_TERMINAL_DISABLED:
+            return True, f"Item is {status.replace('_', ' ')} — no further transitions"
+        if action_id == "mark_shopping_list_ordered" and status != "approved":
+            return True, "Item must be approved before it can be marked as ordered"
 
     elif entity_type == "certificate":
         _CERT_TERMINAL = {"superseded", "revoked"}

--- a/apps/api/action_router/registry.py
+++ b/apps/api/action_router/registry.py
@@ -2175,6 +2175,29 @@ ACTION_REGISTRY: Dict[str, ActionDefinition] = {
         ],
     ),
 
+    # mark_shopping_list_ordered: handler already lives at
+    # routes/handlers/shopping_handler.py:213 (and was wired into SHOP_HANDLERS
+    # at __init__.py:24 from day one of Phase 4). Missing ACTION_REGISTRY entry
+    # meant get_available_actions never surfaced it → UI SplitButton could not
+    # trigger it. Roles + required fields mirror the handler (_MARK_ORDERED_ROLES
+    # at shopping_handler.py:40). Transition is approved → ordered.
+    "mark_shopping_list_ordered": ActionDefinition(
+        action_id="mark_shopping_list_ordered",
+        label="Mark as Ordered",
+        endpoint="/v1/actions/execute",
+        handler_type=HandlerType.INTERNAL,
+        method="POST",
+        allowed_roles=["chief_engineer", "captain", "manager"],
+        required_fields=["yacht_id", "item_id"],
+        domain="shopping_list",
+        variant=ActionVariant.MUTATE,
+        search_keywords=["order", "ordered", "placed", "shopping", "purchase"],
+        field_metadata=[
+            FieldMetadata("yacht_id", FieldClassification.CONTEXT),
+            FieldMetadata("item_id", FieldClassification.REQUIRED, description="Shopping list item ID (must be approved)"),
+        ],
+    ),
+
     "consume_part": ActionDefinition(
         action_id="consume_part",
         label="Consume Part",

--- a/apps/api/routes/entity_routes.py
+++ b/apps/api/routes/entity_routes.py
@@ -719,20 +719,61 @@ async def get_shopping_list_entity(item_id: str, auth: dict = Depends(get_authen
 
         data = r.data
 
-        # Look up names for requester and approver in one query
-        requester_name = None
-        approver_name = None
+        # Load state-machine history (drives the AuditTrailSection on the lens).
+        # Fail-soft: an empty history is the pre-existing behavior.
+        raw_history: list[dict] = []
+        try:
+            hist_r = supabase.table("pms_shopping_list_state_history").select(
+                "id, previous_state, new_state, transition_reason, transition_notes, changed_by, changed_at"
+            ).eq("shopping_list_item_id", item_id).eq("yacht_id", yacht_id) \
+             .order("changed_at", desc=False).execute()
+            raw_history = hist_r.data or []
+        except Exception as e:
+            logger.warning(f"[entity.shopping_list] state_history fetch failed for {item_id}: {e}")
+
+        # Single batched profile lookup: requester + approver + every actor in history.
         requester_id = data.get("requested_by") or data.get("created_by")
         approver_id = data.get("approved_by")
-        lookup_ids = [uid for uid in [requester_id, approver_id] if uid]
+        history_actor_ids = {h.get("changed_by") for h in raw_history if h.get("changed_by")}
+        lookup_ids = list({uid for uid in ({requester_id, approver_id} | history_actor_ids) if uid})
+        profile_map: dict[str, str] = {}
         if lookup_ids:
             try:
                 profiles = supabase.table("auth_users_profiles").select("id, name").in_("id", lookup_ids).execute()
-                profile_map = {p["id"]: p.get("name") for p in (profiles.data or [])}
-                requester_name = profile_map.get(requester_id)
-                approver_name = profile_map.get(approver_id)
-            except Exception:
-                pass
+                profile_map = {p["id"]: p.get("name") for p in (profiles.data or []) if p.get("id")}
+            except Exception as e:
+                logger.warning(f"[entity.shopping_list] profile lookup failed: {e}")
+        requester_name = profile_map.get(requester_id) if requester_id else None
+        approver_name = profile_map.get(approver_id) if approver_id else None
+
+        # Project history rows into the shape ShoppingListContent.tsx expects.
+        # AuditTrailSection reads `action`, `actor`, `timestamp` per event
+        # (ShoppingListContent.tsx:158-163 normalises these aliases).
+        def _event_label(row: dict) -> str:
+            prev = row.get("previous_state")
+            new = row.get("new_state")
+            reason = row.get("transition_reason")
+            if prev and new:
+                label = f"{prev} → {new}"
+            elif new:
+                label = f"Status: {new}"
+            else:
+                label = reason or "State change"
+            return label if not reason or label == reason else f"{label} — {reason}"
+
+        audit_history = [
+            {
+                "id": h.get("id"),
+                "action": _event_label(h),
+                "actor": profile_map.get(h.get("changed_by")) if h.get("changed_by") else None,
+                "timestamp": h.get("changed_at"),
+                # kept for callers that read the raw shape
+                "previous_state": h.get("previous_state"),
+                "new_state": h.get("new_state"),
+                "transition_notes": h.get("transition_notes"),
+            }
+            for h in raw_history
+        ]
 
         item = {
             "id": data.get("id"),
@@ -791,6 +832,7 @@ async def get_shopping_list_entity(item_id: str, auth: dict = Depends(get_authen
             "yacht_id": data.get("yacht_id"),
             "attachments": [],
             "related_entities": nav,
+            "audit_history": audit_history,
         }
         _entity_response["available_actions"] = get_available_actions(
             "shopping_list", _entity_response, auth.get("role", "crew")

--- a/apps/api/routes/p0_actions_routes.py
+++ b/apps/api/routes/p0_actions_routes.py
@@ -909,6 +909,7 @@ async def execute_action(
         "reject_shopping_list_item": ["item_id", "rejection_reason"],
         "promote_candidate_to_part": ["item_id"],
         "view_shopping_list_history": ["item_id"],
+        "mark_shopping_list_ordered": ["item_id"],
     }
 
     if action in REQUIRED_FIELDS:

--- a/apps/web/src/components/lens-v2/entity/ShoppingListContent.tsx
+++ b/apps/web/src/components/lens-v2/entity/ShoppingListContent.tsx
@@ -202,8 +202,21 @@ export function ShoppingListContent() {
     }));
 
   // ── Lifecycle steps ──────────────────────────────────────────────────────────
-  const LIFECYCLE = ['candidate', 'under_review', 'approved', 'ordered', 'fulfilled'] as const;
-  const currentIdx = LIFECYCLE.indexOf(status as typeof LIFECYCLE[number]);
+  // Happy-path statuses from pms_shopping_list_items.status (live DB enum).
+  // `rejected` is a terminal off-ramp rendered separately (see below).
+  const LIFECYCLE = [
+    'candidate',
+    'under_review',
+    'approved',
+    'ordered',
+    'partially_fulfilled',
+    'fulfilled',
+    'installed',
+  ] as const;
+  const isRejected = status === 'rejected';
+  const currentIdx = isRejected
+    ? -1
+    : LIFECYCLE.indexOf(status as typeof LIFECYCLE[number]);
 
   return (
     <>
@@ -226,49 +239,82 @@ export function ShoppingListContent() {
         }
       />
 
-      {/* Lifecycle progress */}
+      {/* Lifecycle progress — rejected items render a terminal banner instead */}
       <ScrollReveal>
-        <div style={{ display: 'flex', alignItems: 'flex-start', gap: 0, padding: '16px 0', marginBottom: 8 }}>
-          {LIFECYCLE.map((step, i) => {
-            const isCompleted = currentIdx >= 0 && i < currentIdx;
-            const isActive = i === currentIdx;
+        {isRejected ? (
+          <div style={{
+            display: 'flex', alignItems: 'center', gap: 12,
+            padding: '12px 16px', margin: '16px 0 8px',
+            borderRadius: 8,
+            background: 'var(--red-bg, rgba(220, 53, 69, 0.1))',
+            border: '1px solid var(--red, #dc3545)',
+          }}>
+            <div style={{
+              width: 10, height: 10, borderRadius: '50%',
+              background: 'var(--red, #dc3545)',
+              boxShadow: '0 0 0 4px var(--red-bg, rgba(220, 53, 69, 0.15))',
+              flexShrink: 0,
+            }} />
+            <div style={{ display: 'flex', flexDirection: 'column', gap: 2, minWidth: 0 }}>
+              <span style={{
+                fontSize: 11, fontWeight: 600, letterSpacing: '0.03em',
+                color: 'var(--red, #dc3545)', textTransform: 'uppercase',
+              }}>
+                Rejected
+              </span>
+              {rejectionReason && (
+                <span style={{
+                  fontSize: 12, color: 'var(--txt2, #bbb)', whiteSpace: 'nowrap',
+                  overflow: 'hidden', textOverflow: 'ellipsis',
+                }}>
+                  {rejectionReason}
+                </span>
+              )}
+            </div>
+          </div>
+        ) : (
+          <div style={{ display: 'flex', alignItems: 'flex-start', gap: 0, padding: '16px 0', marginBottom: 8 }}>
+            {LIFECYCLE.map((step, i) => {
+              const isCompleted = currentIdx >= 0 && i < currentIdx;
+              const isActive = i === currentIdx;
 
-            return (
-              <React.Fragment key={step}>
-                <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', flex: 1, minWidth: 0 }}>
-                  <div style={{
-                    width: isActive ? 12 : 10, height: isActive ? 12 : 10, borderRadius: '50%',
-                    background: isCompleted || isActive ? 'var(--green, #4caf50)' : 'none',
-                    border: `2px solid ${isCompleted || isActive ? 'var(--green, #4caf50)' : 'var(--txt-ghost, #666)'}`,
-                    boxShadow: isActive ? '0 0 0 4px var(--green-bg, rgba(76,175,80,0.15))' : 'none',
-                    display: 'flex', alignItems: 'center', justifyContent: 'center',
-                  }}>
-                    {isCompleted && (
-                      <svg width="8" height="8" viewBox="0 0 12 12" fill="none" stroke="#fff" strokeWidth="2" strokeLinecap="round">
-                        <polyline points="2.5 6 5 8.5 9.5 3.5" />
-                      </svg>
-                    )}
+              return (
+                <React.Fragment key={step}>
+                  <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', flex: 1, minWidth: 0 }}>
+                    <div style={{
+                      width: isActive ? 12 : 10, height: isActive ? 12 : 10, borderRadius: '50%',
+                      background: isCompleted || isActive ? 'var(--green, #4caf50)' : 'none',
+                      border: `2px solid ${isCompleted || isActive ? 'var(--green, #4caf50)' : 'var(--txt-ghost, #666)'}`,
+                      boxShadow: isActive ? '0 0 0 4px var(--green-bg, rgba(76,175,80,0.15))' : 'none',
+                      display: 'flex', alignItems: 'center', justifyContent: 'center',
+                    }}>
+                      {isCompleted && (
+                        <svg width="8" height="8" viewBox="0 0 12 12" fill="none" stroke="#fff" strokeWidth="2" strokeLinecap="round">
+                          <polyline points="2.5 6 5 8.5 9.5 3.5" />
+                        </svg>
+                      )}
+                    </div>
+                    <span style={{
+                      fontSize: 10, fontWeight: isActive ? 600 : 500,
+                      letterSpacing: '0.03em',
+                      color: isActive ? 'var(--green, #4caf50)' : isCompleted ? 'var(--txt3, #999)' : 'var(--txt-ghost, #666)',
+                      marginTop: 8, textTransform: 'uppercase', whiteSpace: 'nowrap',
+                    }}>
+                      {fmt(step)}
+                    </span>
                   </div>
-                  <span style={{
-                    fontSize: 10, fontWeight: isActive ? 600 : 500,
-                    letterSpacing: '0.03em',
-                    color: isActive ? 'var(--green, #4caf50)' : isCompleted ? 'var(--txt3, #999)' : 'var(--txt-ghost, #666)',
-                    marginTop: 8, textTransform: 'uppercase', whiteSpace: 'nowrap',
-                  }}>
-                    {fmt(step)}
-                  </span>
-                </div>
-                {i < LIFECYCLE.length - 1 && (
-                  <div style={{
-                    flex: 1, height: 2,
-                    background: isCompleted ? 'var(--green, #4caf50)' : 'var(--border-sub, #444)',
-                    alignSelf: 'flex-start', marginTop: isActive ? 6 : 5, minWidth: 8,
-                  }} />
-                )}
-              </React.Fragment>
-            );
-          })}
-        </div>
+                  {i < LIFECYCLE.length - 1 && (
+                    <div style={{
+                      flex: 1, height: 2,
+                      background: isCompleted ? 'var(--green, #4caf50)' : 'var(--border-sub, #444)',
+                      alignSelf: 'flex-start', marginTop: isActive ? 6 : 5, minWidth: 8,
+                    }} />
+                  )}
+                </React.Fragment>
+              );
+            })}
+          </div>
+        )}
       </ScrollReveal>
 
       {/* Item detail KV rows */}


### PR DESCRIPTION
## Summary

Executes the four follow-ups flagged in [`docs/ongoing_work/shopping list/SHOPPING_LIST_AUDIT.md §6`](../blob/main/docs/ongoing_work/shopping%20list/SHOPPING_LIST_AUDIT.md). Each was traced to a specific file:line in the audit and is closed here.

## 1 — Hide 6 legacy list-level actions from the UI

`_SHOPPING_LIST_HIDDEN_ACTIONS` set in `apps/api/action_router/entity_actions.py` filters `approve_list`, `add_list_item`, `archive_list`, `delete_list`, `convert_to_po`, `submit_list` out of `get_available_actions` when `entity_type='shopping_list'`.
- Registry entries + handlers are kept so any programmatic caller still works.
- Verified via Python REPL: captain on shopping_list entity no longer sees these 6.

## 2 — Register `mark_shopping_list_ordered` in ACTION_REGISTRY

Handler has lived at `routes/handlers/shopping_handler.py:213` since Phase 4 and was already in `SHOP_HANDLERS`, but the missing `ActionDefinition` meant `get_available_actions` never surfaced it → UI could not trigger the approved → ordered transition.

Added:
- Full `ActionDefinition` in `registry.py` (roles mirror handler's `_MARK_ORDERED_ROLES`: `chief_engineer / captain / manager`)
- `REQUIRED_FIELDS["mark_shopping_list_ordered"] = ["item_id"]` in `p0_actions_routes.py`
- State gate in `entity_actions.py`: disabled unless `status == 'approved'`; also disabled for terminal statuses (`rejected / fulfilled / installed`) along with approve / reject / promote_candidate, with a human-readable reason.

## 3 — Surface `pms_shopping_list_state_history` as `audit_history`

`entity_routes.py` shopping_list endpoint now:
1. Fetches state-history rows ordered by `changed_at`.
2. Batches the profile lookup — requester, approver, and every actor in the history resolved in **one** `auth_users_profiles` query (no N+1).
3. Projects rows into `{action, actor, timestamp}` to match the shape `ShoppingListContent.tsx:158-163` already reads.
4. Fail-soft: empty array on DB error, preserving prior behavior.

Event label format: `"previous_state → new_state"` or `"Status: new_state"` if first entry, with `transition_reason` appended when different.

## 4 — Extend lifecycle stepper

`ShoppingListContent.tsx` `LIFECYCLE` now covers all 7 happy-path statuses:
`candidate → under_review → approved → ordered → partially_fulfilled → fulfilled → installed`

`rejected` renders a distinct terminal red banner with the rejection reason, instead of a stepper where `currentIdx = -1` and no step rendered active.

All styling uses existing design tokens (`--red`, `--red-bg`, `--green`, `--txt-ghost`, `--border-sub`).

## Test plan

- [x] `tsc --noEmit` clean for shopping-list files
- [x] Python smoke: `mark_shopping_list_ordered` registers; hidden set filters 6 legacy actions; state gate disables correctly on `rejected`
- [ ] Production: `/shopping-list/<approved-item>` — dropdown shows "Mark as Ordered"; primary/approve disables; clicking Mark as Ordered transitions to `ordered`
- [ ] Production: `/shopping-list/<rejected-item>` — lifecycle shows red banner with reason; action dropdown shows all mutate actions as disabled
- [ ] Production: `/shopping-list/<any-item>` — audit trail section shows state-change events from history table

## Blast radius

All changes are entity-type gated to `shopping_list`:
- `entity_actions.py` hidden set + state gate — only touches shopping_list branch
- `registry.py` — only adds one new action; no existing entries modified
- `p0_actions_routes.py` — only adds one key to REQUIRED_FIELDS
- `entity_routes.py` — only the shopping_list endpoint is changed
- `ShoppingListContent.tsx` — lens-specific

No other domain's tests, routes, or behavior is affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)