### PR TITLE
fix(shopping-list): Issue 13 follow-up — clickable entity links + audit

### DIFF
--- a/apps/web/src/components/lens-v2/entity/ShoppingListContent.tsx
+++ b/apps/web/src/components/lens-v2/entity/ShoppingListContent.tsx
@@ -11,12 +11,14 @@
  */
 
 import * as React from 'react';
+import { useRouter } from 'next/navigation';
 import styles from '../lens.module.css';
 import { IdentityStrip, type PillDef, type DetailLine } from '../IdentityStrip';
 import { mapActionFields, actionHasFields, getSignatureLevel } from '../mapActionFields';
 import { SplitButton, type DropdownItem } from '../SplitButton';
 import { ScrollReveal } from '../ScrollReveal';
 import { useEntityLensContext } from '@/contexts/EntityLensContext';
+import { getEntityRoute } from '@/lib/entityRoutes';
 
 import {
   AuditTrailSection,
@@ -61,6 +63,7 @@ function formatDate(d?: string): string {
 
 export function ShoppingListContent() {
   const { entity, availableActions, executeAction, getAction } = useEntityLensContext();
+  const router = useRouter();
 
   const payload = (entity?.payload as Record<string, unknown>) ?? {};
   const get = <T = unknown>(key: string): T | undefined =>
@@ -145,13 +148,27 @@ export function ShoppingListContent() {
   if (rejectionReason) kvItems.push({ label: 'Rejection Reason', value: rejectionReason });
 
   // ── Related entity links ─────────────────────────────────────────────────────
-  const docItems: DocRowItem[] = relatedEntities.map((e, i) => ({
-    id: (e.entity_id as string) ?? `link-${i}`,
-    name: (e.label as string) ?? 'Linked Entity',
-    code: (e.entity_type as string) ?? undefined,
-    meta: undefined,
-    date: undefined,
-  }));
+  // Each nav item becomes a clickable row routing to /parts/[id] or
+  // /work-orders/[id] etc. `getEntityRoute` is the cross-domain slug→route
+  // mapper (apps/web/src/lib/entityRoutes.ts) that every other lens uses.
+  // Without this onClick, the "Linked Entities" rows render but go nowhere —
+  // was an interlinking gap flagged in the Issue 13 follow-up audit.
+  const docItems: DocRowItem[] = relatedEntities.map((e, i) => {
+    const entityId = e.entity_id as string | undefined;
+    const entityType = e.entity_type as string | undefined;
+    return {
+      id: entityId ?? `link-${i}`,
+      name: (e.label as string) ?? 'Linked Entity',
+      code: entityType ?? undefined,
+      meta: undefined,
+      date: undefined,
+      onClick: entityId && entityType
+        ? () => router.push(
+            getEntityRoute(entityType as Parameters<typeof getEntityRoute>[0], entityId),
+          )
+        : undefined,
+    };
+  });
 
   // ── Audit events ─────────────────────────────────────────────────────────────
   const history = (get<Array<Record<string, unknown>>>('audit_history') ?? []);

--- a/docs/ongoing_work/shopping list/SHOPPING_LIST_AUDIT.md
+++ b/docs/ongoing_work/shopping list/SHOPPING_LIST_AUDIT.md
@@ -191,6 +191,55 @@ awk '/^    "[a-z_]+": ActionDefinition\(/{a=$0} /domain="shopping_list"/{…prin
 | #671 | Adapter row-render contract fix (B-01 + B-02) + metadata cleanup | ✓ |
 | #675 | **Tabulated list view** — replaces card-style with shared `EntityTableList` + `SHOPPING_LIST_COLUMNS` (9 columns, business-rank sort on status/urgency, pill render slot) | ✓ |
 
+## 8a. Action button audit — Issue 13 / Issue 6 format
+
+Against [`list_of_faults.md`](../../../Desktop/list_of_faults.md) `### Issues 13`
+and using the `BUTTON | KEEP/REMOVE | ROLE | NOTES` table shape from
+`### Issue 6 Work order button drop down`.
+
+Verified live against Render (`pipeline-core.int.celeste7.ai`) as
+`hod.test@alex-short.com` (HoD role) — confirmed backend already emits
+the expected `prefill` + `required_fields` for every KEEP row; no 400s.
+
+| Button (action_id) | Verdict | Role gate | Notes |
+|---|---|---|---|
+| `create_shopping_list_item` | **HIDDEN** from lens dropdown | crew/HoD/captain/manager | Surfacing in the per-item dropdown duplicates the floating "+ Add Item" button and confuses users. Action remains usable via the list-level button; registry entry intact. |
+| `approve_shopping_list_item` | **KEEP** | HoD / captain / manager | State-gated: disabled on approved/ordered/partially_fulfilled/fulfilled/installed/rejected. Prefill injects `item_id` from entity id. Required: `quantity_approved`. |
+| `reject_shopping_list_item` | **KEEP** | HoD / captain / manager | Same state gate as approve. Required: `rejection_reason`. |
+| `promote_candidate_to_part` | **KEEP** | chief_engineer / manager | Only engineers can add a candidate row to the parts catalog (creates a `pms_parts` row + flips `candidate_promoted_to_part_id`). |
+| `view_shopping_list_history` | **HIDDEN** — wasteful | — | Duplicates the `AuditTrailSection` already on the lens (audit_history surfaced from `pms_shopping_list_state_history`). Same pattern Issue 6 called out for `View Work Order History`. |
+| `mark_shopping_list_ordered` | **KEEP** | chief_engineer / captain / manager | State-gated: only enabled when status=`approved`; disabled otherwise with "Already <status>" or "Item must be approved before it can be marked as ordered". |
+| `delete_shopping_item` | **KEEP** | HoD / captain / manager | Deletion allowed in any state (used to clean up rejected / stale candidates). Soft-delete column `deleted_at` exists on the table. |
+| `add_to_shopping_list` | **HIDDEN** — broken on shopping_list entity | crew/HoD/captain/manager | Cross-domain action that populates `part_id` prefill only when the source entity is `part` (`entity_prefill.py:182`). On a shopping_list entity the required field `part_id` is NOT prefilled, so a click produced `MISSING_REQUIRED_FIELD`. Home lives on the Part lens. |
+| `add_to_handover` | **KEEP** | all crew | Core cross-domain feature. Prefill injects `entity_id` + `title`. Required: `summary` (user-typed). |
+| `approve_list` / `add_list_item` / `archive_list` / `delete_list` / `convert_to_po` / `submit_list` | **HIDDEN** — legacy | HoD+ | 6 legacy "list-as-parent" actions from an abandoned design where a `pms_shopping_lists` header row would own items. Parent table never existed in production (probed: HTTP 404). Registry + handlers intact for any programmatic caller; hidden from UI to prevent label duplication with the canonical 5 per-item actions. |
+
+**Result: no 400s, no duplicate labels, no buttons that silently do nothing.**
+Live verification against `hod.test` on Render confirmed every visible
+action returns prefill + required_fields correctly; hidden actions are
+absent from the `available_actions[]` response.
+
+## 8b. Storage / bucket surface
+
+The shopping lens does **not** read or write to any Supabase Storage
+bucket. No photo/file upload action exists today. If one is introduced
+(e.g. attach photo of part needed), the pattern already in use by
+`receiving/accept_receiving` + `work_order/add_work_order_photo` should
+be followed (bucket: `documents`, path keyed by yacht_id/user_id/entity_id,
+RLS on bucket path).
+
+## 8c. Interlinking (part / work_order links)
+
+`entity_routes.py:533-534` builds `related_entities[]` with
+`_nav('part', part_id, 'Linked Part')` and
+`_nav('work_order', source_work_order_id, 'Source Work Order')`. Before
+the Issue 13 follow-up pass, `ShoppingListContent.tsx` rendered these
+rows with no `onClick`, so **links did not navigate**. Fixed by wiring
+`onClick` via the cross-domain slug→route mapper `getEntityRoute`
+(`@/lib/entityRoutes`): click `Linked Part` → `/inventory/<id>`, click
+`Source Work Order` → `/work-orders/<id>`. Lens-to-lens navigation now
+matches the pattern used by `EquipmentContent` and `DocumentContent`.
+
 ## 8. Current state of the shopping lens (end of 2026-04-23)
 
 - **List view**: sortable column table via shared `EntityTableList`. 9 columns: Part # / Item / Status / Urgency / Qty Req / Source / Requester / Required By / Created. Sort state persists per-domain in sessionStorage.


### PR DESCRIPTION
Closes the remaining Issue 13 (shopping-list) follow-ups from `list_of_faults.md`:

## Interlinking — Linked Entities rows had no click handler

`entity_routes.py:533-534` builds `related_entities[]` with `_nav('part', ...)` and `_nav('work_order', ...)`. Before this PR, `ShoppingListContent.tsx:148-154` rendered these as static rows with no `onClick` — clicks went nowhere. Fix wires `onClick` via `@/lib/entityRoutes.getEntityRoute` so:

- Click "Linked Part" → `/inventory/<id>`
- Click "Source Work Order" → `/work-orders/<id>`

Matches the pattern used by `EquipmentContent` + `DocumentContent`.

## SHOPPING_LIST_AUDIT.md §8a — Issue 6 format button audit table

| Button (action_id) | Verdict | Role | Notes |
|---|---|---|---|
| `create_shopping_list_item` | **HIDDEN** | all crew | Duplicates floating "+ Add Item" button; surfacing in per-item dropdown is a non-sequitur |
| `approve_shopping_list_item` | **KEEP** | HoD+ | State-gated; prefill injects `item_id` |
| `reject_shopping_list_item` | **KEEP** | HoD+ | Same gate; required `rejection_reason` |
| `promote_candidate_to_part` | **KEEP** | chief_eng / manager | Engineers only |
| `view_shopping_list_history` | **HIDDEN** | — | Duplicates AuditTrailSection already on lens |
| `mark_shopping_list_ordered` | **KEEP** | chief_eng / captain / manager | State-gated: only enabled when status=approved |
| `delete_shopping_item` | **KEEP** | HoD+ | Soft-delete |
| `add_to_shopping_list` | **HIDDEN** | — | Would 400 on shopping_list entity — prefill only injects part_id on `part` entities |
| `add_to_handover` | **KEEP** | all crew | Core cross-domain |
| 6 legacy list-level | **HIDDEN** | — | `approve_list` / `add_list_item` / `archive_list` / `delete_list` / `convert_to_po` / `submit_list` — kept in registry, hidden from UI |

Verified live against Render as `hod.test`: every KEEP action returns correct `prefill` + `required_fields`; hidden actions are absent from the `available_actions[]` response. **No 400s, no silent failures.**

## §8b — Storage/bucket surface

Shopping list does **not** read or write to any Supabase Storage bucket (no photo upload action today). Documented future-pattern note for reference.

## §8c — Interlinking rationale

Explains the `onClick`-wiring fix with file:line citations.

## Note on backend

The 3 additional `_SHOPPING_LIST_HIDDEN_ACTIONS` entries + state-gate tightening were already shipped on origin/main via PR #683 (receiving audit bundled them). This PR lands only the frontend nav fix + docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)