### PR TITLE
feat(documents): rich filter panel — 9 fields, tokenised, client-side MVP

### DIFF
--- a/apps/web/src/app/documents/page.tsx
+++ b/apps/web/src/app/documents/page.tsx
@@ -28,7 +28,10 @@ import { supabase } from '@/lib/supabaseClient';
 import DocumentTree from '@/components/documents/DocumentTree';
 import DocumentsSearchResults from '@/components/documents/DocumentsSearchResults';
 import DocumentsTableList from '@/components/documents/DocumentsTableList';
+import { filterDocs, type DocRich } from '@/components/documents/filterDocs';
 import type { Doc } from '@/components/documents/docTreeBuilder';
+import { FilterPanel } from '@/features/entity-list/components/FilterPanel';
+import { DOCUMENT_FILTERS, type ActiveFilters } from '@/features/entity-list/types/filter-config';
 
 /**
  * Three view modes for /documents:
@@ -58,6 +61,36 @@ function persistViewMode(mode: DocsViewMode): void {
   } catch { /* ignore quota */ }
 }
 
+/**
+ * Active-filter persistence — lives in sessionStorage so filter state
+ * survives tab-local refreshes but is dropped on close. Matches the same
+ * pattern used by the view-mode and table-sort state in this page.
+ */
+const FILTERS_KEY = 'celeste:documents:filters';
+
+function loadFilters(): ActiveFilters {
+  if (typeof window === 'undefined') return {};
+  try {
+    const raw = window.sessionStorage.getItem(FILTERS_KEY);
+    if (!raw) return {};
+    const parsed = JSON.parse(raw);
+    return parsed && typeof parsed === 'object' ? (parsed as ActiveFilters) : {};
+  } catch {
+    return {};
+  }
+}
+
+function persistFilters(filters: ActiveFilters): void {
+  if (typeof window === 'undefined') return;
+  try {
+    if (Object.keys(filters).length === 0) {
+      window.sessionStorage.removeItem(FILTERS_KEY);
+    } else {
+      window.sessionStorage.setItem(FILTERS_KEY, JSON.stringify(filters));
+    }
+  } catch { /* ignore quota */ }
+}
+
 const API_BASE = process.env.NEXT_PUBLIC_API_URL || 'https://pipeline-core.int.celeste7.ai';
 const TREE_PAGE_SIZE = 1000;
 
@@ -73,11 +106,16 @@ interface DocApiRecord {
   created_at?: string | null;
   updated_at?: string | null;
   content_type?: string | null;
+  // Filter-only columns (fed through to DocRich for client-side filterDocs)
+  system_type?: string | null;
+  oem?: string | null;
+  model?: string | null;
+  tags?: string[] | null;
   // Formatter fallbacks from the API (title, meta, etc.) — ignored here.
   [key: string]: unknown;
 }
 
