### PR TITLE
feat(receiving): rich filter backend + slim lens metadata + wide panel

### DIFF
--- a/apps/api/routes/vessel_surface_routes.py
+++ b/apps/api/routes/vessel_surface_routes.py
@@ -681,6 +681,11 @@ async def get_domain_records(
     preferred_supplier: Optional[str] = Query(None, description="Preferred supplier ilike (shopping_list)"),
     created_from: Optional[str] = Query(None, description="Created_at date from (YYYY-MM-DD, shopping_list)"),
     created_to: Optional[str] = Query(None, description="Created_at date to (YYYY-MM-DD, shopping_list)"),
+    # Receiving-specific filters (2026-04-23, RECEIVING05)
+    vendor_name: Optional[str] = Query(None, description="Vendor name ilike (receiving)"),
+    vendor_reference: Optional[str] = Query(None, description="Vendor reference ilike (receiving)"),
+    po_number: Optional[str] = Query(None, description="PO number ilike (receiving)"),
+    currency: Optional[str] = Query(None, description="Currency exact match (receiving)"),
     sort: Optional[str] = Query(None, description="Sort field"),
     limit: int = Query(50, ge=1, le=2000),
     offset: int = Query(0, ge=0),
@@ -775,6 +780,24 @@ async def get_domain_records(
                 query = query.ilike("manufacturer", f"%{manufacturer}%")
             if preferred_supplier:
                 query = query.ilike("preferred_supplier", f"%{preferred_supplier}%")
+
+        # Receiving-specific filters. Safe no-ops on any other domain.
+        # Each branch maps 1:1 to a key in RECEIVING_FILTERS on the frontend
+        # (apps/web/src/features/entity-list/types/filter-config.ts).
+        # ilike values are wrapped in %..% for substring match.
+        if domain == "receiving":
+            if vendor_name:
+                query = query.ilike("vendor_name", f"%{vendor_name}%")
+            if vendor_reference:
+                query = query.ilike("vendor_reference", f"%{vendor_reference}%")
+            if po_number:
+                query = query.ilike("po_number", f"%{po_number}%")
+            if currency:
+                query = query.eq("currency", currency)
+            if date_from:
+                query = query.gte("received_date", date_from)
+            if date_to:
+                query = query.lte("received_date", date_to)
 
         # Soft-delete filter — hide deleted records
         if domain in ("documents", "purchase_orders"):

--- a/apps/web/src/components/lens-v2/EntityLensPage.tsx
+++ b/apps/web/src/components/lens-v2/EntityLensPage.tsx
@@ -64,7 +64,7 @@ function ErrorState({ message, onRetry }: { message: string; onRetry: () => void
  * extra horizontal room per 2026-04-23 UX spec. Add here when a new lens
  * gains a LensFileViewer.
  */
-const WIDE_LENS_TYPES: Set<string> = new Set(['certificate', 'document']);
+const WIDE_LENS_TYPES: Set<string> = new Set(['certificate', 'document', 'receiving']);
 
 function NotFoundState({ entityType, onBack }: { entityType: EntityType; onBack: () => void }) {
   return (

--- a/apps/web/src/components/lens-v2/entity/ReceivingContent.tsx
+++ b/apps/web/src/components/lens-v2/entity/ReceivingContent.tsx
@@ -71,18 +71,25 @@ export function ReceivingContent() {
   const { entity, availableActions, executeAction, getAction, isLoading } = useEntityLensContext();
 
   // -- Extract entity fields --
+  // Identity rules — every value appears AT MOST once across the strip:
+  //   title    = vendor_name (or "Draft Receiving")
+  //   pills    = [status, item count, optional total/currency money line]
+  //   details  = vendor_reference, received_date, received_by NAME, vessel
+  //   context  = clickable PO link (no supplier echo)
+  // entity_routes.py:get_receiving_entity already resolves received_by UUID -> name.
   const payload = (entity?.payload as Record<string, unknown>) ?? {};
-  const receiving_number = (entity?.receiving_number ?? payload.receiving_number) as string | undefined;
-  const title = ((entity?.title ?? payload.title ?? entity?.description ?? payload.description) as string | undefined) ?? 'Receiving';
-  const status = ((entity?.status ?? payload.status) as string | undefined) ?? 'pending';
+  const status = ((entity?.status ?? payload.status) as string | undefined) ?? 'draft';
   const po_number = (entity?.po_number ?? payload.po_number) as string | undefined;
   const po_id = (entity?.po_id ?? payload.po_id) as string | undefined;
-  const supplier = (entity?.supplier ?? payload.supplier ?? entity?.vendor_name ?? payload.vendor_name) as string | undefined;
-  const supplier_ref = (entity?.supplier_ref ?? payload.supplier_ref ?? entity?.vendor_reference ?? payload.vendor_reference) as string | undefined;
-  const delivery_date = (entity?.delivery_date ?? payload.delivery_date ?? entity?.expected_date ?? payload.expected_date) as string | undefined;
+  const vendor_name = (entity?.vendor_name ?? payload.vendor_name ?? entity?.supplier ?? payload.supplier) as string | undefined;
+  const vendor_reference = (entity?.vendor_reference ?? payload.vendor_reference ?? entity?.supplier_ref ?? payload.supplier_ref) as string | undefined;
+  const received_date = (entity?.received_date ?? payload.received_date) as string | undefined;
   const received_by = (entity?.received_by ?? payload.received_by) as string | undefined;
-  const vessel = (entity?.vessel ?? payload.vessel ?? entity?.yacht_name ?? payload.yacht_name) as string | undefined;
+  const yacht_name = (entity?.yacht_name ?? payload.yacht_name ?? entity?.vessel ?? payload.vessel) as string | undefined;
+  const total = (entity?.total ?? payload.total) as number | undefined;
+  const currency = (entity?.currency ?? payload.currency) as string | undefined;
   const total_items = (entity?.total_items ?? payload.total_items) as number | undefined;
+  const title = vendor_name ?? 'Draft Receiving';
 
   // Section data
   const items = ((entity?.items ?? payload.items) as Array<Record<string, unknown>> | undefined) ?? [];
@@ -127,49 +134,39 @@ export function ReceivingContent() {
   if (itemCount > 0) {
     pills.push({ label: `${itemCount} Item${itemCount === 1 ? '' : 's'}`, variant: 'neutral' });
   }
+  if (typeof total === 'number' && total > 0) {
+    const money = currency ? `${currency} ${total.toFixed(2)}` : total.toFixed(2);
+    pills.push({ label: money, variant: 'neutral' });
+  }
 
   const details: DetailLine[] = [];
-  if (supplier) {
-    details.push({ label: 'Supplier', value: supplier });
+  if (vendor_reference) {
+    details.push({ label: 'Vendor Ref', value: vendor_reference, mono: true });
   }
-  if (supplier_ref) {
-    details.push({ label: 'Supplier Ref', value: supplier_ref, mono: true });
-  }
-  if (po_number) {
-    details.push({ label: 'PO Reference', value: po_number, mono: true });
-  }
-  if (delivery_date) {
-    details.push({ label: 'Expected', value: delivery_date, mono: true });
+  if (received_date) {
+    details.push({ label: 'Received', value: received_date, mono: true });
   }
   if (received_by) {
     details.push({ label: 'Received By', value: received_by });
   }
-  if (vessel) {
-    details.push({ label: 'Vessel', value: vessel });
+  if (yacht_name) {
+    details.push({ label: 'Vessel', value: yacht_name });
   }
 
-  // Context line
-  const contextParts: string[] = [];
-  if (supplier) contextParts.push(supplier);
-  const contextNode = (
+  // Context line — show only the PO link (no supplier echo; supplier IS the title above)
+  const contextNode = po_number ? (
     <>
-      {contextParts.join(' · ')}
-      {po_number && (
-        <>
-          {contextParts.length > 0 && ' · '}
-          PO Reference:{' '}
-          <span
-            className={styles.crewLink}
-            onClick={po_id ? () => router.push(getEntityRoute('purchase-orders' as Parameters<typeof getEntityRoute>[0], po_id)) : undefined}
-            role={po_id ? 'link' : undefined}
-            tabIndex={po_id ? 0 : undefined}
-          >
-            {po_number}
-          </span>
-        </>
-      )}
+      PO Reference:{' '}
+      <span
+        className={styles.crewLink}
+        onClick={po_id ? () => router.push(getEntityRoute('purchase-orders' as Parameters<typeof getEntityRoute>[0], po_id)) : undefined}
+        role={po_id ? 'link' : undefined}
+        tabIndex={po_id ? 0 : undefined}
+      >
+        {po_number}
+      </span>
     </>
-  );
+  ) : undefined;
 
   // -- Split button config --
   const primaryLabel = 'Confirm Receipt';
@@ -280,7 +277,6 @@ export function ReceivingContent() {
     <>
       {/* Identity Strip */}
       <IdentityStrip
-        overline={receiving_number}
         title={title}
         context={contextNode}
         pills={pills}

--- a/apps/web/src/features/receiving/adapter.ts
+++ b/apps/web/src/features/receiving/adapter.ts
@@ -33,7 +33,11 @@ export function receivingToListResult(item: ReceivingItem): EntityListResult {
     ? new Date(item.received_date).toLocaleDateString('en-GB', { day: 'numeric', month: 'short' })
     : '';
 
-  const subtitleParts: string[] = [statusDisplay];
+  // Subtitle shows context the row pill does NOT already render.
+  // Status is on the pill — don't repeat it. Vendor is the title — don't repeat it.
+  const vendorRef = (raw.vendor_reference as string | undefined) || '';
+  const subtitleParts: string[] = [];
+  if (vendorRef) subtitleParts.push(vendorRef);
   if (dateDisplay) subtitleParts.push(dateDisplay);
   if (poNum) subtitleParts.push(`PO ${poNum}`);
 


### PR DESCRIPTION
## Summary
- Backend filter wiring for the 4 new RECEIVING_FILTERS fields (vendor_name, vendor_reference, po_number, currency) — all ilike-based per CEO directive.
- Lens metadata cleanup — removes duplicated 'Supplier' detail (was the title), removes duplicated 'PO Reference' row (now just the linked context), removes broken 'Expected' row (no DB column).
- Adds 'receiving' to WIDE_LENS_TYPES — same wider-panel opt-in as cert/document.

## Backend (\`apps/api/routes/vessel_surface_routes.py\`)
4 new Query params + new \`if domain == \"receiving\":\` branch:
\`\`\`
vendor_name      → .ilike('vendor_name', %val%)
vendor_reference → .ilike('vendor_reference', %val%)
po_number        → .ilike('po_number', %val%)
currency         → .eq('currency', val)
date_from/to     → .gte/.lte('received_date', val)
\`\`\`

## Frontend
- \`ReceivingContent.tsx\` — slim IdentityStrip. Title = vendor_name. Pills = [status, items, total/currency]. Details = vendor_ref, received_date, received_by name, vessel.
- \`adapter.ts\` — subtitle drops status (already on pill).
- \`EntityLensPage.tsx\` — \`'receiving'\` added to \`WIDE_LENS_TYPES\`.

## Test plan
- [ ] Vercel preview: open /receiving, confirm pills + slim details (no Supplier row dup)
- [ ] Filter panel shows 6 fields; vendor name typed → list narrows
- [ ] Date-range filter narrows by received_date
- [ ] Currency select filters
- [ ] Detail panel uses wider 1120px width
- [ ] Existing actions (Confirm Receipt / Flag) still wired

## Coordination
Aligned via claude-peers with DOCUMENTS04, CERTIFICATE04, SHOPPING05, PURCHASE05. Shared FilterPanel spec, no new tokens.

Tabular-list pivot (CEO 2026-04-23 ~23:25Z) tracked separately — DOCUMENTS04 extracting \`EntityTableList\` first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)