### PR TITLE
feat(receiving): tabular columnar list view (EntityTableList opt-in)

### DIFF
--- a/apps/web/src/app/receiving/page.tsx
+++ b/apps/web/src/app/receiving/page.tsx
@@ -8,6 +8,7 @@ import { EntityLensPage } from '@/components/lens-v2/EntityLensPage';
 import { ReceivingContent } from '@/components/lens-v2/entity';
 import { RECEIVING_FILTERS } from '@/features/entity-list/types/filter-config';
 import { receivingToListResult } from '@/features/receiving/adapter';
+import { RECEIVING_COLUMNS } from '@/features/receiving/columns';
 import type { ReceivingItem } from '@/features/receiving/types';
 import lensStyles from '@/components/lens-v2/lens.module.css';
 
@@ -46,6 +47,7 @@ function ReceivingPageContent() {
         columns="id, vendor_name, vendor_reference, status, received_date, notes, po_number, created_at"
         adapter={receivingToListResult}
         filterConfig={RECEIVING_FILTERS}
+        tableColumns={RECEIVING_COLUMNS}
         selectedId={selectedId}
         onSelect={handleSelect}
         emptyMessage="No receiving records found"

--- a/apps/web/src/features/entity-list/components/FilteredEntityList.tsx
+++ b/apps/web/src/features/entity-list/components/FilteredEntityList.tsx
@@ -11,6 +11,7 @@ import { useSearchParams } from 'next/navigation';
 import { FilterPanel } from './FilterPanel';
 import SpotlightResultRow from '@/components/spotlight/SpotlightResultRow';
 import { EntityRecordRow, type RecordRowData } from './EntityRecordRow';
+import { EntityTableList, type EntityTableColumn } from './EntityTableList';
 import { EmptyState } from './EmptyState';
 import { useFilteredEntityList } from '../hooks/useFilteredEntityList';
 import type { FilterFieldConfig, ActiveFilters } from '../types/filter-config';
@@ -55,6 +56,13 @@ interface FilteredEntityListProps<T extends { id: string }> {
   sortBy?: string;
   /** Domain slug for FilterPanel (drives domain pills + presets) */
   domain?: string;
+  /**
+   * Optional opt-in: when provided, results render via the shared
+   * EntityTableList (tabulated columnar view, sortable headers) instead of
+   * the legacy SpotlightResultRow / EntityRecordRow cards.
+   * Per CEO directive 2026-04-23 — every lens migrates to columnar.
+   */
+  tableColumns?: EntityTableColumn<EntityListResult>[];
 }
 
 export function FilteredEntityList<T extends { id: string }>({
@@ -68,6 +76,7 @@ export function FilteredEntityList<T extends { id: string }>({
   emptyMessage,
   sortBy = 'created_at',
   domain,
+  tableColumns,
 }: FilteredEntityListProps<T>) {
   const searchParams = useSearchParams();
 
@@ -254,6 +263,27 @@ export function FilteredEntityList<T extends { id: string }>({
         >
           Clear filters
         </button>
+      </div>
+    );
+  } else if (tableColumns) {
+    // Columnar tabular view (CEO 2026-04-23). Sort, sticky header, keyboard
+    // nav, sessionStorage persistence — all in EntityTableList.
+    resultsContent = (
+      <div style={{ flex: 1, overflowY: 'auto' }}>
+        <EntityTableList
+          rows={items}
+          columns={tableColumns}
+          onSelect={(id, yachtId) => handleSelect(id, yachtId)}
+          selectedId={selectedId}
+          domain={activeDomain}
+          isLoading={false}
+        />
+        <div ref={loadMoreRef} style={{ height: 16 }} />
+        {isFetchingNextPage && (
+          <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', padding: 16 }}>
+            <div style={{ width: 20, height: 20, border: '2px solid var(--border-sub)', borderTopColor: 'var(--txt2)', borderRadius: '50%' }} className="animate-spin" />
+          </div>
+        )}
       </div>
     );
   } else {

--- a/apps/web/src/features/receiving/columns.tsx
+++ b/apps/web/src/features/receiving/columns.tsx
@@ -1,0 +1,129 @@
+/**
+ * RECEIVING_COLUMNS — column spec for the shared EntityTableList.
+ *
+ * One file per lens, matches the pattern from DOCUMENTS04
+ * (DOCUMENT_COLUMNS) per the spec at
+ * docs/ongoing_work/documents/ENTITY_TABLE_LIST_SPEC_2026-04-23.md.
+ *
+ * The accessors read from EntityListResult — that's what FilteredEntityList
+ * passes through after running each row through the per-lens adapter
+ * (`receivingToListResult` for us, see ./adapter.ts). Rich domain fields
+ * (vendor_name, po_number, received_date) live on `metadata` because
+ * EntityListResult only standardises a small set of top-level keys.
+ */
+
+import * as React from 'react';
+import type { EntityTableColumn } from '@/features/entity-list/components/EntityTableList';
+import type { EntityListResult } from '@/features/entity-list/types';
+
+// ── Helpers ────────────────────────────────────────────────────────────────
+
+function meta(row: EntityListResult, key: string): string {
+  const v = row.metadata?.[key];
+  return typeof v === 'string' && v.length > 0 ? v : '';
+}
+
+function formatDate(iso: string | null | undefined): string {
+  if (!iso) return '';
+  try {
+    const d = new Date(iso);
+    if (isNaN(d.getTime())) return '';
+    return d.toISOString().slice(0, 10);
+  } catch {
+    return '';
+  }
+}
+
+// Status pill — uses the same token map as EntityRecordRow's pill so the
+// tabular and card views render identically. No new tokens.
+function StatusPill({ row }: { row: EntityListResult }) {
+  const v = row.statusVariant || 'open';
+  const palette: Record<string, { bg: string; color: string; border: string }> = {
+    overdue:     { bg: 'var(--red-bg)',    color: 'var(--red)',     border: 'var(--red-border)' },
+    critical:    { bg: 'var(--red-bg)',    color: 'var(--red)',     border: 'var(--red-border)' },
+    due_soon:    { bg: 'var(--amber-bg)',  color: 'var(--amber)',   border: 'var(--amber-border)' },
+    warning:     { bg: 'var(--amber-bg)',  color: 'var(--amber)',   border: 'var(--amber-border)' },
+    expiring:    { bg: 'var(--amber-bg)',  color: 'var(--amber)',   border: 'var(--amber-border)' },
+    draft:       { bg: 'var(--amber-bg)',  color: 'var(--amber)',   border: 'var(--amber-border)' },
+    in_progress: { bg: 'var(--teal-bg)',   color: 'var(--mark)',    border: 'var(--mark-hover)' },
+    pending:     { bg: 'var(--teal-bg)',   color: 'var(--mark)',    border: 'var(--mark-hover)' },
+    completed:   { bg: 'var(--green-bg)',  color: 'var(--green)',   border: 'var(--green-border)' },
+    signed:      { bg: 'var(--green-bg)',  color: 'var(--green)',   border: 'var(--green-border)' },
+    open:        { bg: 'var(--status-neutral-bg)', color: 'var(--txt3)', border: 'var(--border-sub)' },
+    cancelled:   { bg: 'var(--status-neutral-bg)', color: 'var(--txt-ghost)', border: 'var(--border-faint)' },
+  };
+  const p = palette[v] || palette.open;
+  return (
+    <span
+      style={{
+        display: 'inline-flex',
+        alignItems: 'center',
+        height: 17,
+        padding: '0 5px',
+        borderRadius: 3,
+        fontSize: 8.5,
+        fontWeight: 600,
+        letterSpacing: '0.04em',
+        textTransform: 'uppercase',
+        whiteSpace: 'nowrap',
+        background: p.bg,
+        color: p.color,
+        border: `1px solid ${p.border}`,
+      }}
+    >
+      {row.status || '—'}
+    </span>
+  );
+}
+
+// ── Column spec ────────────────────────────────────────────────────────────
+
+export const RECEIVING_COLUMNS: EntityTableColumn<EntityListResult>[] = [
+  {
+    key: 'ref',
+    label: 'Ref',
+    accessor: (r) => r.entityRef || '',
+    mono: true,
+    minWidth: 100,
+  },
+  {
+    key: 'vendor',
+    label: 'Vendor',
+    // adapter sets title = vendor_name (or "Draft Receiving")
+    accessor: (r) => r.title || '',
+    minWidth: 200,
+    wrap: true,
+  },
+  {
+    key: 'po_number',
+    label: 'PO Number',
+    accessor: (r) => meta(r, 'po_number'),
+    sortAccessor: (r) => meta(r, 'po_number') || null,
+    mono: true,
+    minWidth: 120,
+  },
+  {
+    key: 'status',
+    label: 'Status',
+    accessor: (r) => r.status || '',
+    render: (r) => <StatusPill row={r} />,
+    minWidth: 110,
+  },
+  {
+    key: 'received_date',
+    label: 'Received',
+    accessor: (r) => formatDate(meta(r, 'received_date')),
+    sortAccessor: (r) => meta(r, 'received_date') || null,
+    mono: true,
+    minWidth: 110,
+  },
+  {
+    key: 'created_at',
+    label: 'Created',
+    accessor: (r) => formatDate(meta(r, 'created_at')),
+    sortAccessor: (r) => meta(r, 'created_at') || null,
+    mono: true,
+    minWidth: 110,
+    align: 'right',
+  },
+];


### PR DESCRIPTION
## Summary
Receiving lens list view migrates from card-style (SpotlightResultRow / EntityRecordRow) to **tabulated columnar view** with click-to-sort headers — per CEO directive 2026-04-23 ~23:25Z, mirrored from the SeaHub UX reference.

Built on the shared \`EntityTableList\` component from PR #673 (DOCUMENTS04). Receiving is the second lens to consume it.

## What ships
1. **\`apps/web/src/features/receiving/columns.tsx\`** — RECEIVING_COLUMNS spec:
   \`Ref | Vendor | PO Number | Status (pill) | Received | Created\`
   Each header is sortable. Status renders as the same token-coloured pill as the legacy card view. Null values sink to the bottom regardless of sort direction.

2. **\`apps/web/src/features/entity-list/components/FilteredEntityList.tsx\`** — adds optional \`tableColumns\` prop. When passed, results render via EntityTableList. When omitted, existing card behaviour is preserved — every other lens is unchanged. Other lens owners opt in the same way (just pass their *_COLUMNS).

3. **\`apps/web/src/app/receiving/page.tsx\`** — passes RECEIVING_COLUMNS. Filter panel logic + backend wiring unchanged.

## Test plan
- [ ] /receiving renders as a table with sticky header
- [ ] Click header → sort cycle: none → asc → desc → none
- [ ] Status column shows token-coloured pill (matches former card pill)
- [ ] Empty cells render em-dash, never empty
- [ ] Sort persists via sessionStorage \`celeste:receiving:sort\`
- [ ] Row click opens lens overlay (existing behaviour)
- [ ] Filter panel still functional (vendor / PO / received_date / etc.)
- [ ] No regressions on other lens lists (cards still render where tableColumns omitted)
- [ ] Mobile viewport still usable

## Coordination
- DOCUMENTS04 — shared EntityTableList consumed unchanged.
- CERTIFICATE04, SHOPPING05, PURCHASE05 — same pattern available; they wire when ready.

🤖 Generated with [Claude Code](https://claude.com/claude-code)