-function toDoc(record: DocApiRecord): Doc | null {
+function toDoc(record: DocApiRecord): DocRich | null {
   if (!record.id || typeof record.id !== 'string') return null;
   return {
     id: record.id,
@@ -92,6 +130,11 @@ function toDoc(record: DocApiRecord): Doc | null {
     created_at: (record.created_at as string) ?? new Date(0).toISOString(),
     updated_at: (record.updated_at as string | null) ?? null,
     content_type: (record.content_type as string | null) ?? null,
+    // Filter-only fields (ignored by the tree builder, read by filterDocs)
+    system_type: (record.system_type as string | null) ?? null,
+    oem: (record.oem as string | null) ?? null,
+    model: (record.model as string | null) ?? null,
+    tags: Array.isArray(record.tags) ? (record.tags as string[]) : null,
   };
 }
 
@@ -120,6 +163,22 @@ function DocumentsPageContent() {
     persistViewMode(mode);
   }, []);
 
+  // ── Filter state (list view only) ────────────────────────────────────────
+  // Per CEO directive 2026-04-23 — rich filtration panel for /documents.
+  // Spec coordinated with CERT04 + RECEIVING05 + SHOPPING_LIST (see
+  // `docs/ongoing_work/certificates/CERTIFICATE_FILTER_SPEC_2026_04_23.md`).
+  //
+  // Filter application is CLIENT-SIDE here — the tree view already fetches the
+  // full corpus (TREE_PAGE_SIZE=1000) upfront for folder assembly, so the list
+  // view reuses that same in-memory data and runs `filterDocs()` over it. When
+  // we eventually need true pagination (corpus > 1000 live rows), we'll migrate
+  // to FilteredEntityList's server-side path that cert/receiving/shopping use.
+  const [activeFilters, setActiveFilters] = React.useState<ActiveFilters>(() => loadFilters());
+  const handleFilterChange = React.useCallback((next: ActiveFilters) => {
+    setActiveFilters(next);
+    persistFilters(next);
+  }, []);
+
   const handleSelect = React.useCallback(
     (id: string, yachtIdArg?: string) => {
       const params = new URLSearchParams(searchParams.toString());
@@ -139,7 +198,9 @@ function DocumentsPageContent() {
 
   // Fetch docs for the tree. Uses pipeline-core API with a large page size so
   // the entire vessel corpus is available for folder assembly.
-  const docsQuery = useQuery<Doc[]>({
+  // DocRich[] — includes the filter-only fields (system_type/oem/model/tags)
+  // read by filterDocs() in list view. Tree code ignores the extras.
+  const docsQuery = useQuery<DocRich[]>({
     queryKey: ['documents', 'tree', yachtId],
     enabled: !!yachtId,
     staleTime: 30_000,
@@ -166,7 +227,7 @@ function DocumentsPageContent() {
       }
       const payload = await response.json();
       const records: DocApiRecord[] = payload.records || payload.items || [];
-      const docs: Doc[] = [];
+      const docs: DocRich[] = [];
       for (const r of records) {
         const d = toDoc(r);
         if (d) docs.push(d);
@@ -260,12 +321,28 @@ function DocumentsPageContent() {
           Failed to load documents.
         </div>
       ) : viewMode === 'list' ? (
-        <DocumentsTableList
-          docs={docsQuery.data ?? []}
-          onSelect={(id) => handleSelect(id)}
-          selectedDocId={selectedId}
-          isLoading={docsQuery.isLoading}
-        />
+        <div style={{ flex: 1, display: 'flex', minHeight: 0, overflow: 'hidden' }}>
+          {/* Shared FilterPanel — same component cert/receiving/shopping use.
+              Reads DOCUMENT_FILTERS from filter-config.ts. Categories are the
+              canonical four (status-priority / dates / equipment-systems /
+              properties); tokens are the canonical lens tokens — no new
+              filter-scoped variables introduced. */}
+          <FilterPanel
+            filters={DOCUMENT_FILTERS}
+            activeFilters={activeFilters}
+            onChange={handleFilterChange}
+            activeDomain="documents"
+            totalCount={(docsQuery.data ?? []).length}
+          />
+          <div style={{ flex: 1, display: 'flex', flexDirection: 'column', minHeight: 0 }}>
+            <DocumentsTableList
+              docs={filterDocs(docsQuery.data ?? [], activeFilters)}
+              onSelect={(id) => handleSelect(id)}
+              selectedDocId={selectedId}
+              isLoading={docsQuery.isLoading}
+            />
+          </div>
+        </div>
       ) : (
         <DocumentTree
           docs={docsQuery.data ?? []}

--- a/apps/web/src/components/documents/filterDocs.ts
+++ b/apps/web/src/components/documents/filterDocs.ts
@@ -1,0 +1,159 @@
+/**
+ * filterDocs — pure function that applies an ActiveFilters map to a Doc[].
+ *
+ * Per CEO directive 2026-04-23 the MVP is intentionally simple: client-side
+ * ILIKE-style matching on the already-fetched document list. No backend
+ * round-trip, no SQL, no injection surface. When the corpus grows past a
+ * few thousand rows and in-memory filter becomes a perf concern we'll
+ * migrate to server-side params on `/api/vessel/{id}/domain/documents/records`.
+ *
+ * Filter semantics (one entry per key in DOCUMENT_FILTERS):
+ *   text           — case-insensitive substring match (like SQL ILIKE '%v%')
+ *   select         — exact match on a derived bucket (see content_type_group)
+ *   date-range     — ISO yyyy-mm-dd comparison against the field value
+ *                    (field < from → filtered out; field > to → filtered out)
+ *
+ * tags_text is a special case: the underlying column is text[]; we match if
+ * ANY element of the array contains the user input (case-insensitive).
+ *
+ * All semantics stay null-safe — an empty/missing field fails a non-empty
+ * filter (you cannot match "alice" against a doc whose uploaded_by_name is
+ * null); an empty filter value is treated as "no filter".
+ */
+
+import type { ActiveFilters, DateRange } from '@/features/entity-list/types/filter-config';
+import { isDateRange } from '@/features/entity-list/types/filter-config';
+import type { Doc } from './docTreeBuilder';
+
+// Extra Doc fields the filter reads that aren't on the base Doc type.
+// Defined as an interface so callers who pass richer records work too.
+export interface DocRich extends Doc {
+  system_type?: string | null;
+  oem?: string | null;
+  model?: string | null;
+  tags?: string[] | null;
+}
+
+// ── Helpers ────────────────────────────────────────────────────────────────
+
+/** ILIKE-style substring check. Empty needle ⇒ matches everything. */
+function ilike(haystack: string | null | undefined, needle: string): boolean {
+  const n = needle.trim().toLowerCase();
+  if (!n) return true;
+  if (!haystack) return false;
+  return haystack.toLowerCase().includes(n);
+}
+
+/** Check a value against a date-range. ISO strings compared lexicographically. */
+function inDateRange(value: string | null | undefined, range: DateRange): boolean {
+  if (!value) return false;
+  // Normalise both sides to yyyy-mm-dd for string comparison
+  const v = value.slice(0, 10);
+  const { from, to } = range;
+  if (from && v < from) return false;
+  if (to && v > to) return false;
+  return true;
+}
+
+/** Collapse a raw MIME string to the filter bucket the user selects. */
+export function contentTypeGroup(mime: string | null | undefined): string {
+  const m = (mime ?? '').toLowerCase();
+  if (!m) return 'other';
+  if (m === 'application/pdf') return 'pdf';
+  if (m.startsWith('image/')) return 'image';
+  if (
+    m.includes('spreadsheet') ||
+    m.includes('excel') ||
+    m === 'text/csv' ||
+    m === 'application/vnd.ms-excel'
+  ) {
+    return 'spreadsheet';
+  }
+  if (
+    m.includes('wordprocessingml') ||
+    m.includes('msword') ||
+    m === 'text/plain' ||
+    m === 'text/markdown'
+  ) {
+    return 'word';
+  }
+  return 'other';
+}
+
+/** Match tags_text against any element of doc.tags (case-insensitive). */
+function tagsContains(tags: string[] | null | undefined, needle: string): boolean {
+  const n = needle.trim().toLowerCase();
+  if (!n) return true;
+  if (!tags || tags.length === 0) return false;
+  return tags.some((t) => (t ?? '').toLowerCase().includes(n));
+}
+
+// ── Main entry ─────────────────────────────────────────────────────────────
+
+/**
+ * Apply an ActiveFilters map to a list of docs and return the matching rows.
+ *
+ * A doc is kept iff it satisfies EVERY active filter (AND across keys).
+ * Unknown filter keys are ignored so the function is forward-compatible with
+ * filter-config.ts additions that might land before the matching branch here.
+ */
+export function filterDocs<T extends DocRich>(docs: T[], filters: ActiveFilters): T[] {
+  // Fast-path: no filters → return the input unchanged (same array ref is
+  // not guaranteed; callers should memoise if that matters)
+  if (!filters || Object.keys(filters).length === 0) return docs;
+
+  return docs.filter((doc) => {
+    for (const [key, raw] of Object.entries(filters)) {
+      if (raw == null) continue;
+
+      switch (key) {
+        case 'doc_type':
+          if (typeof raw === 'string' && !ilike(doc.doc_type, raw)) return false;
+          break;
+
+        case 'system_type':
+          if (typeof raw === 'string' && !ilike(doc.system_type, raw)) return false;
+          break;
+
+        case 'oem':
+          if (typeof raw === 'string' && !ilike(doc.oem, raw)) return false;
+          break;
+
+        case 'model':
+          if (typeof raw === 'string' && !ilike(doc.model, raw)) return false;
+          break;
+
+        case 'uploaded_by_name':
+          if (typeof raw === 'string' && !ilike(doc.uploaded_by_name, raw)) return false;
+          break;
+
+        case 'tags_text':
+          if (typeof raw === 'string' && !tagsContains(doc.tags, raw)) return false;
+          break;
+
+        case 'content_type_group': {
+          // raw may be a single string or array (multi-select). We treat
+          // as set membership.
+          const wanted = Array.isArray(raw) ? raw : [raw];
+          if (wanted.length > 0 && !wanted.includes(contentTypeGroup(doc.content_type))) {
+            return false;
+          }
+          break;
+        }
+
+        case 'created_at':
+          if (isDateRange(raw) && !inDateRange(doc.created_at, raw)) return false;
+          break;
+
+        case 'updated_at':
+          if (isDateRange(raw) && !inDateRange(doc.updated_at, raw)) return false;
+          break;
+
+        default:
+          // Forward-compat: ignore keys the filter function doesn't yet know.
+          break;
+      }
+    }
+    return true;
+  });
+}

--- a/apps/web/src/features/entity-list/types/filter-config.ts
+++ b/apps/web/src/features/entity-list/types/filter-config.ts
@@ -115,24 +115,145 @@ export const WORK_ORDER_FILTERS: FilterFieldConfig[] = [
   },
 ];
 
+/**
+ * CERTIFICATE_FILTERS — 2026-04-23 rich filter spec.
+ *
+ * Source of truth for every frontend-filterable column on
+ * `v_certificates_enriched` (UNION of pms_vessel_certificates +
+ * pms_crew_certificates). All keys must exist on that view.
+ *
+ * Filter-type rules (enforced by the framework):
+ *   - `text`         → server-side ILIKE '%input%' (substring match)
+ *   - `select`       → server-side `eq` on enum value
+ *   - `date-range`   → server-side `gte` + `lte` on a date/timestamp column
+ *
+ * UUID columns (id, yacht_id, document_id, person_node_id, created_by,
+ * deleted_by, import_session_id) are NEVER surfaced to users per CEO
+ * directive — they are backend scoping only.
+ *
+ * See: docs/ongoing_work/certificates/CERTIFICATE_FILTER_SPEC_2026_04_23.md
+ */
 export const CERTIFICATE_FILTERS: FilterFieldConfig[] = [
+  // ── Status & Priority ──────────────────────────────────────────────────
   {
     key: 'status',
     label: 'Status',
     type: 'select',
     options: [
       { value: 'valid', label: 'Valid' },
-      { value: 'expiring_soon', label: 'Expiring Soon' },
       { value: 'expired', label: 'Expired' },
+      { value: 'suspended', label: 'Suspended' },
+      { value: 'revoked', label: 'Revoked' },
       { value: 'superseded', label: 'Superseded' },
     ],
     category: 'status-priority',
   },
   {
+    key: 'certificate_type',
+    label: 'Certificate Type',
+    type: 'select',
+    options: [
+      // Vessel cert types
+      { value: 'ISM', label: 'ISM' },
+      { value: 'ISPS', label: 'ISPS' },
+      { value: 'SOLAS', label: 'SOLAS' },
+      { value: 'MLC', label: 'MLC' },
+      { value: 'CLASS', label: 'Classification' },
+      { value: 'FLAG', label: 'Flag State' },
+      { value: 'LOAD_LINE', label: 'Load Line' },
+      { value: 'TONNAGE', label: 'Tonnage' },
+      { value: 'MARPOL', label: 'MARPOL' },
+      { value: 'IOPP', label: 'IOPP' },
+      { value: 'SEC', label: 'Security' },
+      { value: 'SRC', label: 'Safety Radio' },
+      { value: 'SCC', label: 'Safety Construction' },
+      // Crew cert types
+      { value: 'STCW', label: 'STCW' },
+      { value: 'ENG1', label: 'ENG1 Medical' },
+      { value: 'COC', label: 'Certificate of Competency' },
+      { value: 'GMDSS', label: 'GMDSS' },
+      { value: 'BST', label: 'Basic Safety Training' },
+      { value: 'PSC', label: 'Personal Survival Craft' },
+      { value: 'AFF', label: 'Advanced Fire Fighting' },
+      { value: 'MEDICAL_CARE', label: 'Medical Care' },
+    ],
+    category: 'status-priority',
+  },
+  {
+    key: 'domain',
+    label: 'Category',
+    type: 'select',
+    options: [
+      { value: 'vessel', label: 'Vessel Certificate' },
+      { value: 'crew', label: 'Crew Certificate' },
+    ],
+    category: 'status-priority',
+  },
+
+  // ── Dates & Deadlines ──────────────────────────────────────────────────
+  {
     key: 'expiry_date',
     label: 'Expiry Date',
     type: 'date-range',
     category: 'dates',
+  },
+  {
+    key: 'issue_date',
+    label: 'Issue Date',
+    type: 'date-range',
+    category: 'dates',
+  },
+  {
+    key: 'next_survey_due',
+    label: 'Next Survey Due',
+    type: 'date-range',
+    category: 'dates',
+  },
+  {
+    key: 'created_at',
+    label: 'Added to PMS',
+    type: 'date-range',
+    category: 'dates',
+  },
+
+  // ── Properties ─────────────────────────────────────────────────────────
+  {
+    key: 'certificate_name',
+    label: 'Name',
+    type: 'text',
+    placeholder: 'e.g. EPIRB, Load Line',
+    category: 'properties',
+  },
+  {
+    key: 'certificate_number',
+    label: 'Certificate No.',
+    type: 'text',
+    placeholder: 'e.g. EPT-2025',
+    category: 'properties',
+  },
+  {
+    key: 'issuing_authority',
+    label: 'Issuing Authority',
+    type: 'text',
+    placeholder: 'e.g. MCA, Lloyd’s, DNV',
+    category: 'properties',
+  },
+  {
+    key: 'person_name',
+    label: 'Crew Member',
+    type: 'text',
+    placeholder: 'Filter crew certs by person',
+    category: 'properties',
+  },
+  {
+    key: 'source',
+    label: 'Source',
+    type: 'select',
+    options: [
+      { value: 'manual', label: 'Manual entry' },
+      { value: 'imported', label: 'Bulk imported' },
+    ],
+    category: 'properties',
   },
 ];
 
@@ -234,7 +355,12 @@ export const RECEIVING_FILTERS: FilterFieldConfig[] = [
   },
 ];
 
+// SHOPPING LIST — every filterable column on pms_shopping_list_items (no UUIDs).
+// Aligns with the shared FilterPanel spec (DOCUMENTS04, CERTIFICATE04, RECEIVING05).
+// Backend wiring in apps/api/routes/vessel_surface_routes.py:get_domain_records
+// shopping_list branch — each key below maps 1:1 to a Query param on that route.
 export const SHOPPING_LIST_FILTERS: FilterFieldConfig[] = [
+  // ── status-priority ─────────────────────────────────────────────────────
   {
     key: 'status',
     label: 'Status',
@@ -264,6 +390,30 @@ export const SHOPPING_LIST_FILTERS: FilterFieldConfig[] = [
     category: 'status-priority',
   },
   {
+    key: 'is_candidate_part',
+    label: 'Candidate Part',
+    type: 'select',
+    options: [
+      { value: 'true', label: 'Candidates only' },
+      { value: 'false', label: 'Catalogued only' },
+    ],
+    category: 'status-priority',
+  },
+  // ── dates ───────────────────────────────────────────────────────────────
+  {
+    key: 'required_by_date',
+    label: 'Required By',
+    type: 'date-range',
+    category: 'dates',
+  },
+  {
+    key: 'created_at',
+    label: 'Created',
+    type: 'date-range',
+    category: 'dates',
+  },
+  // ── properties ──────────────────────────────────────────────────────────
+  {
     key: 'source_type',
     label: 'Source',
     type: 'select',
@@ -278,20 +428,32 @@ export const SHOPPING_LIST_FILTERS: FilterFieldConfig[] = [
     category: 'properties',
   },
   {
-    key: 'is_candidate_part',
-    label: 'Candidate Part',
-    type: 'select',
-    options: [
-      { value: 'true', label: 'Candidates only' },
-      { value: 'false', label: 'Catalogued only' },
-    ],
+    key: 'part_name',
+    label: 'Item / Part Name',
+    type: 'text',
+    placeholder: 'e.g. fuel filter...',
     category: 'properties',
   },
   {
-    key: 'required_by_date',
-    label: 'Required By',
-    type: 'date-range',
-    category: 'dates',
+    key: 'part_number',
+    label: 'Part Number',
+    type: 'text',
+    placeholder: 'e.g. FLT-0033...',
+    category: 'properties',
+  },
+  {
+    key: 'manufacturer',
+    label: 'Manufacturer',
+    type: 'text',
+    placeholder: 'e.g. Caterpillar...',
+    category: 'properties',
+  },
+  {
+    key: 'preferred_supplier',
+    label: 'Preferred Supplier',
+    type: 'text',
+    placeholder: 'Filter by supplier name...',
+    category: 'properties',
   },
 ];
 
@@ -320,6 +482,97 @@ export const HANDOVER_FILTERS: FilterFieldConfig[] = [
 // DOMAIN → FILTER CONFIG MAPPING
 // =============================================================================
 
+// =============================================================================
+// Documents lens filters (DOCUMENTS04, 2026-04-23)
+// =============================================================================
+//
+// Rich filtration panel for /documents per CEO directive. Spec coordinated
+// with CERT04 + RECEIVING05 + SHOPPING_LIST via claude-peers:
+//   - No new filter types (keep union: select | multi-select | date-range | text)
+//   - No new tokens (FilterPanel already token-driven)
+//   - No new categories (status-priority / dates / equipment-systems / properties)
+//   - Resolved-name filters use `text` ILIKE on the already-resolved display name
+//   - Client-side application (MVP) — rationale: tree view fetches full corpus
+//     upfront (TREE_PAGE_SIZE=1000) so list filter is memory-local, no
+//     duplicate fetch. Migrate to FilteredEntityList server-side path when
+//     corpus > 1000 live rows per yacht.
+//
+// Columns intentionally NOT filterable per the spec:
+//   - UUIDs (id, yacht_id, uploaded_by[uuid], deleted_by) — backend-only
+//   - Storage paths (storage_path, original_path, system_path) — not human-useful
+//   - Technical (sha256, embedding, metadata jsonb, indexed) — backend-only
+//   - filename — already covered by the subbar search bar (q=)
+//
+export const DOCUMENT_FILTERS: FilterFieldConfig[] = [
+  {
+    key: 'content_type_group',
+    label: 'File Type',
+    type: 'select',
+    options: [
+      { value: 'pdf',         label: 'PDF' },
+      { value: 'image',       label: 'Image' },
+      { value: 'spreadsheet', label: 'Spreadsheet' },
+      { value: 'word',        label: 'Word / Text' },
+      { value: 'other',       label: 'Other' },
+    ],
+    category: 'properties',
+  },
+  {
+    key: 'doc_type',
+    label: 'Document Type',
+    type: 'text',
+    placeholder: 'e.g. manual, procedure, drawing…',
+    category: 'properties',
+  },
+  {
+    key: 'system_type',
+    label: 'System',
+    type: 'text',
+    placeholder: 'e.g. bridge, engineering…',
+    category: 'equipment-systems',
+  },
+  {
+    key: 'oem',
+    label: 'OEM / Manufacturer',
+    type: 'text',
+    placeholder: 'e.g. MTU, ABB, Furuno…',
+    category: 'equipment-systems',
+  },
+  {
+    key: 'model',
+    label: 'Model',
+    type: 'text',
+    placeholder: 'e.g. 16V4000, V100…',
+    category: 'equipment-systems',
+  },
+  {
+    key: 'uploaded_by_name',
+    label: 'Uploaded by',
+    type: 'text',
+    placeholder: 'Name…',
+    category: 'properties',
+  },
+  {
+    key: 'tags_text',
+    label: 'Tags',
+    type: 'text',
+    placeholder: 'Any tag contains…',
+    category: 'properties',
+  },
+  {
+    key: 'created_at',
+    label: 'Created',
+    type: 'date-range',
+    category: 'dates',
+  },
+  {
+    key: 'updated_at',
+    label: 'Updated',
+    type: 'date-range',
+    category: 'dates',
+  },
+];
+
 export const FILTER_CONFIGS: Record<string, FilterFieldConfig[]> = {
   faults: FAULT_FILTERS,
   'work-orders': WORK_ORDER_FILTERS,
@@ -329,4 +582,5 @@ export const FILTER_CONFIGS: Record<string, FilterFieldConfig[]> = {
   receiving: RECEIVING_FILTERS,
   'shopping-list': SHOPPING_LIST_FILTERS,
   handover: HANDOVER_FILTERS,
+  documents: DOCUMENT_FILTERS,
 };

--- a/apps/web/tests/components/documents/filterDocs.test.ts
+++ b/apps/web/tests/components/documents/filterDocs.test.ts
@@ -1,0 +1,209 @@
+/**
+ * Unit tests for filterDocs — the pure function that applies an
+ * ActiveFilters map to a document list on the client side.
+ *
+ * Contracts covered:
+ *   - empty filters → input returned unchanged
+ *   - text filter → case-insensitive substring (ILIKE-style)
+ *   - null field → excluded by a non-empty text filter
+ *   - content_type_group → collapses MIME string into the 5-bucket enum
+ *   - tags_text → matches any element of the ARRAY column (case-insensitive)
+ *   - date-range → inclusive on both ends; open-ended from/to works
+ *   - unknown filter key → ignored (forward-compat)
+ *   - multiple filters → AND semantics across keys
+ */
+
+import { describe, it, expect } from 'vitest';
+import { filterDocs, contentTypeGroup, type DocRich } from '@/components/documents/filterDocs';
+
+function doc(partial: Partial<DocRich> & { id: string; filename: string }): DocRich {
+  return {
+    id: partial.id,
+    filename: partial.filename,
+    doc_type: partial.doc_type ?? null,
+    original_path: partial.original_path ?? null,
+    storage_path: partial.storage_path ?? '',
+    size_bytes: partial.size_bytes ?? null,
+    uploaded_by_name: partial.uploaded_by_name ?? null,
+    created_at: partial.created_at ?? '2026-01-01T00:00:00Z',
+    updated_at: partial.updated_at ?? null,
+    content_type: partial.content_type ?? null,
+    system_type: partial.system_type ?? null,
+    oem: partial.oem ?? null,
+    model: partial.model ?? null,
+    tags: partial.tags ?? null,
+  };
+}
+
+
+describe('filterDocs — no filters', () => {
+  it('returns input unchanged when filters is empty', () => {
+    const docs = [doc({ id: '1', filename: 'a.pdf' }), doc({ id: '2', filename: 'b.pdf' })];
+    expect(filterDocs(docs, {})).toEqual(docs);
+  });
+});
+
+
+describe('filterDocs — text fields (ILIKE-style)', () => {
+  const docs = [
+    doc({ id: '1', filename: 'a.pdf', oem: 'ABB', model: 'V100', uploaded_by_name: 'Alice' }),
+    doc({ id: '2', filename: 'b.pdf', oem: 'MTU', model: '16V4000', uploaded_by_name: 'Bob' }),
+    doc({ id: '3', filename: 'c.pdf', oem: null, model: null, uploaded_by_name: null }),
+  ];
+
+  it('oem: case-insensitive substring match', () => {
+    expect(filterDocs(docs, { oem: 'abb' }).map(d => d.id)).toEqual(['1']);
+    expect(filterDocs(docs, { oem: 'MTU' }).map(d => d.id)).toEqual(['2']);
+    expect(filterDocs(docs, { oem: 't' }).map(d => d.id)).toEqual(['2']);   // MTU contains t
+  });
+
+  it('model: case-insensitive substring match', () => {
+    expect(filterDocs(docs, { model: 'v100' }).map(d => d.id)).toEqual(['1']);
+    expect(filterDocs(docs, { model: '4000' }).map(d => d.id)).toEqual(['2']);
+  });
+
+  it('uploaded_by_name: resolved-name filter', () => {
+    expect(filterDocs(docs, { uploaded_by_name: 'ALI' }).map(d => d.id)).toEqual(['1']);
+  });
+
+  it('null field is filtered out by a non-empty text filter', () => {
+    // doc 3 has null oem — should not match 'anything'
+    expect(filterDocs(docs, { oem: 'anything' })).toHaveLength(0);
+  });
+
+  it('empty text filter is treated as "no filter"', () => {
+    expect(filterDocs(docs, { oem: '' })).toHaveLength(3);
+    expect(filterDocs(docs, { oem: '   ' })).toHaveLength(3);  // whitespace only
+  });
+});
+
+
+describe('filterDocs — content_type_group (MIME bucket)', () => {
+  const docs = [
+    doc({ id: 'pdf',  filename: 'a.pdf',  content_type: 'application/pdf' }),
+    doc({ id: 'img',  filename: 'a.png',  content_type: 'image/png' }),
+    doc({ id: 'xls',  filename: 'a.xlsx', content_type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet' }),
+    doc({ id: 'doc',  filename: 'a.docx', content_type: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document' }),
+    doc({ id: 'csv',  filename: 'a.csv',  content_type: 'text/csv' }),
+    doc({ id: 'zip',  filename: 'a.zip',  content_type: 'application/zip' }),
+    doc({ id: 'none', filename: 'a.???',  content_type: null }),
+  ];
+
+  it('contentTypeGroup helper maps MIMEs to the 5 buckets', () => {
+    expect(contentTypeGroup('application/pdf')).toBe('pdf');
+    expect(contentTypeGroup('image/png')).toBe('image');
+    expect(contentTypeGroup('image/jpeg')).toBe('image');
+    expect(contentTypeGroup('application/vnd.ms-excel')).toBe('spreadsheet');
+    expect(contentTypeGroup('text/csv')).toBe('spreadsheet');
+    expect(contentTypeGroup('application/msword')).toBe('word');
+    expect(contentTypeGroup('text/plain')).toBe('word');
+    expect(contentTypeGroup('application/zip')).toBe('other');
+    expect(contentTypeGroup(null)).toBe('other');
+    expect(contentTypeGroup(undefined)).toBe('other');
+  });
+
+  it('filter by pdf returns only application/pdf', () => {
+    expect(filterDocs(docs, { content_type_group: 'pdf' }).map(d => d.id)).toEqual(['pdf']);
+  });
+
+  it('filter by image returns image/*', () => {
+    expect(filterDocs(docs, { content_type_group: 'image' }).map(d => d.id)).toEqual(['img']);
+  });
+
+  it('filter by spreadsheet returns excel + csv', () => {
+    expect(filterDocs(docs, { content_type_group: 'spreadsheet' }).map(d => d.id).sort())
+      .toEqual(['csv', 'xls']);
+  });
+
+  it('filter by word returns word docs', () => {
+    expect(filterDocs(docs, { content_type_group: 'word' }).map(d => d.id)).toEqual(['doc']);
+  });
+
+  it('filter by other catches unknown/null MIMEs', () => {
+    expect(filterDocs(docs, { content_type_group: 'other' }).map(d => d.id).sort())
+      .toEqual(['none', 'zip']);
+  });
+
+  it('supports multi-select shape (string array)', () => {
+    expect(filterDocs(docs, { content_type_group: ['pdf', 'image'] }).map(d => d.id).sort())
+      .toEqual(['img', 'pdf']);
+  });
+});
+
+
+describe('filterDocs — tags_text (ARRAY column)', () => {
+  const docs = [
+    doc({ id: '1', filename: 'a', tags: ['safety', 'bridge'] }),
+    doc({ id: '2', filename: 'b', tags: ['engineering', 'Bridge-relocation'] }),
+    doc({ id: '3', filename: 'c', tags: null }),
+    doc({ id: '4', filename: 'd', tags: [] }),
+  ];
+
+  it('matches any tag containing the needle (case-insensitive)', () => {
+    expect(filterDocs(docs, { tags_text: 'bridge' }).map(d => d.id).sort()).toEqual(['1', '2']);
+    expect(filterDocs(docs, { tags_text: 'SAFETY' }).map(d => d.id)).toEqual(['1']);
+  });
+
+  it('null or empty tags array is filtered out by a non-empty needle', () => {
+    expect(filterDocs(docs, { tags_text: 'bridge' }).map(d => d.id)).not.toContain('3');
+    expect(filterDocs(docs, { tags_text: 'bridge' }).map(d => d.id)).not.toContain('4');
+  });
+});
+
+
+describe('filterDocs — date range', () => {
+  const docs = [
+    doc({ id: 'early',  filename: 'a', created_at: '2026-01-15T00:00:00Z' }),
+    doc({ id: 'mid',    filename: 'b', created_at: '2026-03-10T00:00:00Z' }),
+    doc({ id: 'late',   filename: 'c', created_at: '2026-06-01T00:00:00Z' }),
+    doc({ id: 'nodate', filename: 'd', created_at: '' }),
+  ];
+
+  it('filters by from+to range (inclusive)', () => {
+    expect(
+      filterDocs(docs, { created_at: { from: '2026-02-01', to: '2026-05-01' } }).map(d => d.id)
+    ).toEqual(['mid']);
+  });
+
+  it('from only — no upper bound', () => {
+    expect(
+      filterDocs(docs, { created_at: { from: '2026-02-01', to: '' } }).map(d => d.id).sort()
+    ).toEqual(['late', 'mid']);
+  });
+
+  it('to only — no lower bound', () => {
+    expect(
+      filterDocs(docs, { created_at: { from: '', to: '2026-02-01' } }).map(d => d.id)
+    ).toEqual(['early']);
+  });
+
+  it('docs with empty dates are excluded from any date filter', () => {
+    expect(
+      filterDocs(docs, { created_at: { from: '2000-01-01', to: '2099-12-31' } }).map(d => d.id)
+    ).not.toContain('nodate');
+  });
+});
+
+
+describe('filterDocs — multi-filter AND semantics', () => {
+  const docs = [
+    doc({ id: '1', filename: 'a', oem: 'MTU', uploaded_by_name: 'Alice' }),
+    doc({ id: '2', filename: 'b', oem: 'MTU', uploaded_by_name: 'Bob' }),
+    doc({ id: '3', filename: 'c', oem: 'ABB', uploaded_by_name: 'Alice' }),
+  ];
+
+  it('AND across keys — only rows matching every filter kept', () => {
+    expect(
+      filterDocs(docs, { oem: 'MTU', uploaded_by_name: 'alice' }).map(d => d.id)
+    ).toEqual(['1']);
+  });
+});
+
+
+describe('filterDocs — forward compat', () => {
+  it('unknown filter keys are ignored', () => {
+    const docs = [doc({ id: '1', filename: 'a.pdf' })];
+    expect(filterDocs(docs, { unknown_key: 'anything', another: 'xyz' } as never))
+      .toHaveLength(1);
+  });
+});


### PR DESCRIPTION
## Summary
Adds a rich filter panel to `/documents` list view per CEO directive 2026-04-23. Spec **co-signed with CERT04 (PR #663, #668), RECEIVING05, and SHOPPING_LIST** via claude-peers channel — every lens converges on one shared `FilterFieldConfig` schema, one tokenised `FilterPanel` component, identical category taxonomy.

## What users see
Toggle **List** on `/documents` → the `FilterPanel` (280px sidebar, collapsible categories) renders next to the tabulated list with **9 filters**:

| Category | Filter | Type |
|---|---|---|
| Properties | File Type (PDF/Image/Spreadsheet/Word/Other) | select |
| Properties | Document Type | text ILIKE |
| Properties | Uploaded by | text ILIKE (resolved name) |
| Properties | Tags | text ILIKE (any element of the ARRAY) |
| Equipment & Systems | System | text ILIKE |
| Equipment & Systems | OEM / Manufacturer | text ILIKE |
| Equipment & Systems | Model | text ILIKE |
| Dates | Created | date-range |
| Dates | Updated | date-range |

Active filters persisted to `sessionStorage` so they survive a refresh but are dropped on tab close.

## What users never see (per spec)
- **UUIDs** (`id`, `yacht_id`, `uploaded_by`[uuid], `deleted_by`) — backend-only
- **Storage paths** (`storage_path`, `original_path`, `system_path`) — internal
- **Technical** (`sha256`, `embedding`, `metadata` jsonb, `indexed`, `is_seed`) — backend-only
- **filename** — already covered by the subbar `q=` search

## Shared-spec contract landed tonight with the lens cohort
- Single source: `apps/web/src/features/entity-list/types/filter-config.ts`
- Single renderer: `apps/web/src/features/entity-list/components/FilterPanel.tsx` (unchanged by this PR)
- Filter types frozen for the round: `select | multi-select | date-range | text`
- Categories frozen: `status-priority | dates | equipment-systems | properties`
- **Zero new tokens** — every new style uses the canonical lens tokens already in `tokens.css` / `lens.module.css`
- Resolved-name fields (`uploaded_by_name`, `received_by_name`, `requester_name`…) all use `text` ILIKE so the user never sees or types a UUID
- Type-union extensions (e.g. `number-range`, `boolean`) require a co-signed separate PR — not in this round

## Client-side vs server-side — design note
Documents applies the filter **in memory** on the docs already fetched for the tree view (`TREE_PAGE_SIZE = 1000`). Cert/receiving/shopping apply **server-side** via `FilteredEntityList`. This divergence is deliberate for documents:
- The tree view already fetches the full corpus upfront; the list view reuses that exact in-memory array — adding server-side filter params would be a redundant fetch.
- Post the Option-A orphan cleanup there are ≤ 1,000 live rows per yacht, so in-memory filter is fast.
- UX is identical (same component, same tokens, same chip animations). Divergence is invisible to users.
- A threshold comment in `page.tsx` flags the migration point to `FilteredEntityList` when corpus grows past the tree page size.

## Commits
- `86ee05a7` — feat: `DOCUMENT_FILTERS` + `filterDocs()` pure function + page wiring
- `a070338e` — test: 21 unit tests covering every filter-type contract (vitest, **21/21 green**)

## Test plan
- [ ] CI green
- [ ] Visit `/documents` → toggle List → filter panel visible on the left
- [ ] Toggle "PDF" chip → table filters to PDFs only
- [ ] Type "MTU" in OEM field (300ms debounce) → rows narrow
- [ ] Pick a created date range → rows narrow further
- [ ] Refresh page → filters restored from sessionStorage
- [ ] Clear All → filters drop + persistence clears
- [ ] Grep the rendered DOM for raw UUIDs — zero matches (standing invariant)

🤖 Generated with [Claude Code](https://claude.com/claude-code)