### PR TITLE
fix(documents): unbreak Add Document Note + cull dead action dropdown entries

### DIFF
--- a/apps/api/action_router/entity_prefill.py
+++ b/apps/api/action_router/entity_prefill.py
@@ -133,9 +133,17 @@ CONTEXT_PREFILL_MAP: Dict[Tuple[str, str], Dict[str, str]] = {
 
     # ── Document ──────────────────────────────────────────────────────────────
     ("document", "update_document"):              {"document_id": "id"},
+    # FIX 2026-04-23: add_document_note was missing a prefill entry — the
+    # AddNoteModal on the documents lens submits {note_text} and relies on
+    # this map to inject document_id. Without it the action validator 400'd.
+    # Paired with the registry.py required_fields correction (equipment_id
+    # → document_id on add_document_note).
+    ("document", "add_document_note"):            {"document_id": "id"},
     ("document", "add_document_comment"):         {"document_id": "id"},
     ("document", "add_document_tags"):            {"document_id": "id"},
     ("document", "delete_document"):              {"document_id": "id"},
+    # archive_document uses entity_id per its required_fields declaration.
+    ("document", "archive_document"):             {"entity_id": "id"},
     ("document", "update_document_comment"):      {"document_id": "id"},
     ("document", "link_document_to_equipment"):   {"document_id": "id"},
     ("document", "get_document_url"):             {"document_id": "id"},

--- a/apps/api/action_router/registry.py
+++ b/apps/api/action_router/registry.py
@@ -2784,6 +2784,13 @@ ACTION_REGISTRY: Dict[str, ActionDefinition] = {
         variant=ActionVariant.MUTATE,
     ),
 
+    # FIX 2026-04-23 (DOCUMENTS04): required_fields declared a stale
+    # `equipment_id` copy-pasted from add_equipment_note. Every real "Add
+    # Document Note" click 400'd at the action validator (identical pattern
+    # to the add_po_note bug fixed earlier this session). The generic
+    # add_note handler in internal_dispatcher.py already accepts
+    # document_id — only the declaration was wrong. Paired with an
+    # entity_prefill.py entry so the frontend auto-populates document_id.
     "add_document_note": ActionDefinition(
         action_id="add_document_note",
         label="Add Document Note",
@@ -2791,7 +2798,7 @@ ACTION_REGISTRY: Dict[str, ActionDefinition] = {
         handler_type=HandlerType.INTERNAL,
         method="POST",
         allowed_roles=["chief_engineer", "chief_officer", "captain", "manager"],
-        required_fields=["yacht_id", "equipment_id", "note_text"],
+        required_fields=["yacht_id", "document_id", "note_text"],
         domain="documents",
         variant=ActionVariant.MUTATE,
     ),

--- a/apps/web/src/components/lens-v2/entity/DocumentContent.tsx
+++ b/apps/web/src/components/lens-v2/entity/DocumentContent.tsx
@@ -337,15 +337,38 @@ export function DocumentContent() {
   const DANGER_ACTIONS = new Set(['archive_document', 'delete_document']);
 
   // ── Hidden-in-dropdown list ──
-  // Per doc_cert_ux_change.md: the old "Link document to certificate" search
-  // modal is removed for MVP — supporting documents / attachments cover the
-  // need. Related equipment has its own dedicated section + picker, so we
-  // also hide the backend link action from the generic action dropdown
-  // (users open the picker via the section's "+ Link equipment" button).
+  // Per doc_cert_ux_change.md + Issue 6 button audit pattern (2026-04-23):
+  //
+  //   link_document_to_certificate  — removed for MVP (spec line 159).
+  //   link_equipment_to_document    — surfaced via Related Equipment picker,
+  //                                   not the generic dropdown.
+  //   unlink_equipment_from_document — surfaced via Related Equipment row ×.
+  //   upload_document               — creates a NEW top-level doc. That
+  //                                   flow belongs on the /documents page's
+  //                                   AppShell primary action + the Supporting
+  //                                   Documents section's "+ Upload" (with
+  //                                   "DOES NOT OVERWRITE" warning). Rendering
+  //                                   it in a per-doc lens dropdown is
+  //                                   misleading ("Update Document" is what
+  //                                   the user wants on this lens).
+  //   view_document / open_document — the lens card IS the view. These are
+  //                                   leftover P3 scaffolding; they fire
+  //                                   ledger events but render nothing the
+  //                                   user doesn't already see. Same rule
+  //                                   Issue 6 applies to work-order's
+  //                                   "View Work Order Detail / History".
+  //   view_related_documents        — Show Related is a separate feature.
+  //   view_document_section         — unclear P3 scaffolding; never called
+  //                                   from a meaningful UI flow.
   const HIDDEN_FROM_DROPDOWN = new Set([
     'link_document_to_certificate',
     'link_equipment_to_document',
     'unlink_equipment_from_document',
+    'upload_document',
+    'view_document',
+    'view_related_documents',
+    'view_document_section',
+    'open_document',
   ]);
 
   const dropdownItems: DropdownItem[] = availableActions


### PR DESCRIPTION
## Summary
Issue 6 / Issue 18 button audit for the documents lens — mirrors CERT04's #681 cleanup landed minutes ago. Three surgical fixes so every button in the documents lens Actions dropdown either works or is not there.

## Fixes

1. **`apps/api/action_router/registry.py`** — `add_document_note.required_fields` had a stale `equipment_id` copy-pasted from `add_equipment_note`. Every click 400'd at the action validator. Generic `add_note` handler already accepts `document_id` so this was declaration-only. Changed to `['yacht_id','document_id','note_text']`. Same pattern as the `add_po_note` fix earlier this session.

2. **`apps/api/action_router/entity_prefill.py`** — added missing entries:
   - `('document','add_document_note') → {document_id: id}` — the AddNoteModal submits `{note_text}` and relies on this to inject `document_id` from the lens entity.
   - `('document','archive_document') → {entity_id: id}` — aligns with the action's `required_fields`.

3. **`apps/web/src/components/lens-v2/entity/DocumentContent.tsx`** — expanded `HIDDEN_FROM_DROPDOWN` from 3 → 8 entries. Applies Issue 6's "remove wasteful repeated buttons that duplicate existing lens surfaces" rule:
   - `upload_document` — belongs on `/documents` AppShell + Supporting Documents section with the "does NOT overwrite" warning; per-doc lens is misleading.
   - `view_document` — the lens card IS the view.
   - `view_related_documents` — Show Related is a separate feature.
   - `view_document_section` — dead P3 scaffolding.
   - `open_document` — duplicates the viewer's open-in-new-tab + Download.

## Verification
- Python AST parse on the 2 .py files: pass
- `CONTEXT_PREFILL_MAP[('document','add_document_note')] == {'document_id':'id'}` verified
- `tsc --noEmit` clean on apps/web
- `DocumentsTableList.test.tsx`: 14/14 still green
- Pre-existing `docTreeBuilder.test.ts` failures are unrelated ambient (tests never updated when PR #654 migrated to `storage_path`)

## Plan
Instant-merge per CEO "no more branches" directive. Branch lives ~30s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)