### PR TITLE
fix(certificates): unbreak dropdown — Archive/Suspend/Revoke/Assign 400 wiring

### DIFF
--- a/apps/api/action_router/entity_prefill.py
+++ b/apps/api/action_router/entity_prefill.py
@@ -96,6 +96,18 @@ CONTEXT_PREFILL_MAP: Dict[Tuple[str, str], Dict[str, str]] = {
     ("certificate", "renew_certificate"):           {"certificate_id": "id"},
     ("certificate", "link_equipment_to_certificate"):   {"certificate_id": "id"},
     ("certificate", "unlink_equipment_from_certificate"):{"certificate_id": "id"},
+    # Archive / suspend / revoke registry rows declare `entity_id` (not
+    # `certificate_id`) as the required key, matching the generic
+    # archive/suspend/revoke pattern other domains use. Without these prefill
+    # rows the router's required-fields gate rejected every dropdown click
+    # with 400 before the handler ever ran (Issue 6 pattern in
+    # /Users/celeste7/Desktop/list_of_faults.md — "every button gives 400").
+    # Handler bodies already accept either key (certificate_handlers.py:1528,
+    # 1600) so this is a wiring fix only — no behavioural change.
+    ("certificate", "archive_certificate"):         {"entity_id": "id"},
+    ("certificate", "suspend_certificate"):         {"entity_id": "id"},
+    ("certificate", "revoke_certificate"):          {"entity_id": "id"},
+    ("certificate", "assign_certificate"):          {"certificate_id": "id"},
 
     # ── Receiving ─────────────────────────────────────────────────────────────
     ("receiving", "add_receiving_item"):                  {"receiving_id": "id"},

--- a/apps/web/src/components/lens-v2/entity/CertificateContent.tsx
+++ b/apps/web/src/components/lens-v2/entity/CertificateContent.tsx
@@ -131,16 +131,20 @@ const DELETED_AUDIT_ACTIONS = new Set([
 
 /** Dropdown filter: actions hidden from the lens dropdown.
  *  - create_* : only reachable from the list page, not a lens action.
- *  - assign_certificate : captain-only, surfaced elsewhere.
  *  - supersede_certificate : manual "Renew" supersedes via chain; the raw
- *    supersede action is an admin escape hatch.
- *  - link_document_to_certificate : removed from MVP surface per spec
- *    ("for mvp this is too complex. the attachments section will suffice.").
+ *    supersede action is an admin escape hatch not surfaced to crew.
+ *  - link_document_to_certificate : removed from MVP surface per
+ *    doc_cert_ux_change.md — the "Supporting Documents" section already
+ *    covers the upload path. Handler kept for API compat, UI gone.
+ *
+ * NOTE: `assign_certificate` is INTENTIONALLY visible. Backend gates it to
+ * captain/manager via allowed_roles, so engineers never see the action in
+ * `availableActions` anyway. Hiding it here stranded captains with no way
+ * to assign a responsible officer from the lens.
  */
 const HIDDEN_FROM_DROPDOWN = new Set([
   'create_vessel_certificate',
   'create_crew_certificate',
-  'assign_certificate',
   'supersede_certificate',
   'link_document_to_certificate',
 ]);


### PR DESCRIPTION
## Summary

Addresses list_of_faults.md **Issue 6 pattern** ("every button gives 400 error code") applied to the certificate lens.

## Root cause

Registry declares `required_fields: ["yacht_id", "entity_id"]` for archive/suspend/revoke (matching the generic cross-domain convention), but `apps/api/action_router/entity_prefill.py` had no prefill rows for those action IDs. Router's required-fields gate therefore rejected the call **before the handler ever ran**.

Handler bodies already accept either key (`params.get("entity_id") or params.get("certificate_id")` at `certificate_handlers.py:1528` + `:1600`), so the bug was purely at the wiring layer — not at the business-logic layer.

## Changes

- **`apps/api/action_router/entity_prefill.py`** — four new prefill rows:
  - `("certificate", "archive_certificate"): {"entity_id": "id"}`
  - `("certificate", "suspend_certificate"): {"entity_id": "id"}`
  - `("certificate", "revoke_certificate"):  {"entity_id": "id"}`
  - `("certificate", "assign_certificate"):  {"certificate_id": "id"}`
- **`apps/web/src/components/lens-v2/entity/CertificateContent.tsx`** — removed `assign_certificate` from `HIDDEN_FROM_DROPDOWN`. Backend already gates to captain+manager via `allowed_roles`; hiding at the UI level was redundant defence-in-depth that stranded captains with no way to assign a responsible officer from the lens. Added a NOTE block explaining why each remaining hidden action is hidden.

## Action inventory after fix (`BUTTON | KEEP | ROLE SECURITY | STATUS`)

| Button | | Role | Wiring |
|---|---|---|---|
| Renew Certificate (primary) | KEEP | engineer+ | ✓ |
| Update Certificate | KEEP | engineer+ | ✓ |
| Add Certificate Note | KEEP | all | ✓ |
| Link Equipment | KEEP | engineer+ | ✓ |
| Unlink Equipment | KEEP | engineer+ | ✓ |
| Assign Responsible Officer | KEEP | captain+ | **fixed** (was hidden + 400) |
| Archive Certificate | KEEP | captain+ | **fixed** (was 400) |
| Suspend Certificate | KEEP | captain+ | **fixed** (was 400) |
| Revoke Certificate | KEEP | captain+ | **fixed** (was 400) |
| Create Vessel Cert | REMOVE from dropdown | (list page only) | correctly hidden |
| Create Crew Cert | REMOVE from dropdown | (list page only) | correctly hidden |
| Supersede Certificate | REMOVE from dropdown | admin escape hatch | correctly hidden (Renew supersedes) |
| Link Document | REMOVE from dropdown | MVP spec | correctly hidden (Supporting Documents section replaces) |

Zero duplicates, zero wasteful entries. Same rigour as the work-order dropdown cleanup CEO demanded in Issue 6.

## Security

- No handler signatures changed
- No role gates weakened
- No UUIDs newly exposed
- No new env vars, endpoints, or tokens

## Verification

- [x] `python3 -c "import ast; ast.parse(...)"` on entity_prefill.py — OK
- [x] `npm run typecheck` — clean
- [x] `next lint` on CertificateContent.tsx — clean
- [ ] Post-deploy: log in as captain, click each dropdown action → confirm no 400s. Log in as engineer → confirm Archive/Suspend/Revoke/Assign don't appear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)