### PR TITLE
feat(purchasing): tabulated list view — PURCHASE_ORDER_COLUMNS

### DIFF
--- a/apps/web/src/app/purchasing/page.tsx
+++ b/apps/web/src/app/purchasing/page.tsx
@@ -8,6 +8,7 @@ import { EntityLensPage } from '@/components/lens-v2/EntityLensPage';
 import { PurchaseOrderContent } from '@/components/lens-v2/entity';
 import lensStyles from '@/components/lens-v2/lens.module.css';
 import { PURCHASE_ORDER_FILTERS } from '@/features/entity-list/types/filter-config';
+import { PURCHASE_ORDER_COLUMNS } from '@/features/purchasing/columns';
 import type { EntityListResult } from '@/features/entity-list/types';
 
 interface PurchaseOrder {
@@ -57,6 +58,17 @@ function poAdapter(po: PurchaseOrder): EntityListResult {
     statusVariant: poStatusVariant(po.status),
     severity: null,
     age: po.ordered_at ? formatAge(po.ordered_at) : (po.created_at ? formatAge(po.created_at) : '\u2014'),
+    // Raw fields for PURCHASE_ORDER_COLUMNS (tabulated view). Matches the
+    // RECEIVING_COLUMNS pattern at apps/web/src/features/receiving/columns.tsx.
+    metadata: {
+      status: po.status || '',
+      supplier_name: po.supplier_name || '',
+      currency: po.currency || '',
+      total_amount: po.total_amount ?? null,
+      ordered_at: po.ordered_at || '',
+      received_at: po.received_at || '',
+      created_at: po.created_at || '',
+    },
   };
 }
 
