### PR TITLE
feat(receiving): business-rank sort for status column

### DIFF
--- a/apps/web/src/features/receiving/columns.tsx
+++ b/apps/web/src/features/receiving/columns.tsx
@@ -76,6 +76,24 @@ function StatusPill({ row }: { row: EntityListResult }) {
   );
 }
 
+// Business-rank sort for status. Ordering reflects the receiving lifecycle
+// (draft → in_review → accepted) so an asc sort puts rows in flow order.
+// rejected is the sad-path terminal — sinks to the bottom of asc (rank 99)
+// and rises to the top of desc (where the user is most likely scanning for
+// recently flagged issues). Pattern shared with SHOPPING05's STATUS_RANK.
+const STATUS_RANK: Record<string, number> = {
+  draft: 0,
+  in_review: 1,
+  accepted: 2,
+  rejected: 99,
+};
+function statusRank(row: EntityListResult): number | null {
+  const k = (row.metadata?.status as string | undefined) || row.status?.toLowerCase();
+  if (!k) return null;
+  const v = STATUS_RANK[k];
+  return typeof v === 'number' ? v : 50;
+}
+
 // ── Column spec ────────────────────────────────────────────────────────────
 
 export const RECEIVING_COLUMNS: EntityTableColumn<EntityListResult>[] = [
@@ -106,6 +124,7 @@ export const RECEIVING_COLUMNS: EntityTableColumn<EntityListResult>[] = [
     key: 'status',
     label: 'Status',
     accessor: (r) => r.status || '',
+    sortAccessor: statusRank, // business-flow order, not alphabetic
     render: (r) => <StatusPill row={r} />,
     minWidth: 110,
   },


### PR DESCRIPTION
## Summary
Receiving status column was sorting alphabetically (\`accepted < draft < in_review < rejected\`) — useless to humans. Adds a STATUS_RANK so the column sorts by lifecycle order:

\`\`\`
draft → in_review → accepted   (rank 0, 1, 2)
rejected                       (rank 99 — sad-path terminal)
\`\`\`

Asc puts rows in flow order. Desc surfaces recently-rejected rows at the top — what a user scanning for issues wants.

Pattern adopted from SHOPPING05's PR #675 (their STATUS_RANK on shopping urgency).

## Files
- \`apps/web/src/features/receiving/columns.tsx\` — adds STATUS_RANK constant + statusRank() helper, wires it as the status column's sortAccessor.

## Test plan
- [ ] /receiving renders unchanged at first load
- [ ] Click Status header asc → draft rows first, rejected at the bottom
- [ ] Click again (desc) → rejected at top, accepted near bottom
- [ ] Sort persists in sessionStorage \`celeste:receiving:sort\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)