### PR TITLE
feat(certificates): rich filter panel — 12 fields + shared filter spec

### DIFF
--- a/apps/web/src/app/certificates/page.tsx
+++ b/apps/web/src/app/certificates/page.tsx
@@ -4,6 +4,7 @@ import * as React from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { useQueryClient } from '@tanstack/react-query';
 import { FilteredEntityList } from '@/features/entity-list/components/FilteredEntityList';
+import { CERTIFICATE_FILTERS } from '@/features/entity-list/types/filter-config';
 import { EntityDetailOverlay } from '@/features/entity-list/components/EntityDetailOverlay';
 import { EntityLensPage } from '@/components/lens-v2/EntityLensPage';
 import { CertificateContent } from '@/components/lens-v2/entity';
@@ -61,7 +62,9 @@ function certAdapter(c: Certificate): EntityListResult {
     id: c.id,
     type: c.domain === 'crew' ? 'pms_crew_certificates' : 'pms_vessel_certificates',
     title,
-    subtitle: `${c.certificate_type || ''} · ${c.issuing_authority || ''}`.replace(/^ · |· $/g, ''),
+    // Subtitle = issuing authority + expiry (no repetition with title / no double-rendered status).
+    // certificate_type is exposed via filter + pill, not repeated inline.
+    subtitle: [c.issuing_authority || null, c.expiry_date ? `Expires ${c.expiry_date}` : null].filter(Boolean).join(' · '),
     entityRef: c.certificate_number || (c.domain === 'crew' ? 'Crew' : 'Vessel'),
     status,
     statusVariant: c.status === 'expired' ? 'critical' : c.status === 'revoked' ? 'critical' : c.status === 'suspended' ? 'warning' : c.status === 'expiring_soon' ? 'warning' : c.status === 'superseded' ? 'cancelled' : c.status === 'valid' ? 'completed' : 'open',
@@ -300,31 +303,7 @@ function CertificatesPageContent() {
           table="v_certificates_enriched"
           columns="id,certificate_name,certificate_number,certificate_type,issuing_authority,issue_date,expiry_date,status,domain,person_name,created_at"
           adapter={certAdapter}
-          filterConfig={[
-            {
-              key: 'cert_domain',
-              label: 'Type',
-              type: 'select' as const,
-              options: [
-                { label: 'All', value: '' },
-                { label: 'Vessel', value: 'vessel' },
-                { label: 'Crew', value: 'crew' },
-              ],
-            },
-            {
-              key: 'status',
-              label: 'Status',
-              type: 'select' as const,
-              options: [
-                { label: 'All', value: '' },
-                { label: 'Valid', value: 'valid' },
-                { label: 'Expired', value: 'expired' },
-                { label: 'Revoked', value: 'revoked' },
-                { label: 'Superseded', value: 'superseded' },
-                { label: 'Suspended', value: 'suspended' },
-              ],
-            },
-          ]}
+          filterConfig={CERTIFICATE_FILTERS}
           selectedId={selectedId}
           onSelect={handleSelect}
           emptyMessage="No certificates recorded"

--- a/apps/web/src/features/entity-list/types/filter-config.ts
+++ b/apps/web/src/features/entity-list/types/filter-config.ts
@@ -115,24 +115,145 @@ export const WORK_ORDER_FILTERS: FilterFieldConfig[] = [
   },
 ];
 
+/**
+ * CERTIFICATE_FILTERS — 2026-04-23 rich filter spec.
+ *
+ * Source of truth for every frontend-filterable column on
+ * `v_certificates_enriched` (UNION of pms_vessel_certificates +
+ * pms_crew_certificates). All keys must exist on that view.
+ *
+ * Filter-type rules (enforced by the framework):
+ *   - `text`         → server-side ILIKE '%input%' (substring match)
+ *   - `select`       → server-side `eq` on enum value
+ *   - `date-range`   → server-side `gte` + `lte` on a date/timestamp column
+ *
+ * UUID columns (id, yacht_id, document_id, person_node_id, created_by,
+ * deleted_by, import_session_id) are NEVER surfaced to users per CEO
+ * directive — they are backend scoping only.
+ *
+ * See: docs/ongoing_work/certificates/CERTIFICATE_FILTER_SPEC_2026_04_23.md
+ */
 export const CERTIFICATE_FILTERS: FilterFieldConfig[] = [
+  // ── Status & Priority ──────────────────────────────────────────────────
   {
     key: 'status',
     label: 'Status',
     type: 'select',
     options: [
       { value: 'valid', label: 'Valid' },
-      { value: 'expiring_soon', label: 'Expiring Soon' },
       { value: 'expired', label: 'Expired' },
+      { value: 'suspended', label: 'Suspended' },
+      { value: 'revoked', label: 'Revoked' },
       { value: 'superseded', label: 'Superseded' },
     ],
     category: 'status-priority',
   },
   {
+    key: 'certificate_type',
+    label: 'Certificate Type',
+    type: 'select',
+    options: [
+      // Vessel cert types
+      { value: 'ISM', label: 'ISM' },
+      { value: 'ISPS', label: 'ISPS' },
+      { value: 'SOLAS', label: 'SOLAS' },
+      { value: 'MLC', label: 'MLC' },
+      { value: 'CLASS', label: 'Classification' },
+      { value: 'FLAG', label: 'Flag State' },
+      { value: 'LOAD_LINE', label: 'Load Line' },
+      { value: 'TONNAGE', label: 'Tonnage' },
+      { value: 'MARPOL', label: 'MARPOL' },
+      { value: 'IOPP', label: 'IOPP' },
+      { value: 'SEC', label: 'Security' },
+      { value: 'SRC', label: 'Safety Radio' },
+      { value: 'SCC', label: 'Safety Construction' },
+      // Crew cert types
+      { value: 'STCW', label: 'STCW' },
+      { value: 'ENG1', label: 'ENG1 Medical' },
+      { value: 'COC', label: 'Certificate of Competency' },
+      { value: 'GMDSS', label: 'GMDSS' },
+      { value: 'BST', label: 'Basic Safety Training' },
+      { value: 'PSC', label: 'Personal Survival Craft' },
+      { value: 'AFF', label: 'Advanced Fire Fighting' },
+      { value: 'MEDICAL_CARE', label: 'Medical Care' },
+    ],
+    category: 'status-priority',
+  },
+  {
+    key: 'domain',
+    label: 'Category',
+    type: 'select',
+    options: [
+      { value: 'vessel', label: 'Vessel Certificate' },
+      { value: 'crew', label: 'Crew Certificate' },
+    ],
+    category: 'status-priority',
+  },
+
+  // ── Dates & Deadlines ──────────────────────────────────────────────────
+  {
     key: 'expiry_date',
     label: 'Expiry Date',
     type: 'date-range',
     category: 'dates',
+  },
+  {
+    key: 'issue_date',
+    label: 'Issue Date',
+    type: 'date-range',
+    category: 'dates',
+  },
+  {
+    key: 'next_survey_due',
+    label: 'Next Survey Due',
+    type: 'date-range',
+    category: 'dates',
+  },
+  {
+    key: 'created_at',
+    label: 'Added to PMS',
+    type: 'date-range',
+    category: 'dates',
+  },
+
+  // ── Properties ─────────────────────────────────────────────────────────
+  {
+    key: 'certificate_name',
+    label: 'Name',
+    type: 'text',
+    placeholder: 'e.g. EPIRB, Load Line',
+    category: 'properties',
+  },
+  {
+    key: 'certificate_number',
+    label: 'Certificate No.',
+    type: 'text',
+    placeholder: 'e.g. EPT-2025',
+    category: 'properties',
+  },
+  {
+    key: 'issuing_authority',
+    label: 'Issuing Authority',
+    type: 'text',
+    placeholder: 'e.g. MCA, Lloyd’s, DNV',
+    category: 'properties',
+  },
+  {
+    key: 'person_name',
+    label: 'Crew Member',
+    type: 'text',
+    placeholder: 'Filter crew certs by person',
+    category: 'properties',
+  },
+  {
+    key: 'source',
+    label: 'Source',
+    type: 'select',
+    options: [
+      { value: 'manual', label: 'Manual entry' },
+      { value: 'imported', label: 'Bulk imported' },
+    ],
+    category: 'properties',
   },
 ];
 


### PR DESCRIPTION
## Summary

Addresses CEO note — "your lens has weak, if not 0 filtration options" and title repetition on list rows.

- `CERTIFICATE_FILTERS` grows from 2 fields to **12**, across types `select`, `date-range`, `text` (ILIKE) and categories status-priority, dates, properties.
- `certificates/page.tsx` drops inline `filterConfig={[…]}` and imports `CERTIFICATE_FILTERS` from `filter-config.ts`.
- List-row subtitle no longer repeats certificate_type. Status stays on the pill only.
- Universal filter-panel contract captured in `/docs/ongoing_work/certificates/CERTIFICATE_FILTER_SPEC_2026_04_23.md` — shared with RECEIVING05 / DOCUMENTS04 / PURCHASE05 / SHOPPING05 / WARRANTY04.

## Filters added

| Category | Keys |
|---|---|
| Status & Priority | `status`, `certificate_type`, `domain` |
| Dates & Deadlines | `expiry_date`, `issue_date`, `next_survey_due`, `created_at` |
| Properties | `certificate_name`, `certificate_number`, `issuing_authority`, `person_name`, `source` |

Every key verified against live `\d v_certificates_enriched`.

## Security

- No UUID filters, no JSON-blob filters, no audit-lifecycle filters.
- Allowlist model — framework iterates `filterConfig` only.
- Parameterised via Supabase JS client. RLS + yacht scope applied before filter runs.

## Styling

Zero hardcoded styles. FilterBar + FilterPanel already consume tokens.

## Test plan
- [x] `npm run typecheck` clean
- [x] Every filter key exists on `v_certificates_enriched`
- [ ] Manual: open /certificates, verify enriched filter bar, ILIKE text search, date range, cert_type select
- [ ] Verify row subtitle no longer shows duplicate cert_type

🤖 Generated with [Claude Code](https://claude.com/claude-code)