@@ -103,6 +115,7 @@ function PurchasingPageContent() {
         columns="id, po_number, status, supplier_id, ordered_at, received_at, currency, created_at, updated_at"
         adapter={poAdapter}
         filterConfig={PURCHASE_ORDER_FILTERS}
+        tableColumns={PURCHASE_ORDER_COLUMNS}
         selectedId={selectedId}
         onSelect={handleSelect}
         emptyMessage="No purchase orders recorded"

--- a/apps/web/src/features/purchasing/columns.tsx
+++ b/apps/web/src/features/purchasing/columns.tsx
@@ -1,0 +1,162 @@
+/**
+ * PURCHASE_ORDER_COLUMNS — column spec for the shared EntityTableList.
+ *
+ * One file per lens, matches the pattern from DOCUMENTS04
+ * (DOCUMENT_COLUMNS) per the spec at
+ * docs/ongoing_work/documents/ENTITY_TABLE_LIST_SPEC_2026-04-23.md.
+ *
+ * Accessors read from EntityListResult — FilteredEntityList passes each
+ * row through poAdapter in apps/web/src/app/purchasing/page.tsx first.
+ * Domain-specific fields (supplier_name, currency, total_amount, ordered_at,
+ * received_at, expected_delivery) live on `metadata` because
+ * EntityListResult only standardises a small set of top-level keys.
+ */
+
+import * as React from 'react';
+import type { EntityTableColumn } from '@/features/entity-list/components/EntityTableList';
+import type { EntityListResult } from '@/features/entity-list/types';
+
+// ── Helpers ────────────────────────────────────────────────────────────────
+
+function meta(row: EntityListResult, key: string): string {
+  const v = row.metadata?.[key];
+  return typeof v === 'string' && v.length > 0 ? v : '';
+}
+
+function metaNumber(row: EntityListResult, key: string): number | null {
+  const v = row.metadata?.[key];
+  return typeof v === 'number' && !isNaN(v) ? v : null;
+}
+
+function formatDate(iso: string | null | undefined): string {
+  if (!iso) return '';
+  try {
+    const d = new Date(iso);
+    if (isNaN(d.getTime())) return '';
+    return d.toISOString().slice(0, 10);
+  } catch {
+    return '';
+  }
+}
+
+function formatAmount(row: EntityListResult): string {
+  const total = metaNumber(row, 'total_amount');
+  if (total == null) return '';
+  const currency = meta(row, 'currency') || 'USD';
+  const symbol = currency === 'EUR' ? '€' : currency === 'GBP' ? '£' : '$';
+  return `${symbol}${total.toLocaleString(undefined, {
+    minimumFractionDigits: 0,
+    maximumFractionDigits: 0,
+  })}`;
+}
+
+// Status pill — same palette as EntityRecordRow + receiving/columns.tsx so
+// tabular and card views render identically. Uses tokens only; no hard-coded
+// colours per CEO directive.
+function StatusPill({ row }: { row: EntityListResult }) {
+  const v = row.statusVariant || 'open';
+  const palette: Record<string, { bg: string; color: string; border: string }> = {
+    overdue:     { bg: 'var(--red-bg)',    color: 'var(--red)',     border: 'var(--red-border)' },
+    critical:    { bg: 'var(--red-bg)',    color: 'var(--red)',     border: 'var(--red-border)' },
+    due_soon:    { bg: 'var(--amber-bg)',  color: 'var(--amber)',   border: 'var(--amber-border)' },
+    warning:     { bg: 'var(--amber-bg)',  color: 'var(--amber)',   border: 'var(--amber-border)' },
+    expiring:    { bg: 'var(--amber-bg)',  color: 'var(--amber)',   border: 'var(--amber-border)' },
+    draft:       { bg: 'var(--amber-bg)',  color: 'var(--amber)',   border: 'var(--amber-border)' },
+    in_progress: { bg: 'var(--teal-bg)',   color: 'var(--mark)',    border: 'var(--mark-hover)' },
+    pending:     { bg: 'var(--teal-bg)',   color: 'var(--mark)',    border: 'var(--mark-hover)' },
+    completed:   { bg: 'var(--green-bg)',  color: 'var(--green)',   border: 'var(--green-border)' },
+    signed:      { bg: 'var(--green-bg)',  color: 'var(--green)',   border: 'var(--green-border)' },
+    open:        { bg: 'var(--status-neutral-bg)', color: 'var(--txt3)',      border: 'var(--border-sub)' },
+    cancelled:   { bg: 'var(--status-neutral-bg)', color: 'var(--txt-ghost)', border: 'var(--border-faint)' },
+  };
+  const p = palette[v] || palette.open;
+  return (
+    <span
+      style={{
+        display: 'inline-flex',
+        alignItems: 'center',
+        height: 17,
+        padding: '0 5px',
+        borderRadius: 3,
+        fontSize: 8.5,
+        fontWeight: 600,
+        letterSpacing: '0.04em',
+        textTransform: 'uppercase',
+        whiteSpace: 'nowrap',
+        background: p.bg,
+        color: p.color,
+        border: `1px solid ${p.border}`,
+      }}
+    >
+      {row.status || '—'}
+    </span>
+  );
+}
+
+// ── Column spec ────────────────────────────────────────────────────────────
+
+export const PURCHASE_ORDER_COLUMNS: EntityTableColumn<EntityListResult>[] = [
+  {
+    key: 'po_number',
+    label: 'PO Number',
+    accessor: (r) => r.entityRef || '',
+    mono: true,
+    minWidth: 130,
+  },
+  {
+    key: 'supplier',
+    label: 'Supplier',
+    // adapter writes supplier_name (or description fallback) as title
+    accessor: (r) => r.title || '',
+    minWidth: 200,
+    wrap: true,
+  },
+  {
+    key: 'status',
+    label: 'Status',
+    accessor: (r) => r.status || '',
+    render: (r) => <StatusPill row={r} />,
+    minWidth: 120,
+  },
+  {
+    key: 'currency',
+    label: 'Ccy',
+    accessor: (r) => meta(r, 'currency'),
+    mono: true,
+    minWidth: 60,
+  },
+  {
+    key: 'total',
+    label: 'Total',
+    accessor: (r) => formatAmount(r),
+    sortAccessor: (r) => metaNumber(r, 'total_amount'),
+    mono: true,
+    minWidth: 100,
+    align: 'right',
+  },
+  {
+    key: 'ordered_at',
+    label: 'Ordered',
+    accessor: (r) => formatDate(meta(r, 'ordered_at')),
+    sortAccessor: (r) => meta(r, 'ordered_at') || null,
+    mono: true,
+    minWidth: 110,
+  },
+  {
+    key: 'received_at',
+    label: 'Received',
+    accessor: (r) => formatDate(meta(r, 'received_at')),
+    sortAccessor: (r) => meta(r, 'received_at') || null,
+    mono: true,
+    minWidth: 110,
+  },
+  {
+    key: 'created_at',
+    label: 'Created',
+    accessor: (r) => formatDate(meta(r, 'created_at')),
+    sortAccessor: (r) => meta(r, 'created_at') || null,
+    mono: true,
+    minWidth: 110,
+    align: 'right',
+  },
+];


### PR DESCRIPTION
## Summary

Wires the Purchase Order lens into the shared `EntityTableList<T>` per DOCUMENTS04's spec. Same pattern as RECEIVING_COLUMNS / CERTIFICATE_COLUMNS / DOCUMENT_COLUMNS — one `PURCHASE_ORDER_COLUMNS` file, adapter writes raw fields to `metadata`, page.tsx passes `tableColumns` prop.

## Columns (8, all sortable)

| Key | Label | Source | Notes |
|---|---|---|---|
| po_number | PO Number | `entityRef` | mono |
| supplier | Supplier | `title` (adapter uses `supplier_name` fallback `description`) | wrap |
| status | Status | `statusVariant` | rendered as pill (same palette as EntityRecordRow) |
| currency | Ccy | `metadata.currency` | mono |
| total | Total | `metadata.total_amount` | right-aligned, numeric sort |
| ordered_at | Ordered | `metadata.ordered_at` | ISO date |
| received_at | Received | `metadata.received_at` | ISO date |
| created_at | Created | `metadata.created_at` | right-aligned |

## Files

- new: `apps/web/src/features/purchasing/columns.tsx` (162 lines, tokenised pill)
- `apps/web/src/app/purchasing/page.tsx` — poAdapter writes `metadata` + passes `tableColumns` prop

## Backend

No change — `/api/vessel/{id}/domain/purchase_orders/records` already returns all the fields the columns need via `vessel_surface_routes._format_record` plus the supplier/total enrichment loop.

## Test plan

- [ ] /purchasing shows tabular list with 8 columns
- [ ] Click PO Number / Supplier / Status / Total / Ordered / Received / Created — sorts ascending/descending
- [ ] Status column renders coloured pill
- [ ] Total column right-aligns with currency symbol
- [ ] Existing filters (PO Number, Supplier, Status, Currency, Ordered, Received) still work

Generated with Claude Code