### PR TITLE
fix(shopping-list): adapter reads ref + part_name (row-render contract)

### DIFF
--- a/apps/web/src/features/shopping-list/adapter.ts
+++ b/apps/web/src/features/shopping-list/adapter.ts
@@ -23,16 +23,42 @@ function fmt(str?: string): string {
   return str.replace(/_/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase());
 }
 
-export function shoppingListToListResult(item: ShoppingListItem): EntityListResult {
-  const statusDisplay = fmt(item.status) || 'Pending';
-  const urgency = item.urgency;
+/**
+ * Adapter input is a superset of ShoppingListItem — the backend
+ * (vessel_surface_routes._format_record shopping_list branch) emits two extra
+ * keys on every row:
+ *   - ref   — never empty (part_number || SL-<id6>); guarantees every row
+ *             takes the rich EntityRecordRow template via entityRef
+ *             (FilteredEntityList.tsx:260-289 switches on entityRef truthiness).
+ *   - part_name — real DB value; without this the adapter's
+ *             `item.part_name || 'Shopping List Item'` fallback collapsed
+ *             to the literal, hiding the real item name.
+ */
+type AdapterInput = ShoppingListItem & {
+  ref?: string;
+  part_name?: string;
+  requested_by_name?: string;
+};
+
+export function shoppingListToListResult(item: AdapterInput): EntityListResult {
   const qty = item.quantity_requested;
   const unit = item.unit || '';
   const qtyDisplay = qty != null ? `Qty ${qty}${unit ? ` ${unit}` : ''}` : '';
-  const candidateTag = item.is_candidate_part ? 'Candidate' : '';
 
-  const subtitleBits = [statusDisplay, qtyDisplay, urgency ? fmt(urgency) : '', candidateTag]
-    .filter(Boolean);
+  // Subtitle is line 2 under the title. Pill already shows status and the
+  // age column already shows the date — don't duplicate. Show: qty, urgency
+  // (only when non-default), candidate flag.
+  const urgencyLabel = item.urgency && item.urgency !== 'normal' ? fmt(item.urgency) : '';
+  const subtitleBits = [
+    qtyDisplay,
+    urgencyLabel,
+    item.is_candidate_part ? 'Candidate' : '',
+  ].filter(Boolean);
+
+  // entityRef must be truthy for the rich renderer to kick in. Backend
+  // always emits `ref` with SL-<id6> fallback; keep part_number as
+  // secondary fallback for any caller on the old shape.
+  const entityRef = item.ref || item.part_number || '';
 
   return {
     id: item.id,
@@ -42,7 +68,7 @@ export function shoppingListToListResult(item: ShoppingListItem): EntityListResu
     snippet: item.source_notes,
     metadata: {
       status: item.status,
-      urgency,
+      urgency: item.urgency,
       source_type: item.source_type,
       part_number: item.part_number,
       quantity_requested: qty,
@@ -53,9 +79,9 @@ export function shoppingListToListResult(item: ShoppingListItem): EntityListResu
     },
 
     // Extended fields for EntityRecordRow
-    entityRef: item.part_number || '',
+    entityRef,
     assignedTo: item.requested_by_name || undefined,
-    status: statusDisplay,
+    status: fmt(item.status) || 'Pending',
     statusVariant: slStatusVariant(item.status),
     severity: null,
     age: formatAge(item.created_at),


### PR DESCRIPTION
Closes B-01 + B-02 from [SHOPPING_LIST_AUDIT.md §6](../blob/main/docs/ongoing%20work/shopping%20list/SHOPPING_LIST_AUDIT.md).

## B-01 — legacy row template for items without part_number

`FilteredEntityList.tsx:260-289` switches row template on `item.entityRef` truthiness. Rich `EntityRecordRow` only kicks in when entityRef is non-empty. Adapter previously set `entityRef: item.part_number || ''`, and 10/12 live non-seed rows on the test yacht have `part_number=NULL` → empty string → legacy `SpotlightResultRow` (the "old interface" in the screenshot).

Fix: adapter now reads `item.ref || item.part_number`. Backend's `_format_record` shopping_list branch at `vessel_surface_routes.py:1135` already emits a non-empty `ref` (`part_number || SL-<id6>` fallback) — adapter just wasn't consuming it.

## B-02 — title always rendered literal 'Shopping List Item'

Backend now emits `part_name` explicitly at `vessel_surface_routes.py:1137`. Adapter reads `item.part_name`, but the typed input type was `ShoppingListItem` which didn't declare `part_name` on the formatted wire shape. The value came through in practice via JS spread but TypeScript didn't know about it.

Fix: typed `AdapterInput = ShoppingListItem & { ref?, part_name?, requested_by_name? }` so the `part_name || fallback` chain actually resolves to the real DB value. Verified against live DB: top-2 visible rows have `part_name='Fuel Filter Generator'` and should now render correctly.

## Lens metadata cleanup

Subtitle previously was `statusDisplay · qtyDisplay · urgency · candidateTag` — duplicated status (pill already shows it) and echoed "Candidate" twice. Now shows only qty + urgency (when non-default) + candidate flag.

## Test plan

- [ ] `/shopping-list` list view: all rows take the rich `EntityRecordRow` template (SL-xxxxx ref, status pill, date)
- [ ] Rows show real part_name (e.g. "Fuel Filter Generator"), not "Shopping List Item"
- [ ] Subtitle: `Qty 5 ea · High · Candidate` — no status/candidate repetition

Backend + filter-config changes already shipped in PR #670. This PR is adapter-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)