### PR TITLE
hotfix(docker): unbreak /v1/entity/* — .dockerignore excluded apps/api/lib

### DIFF
--- a/apps/api/.dockerignore
+++ b/apps/api/.dockerignore
@@ -20,8 +20,14 @@ dist/
 downloads/
 eggs/
 .eggs/
-lib/
-lib64/
+# NOTE: `lib/` and `lib64/` removed 2026-04-23 — they came from the standard
+# Python .gitignore template and were meant to exclude venv directories. We
+# build the venv at `/opt/venv` inside the Dockerfile, so those patterns
+# never match anything REAL, but they DO silently exclude our source module
+# `apps/api/lib/` (user_resolver + future helpers). Leaving them in made the
+# entity lens routes 404 in production because `from lib.user_resolver import`
+# raised ModuleNotFoundError and the try/except in pipeline_service.py:485-491
+# swallowed it.
 parts/
 sdist/
 var/


### PR DESCRIPTION
## Summary

Production is returning 404 for every `/v1/entity/{type}/{id}` call (cert lens, doc lens, any other entity lens) since PR #663 merged. Root cause: `apps/api/.dockerignore` had `lib/` and `lib64/` from the standard Python .gitignore template. Those patterns never matched anything real (our venv lives at `/opt/venv`) but they silently excluded `apps/api/lib/user_resolver.py` — the helper module introduced by #663.

Runtime consequence:
1. Docker image built without `apps/api/lib/*`
2. `from lib.user_resolver import …` at `routes/entity_routes.py:23` raised `ModuleNotFoundError`
3. The `try/except` wrapper at `pipeline_service.py:485-491` logged `❌ Failed to register Entity lens routes` and kept the app up
4. FastAPI served `/v1/entity/…` as `{"detail":"Not Found"}` — the cert lens saw 404 and rendered Not Found

## Evidence

- Production `/version` confirms commit `a3f1b5df` (post-#663) is deployed
- Production `/openapi.json` contains only `/workers/health` — the entity router is missing
- Same test against both `backend.celeste7.ai` and `pipeline-core.int.celeste7.ai` — same outcome
- `git show a3f1b5df:apps/api/lib/user_resolver.py` shows the file IS in the commit, so it's a Docker-build problem, not a git problem
- Live DB confirms the "EPIRB Annual Test Certificate" row (id `44140346-65ce-44de-a905-0be7af23fd00`, yacht `85fe1119-…`, `is_seed=false`, `deleted_at=null`) is readable via service key — DB is fine, handler never runs

## Change

One file, 6 effective lines. Removed the `lib/` and `lib64/` ignores and added a block comment explaining why so no future cleanup PR reintroduces the trap.

No new modules, no new imports, no behaviour changes — only "entity routes actually ship now."

## Test plan

- [x] `grep lib apps/api/.dockerignore` shows only venv-adjacent entries removed
- [ ] Merge → Render auto-deploy
- [ ] After deploy: `curl https://backend.celeste7.ai/v1/entity/certificate/44140346-65ce-44de-a905-0be7af23fd00` should NOT return `{"detail":"Not Found"}` (should return 401/403 without auth, or 200 with auth)
- [ ] `/openapi.json` should return >1 path
- [ ] Frontend cert lens renders the EPIRB cert for captain

🤖 Generated with [Claude Code](https://claude.com/claude-code)