### PR TITLE
feat(work-orders): tabulated list view on shared EntityTableList

### DIFF
--- a/apps/api/routes/vessel_surface_routes.py
+++ b/apps/api/routes/vessel_surface_routes.py
@@ -58,7 +58,7 @@ DOMAIN_TABLE_MAP = {
 
 # Select columns per domain (lightweight — only what list views need)
 DOMAIN_SELECT = {
-    "work_orders": "id, title, wo_number, status, priority, assigned_to, equipment_id, due_date, severity, created_at, updated_at",
+    "work_orders": "id, title, wo_number, status, priority, assigned_to, equipment_id, due_date, severity, type, work_order_type, frequency, completed_at, created_at, updated_at",
     "faults": "id, title, fault_code, status, severity, equipment_id, created_at, updated_at",
     "equipment": "id, name, code, system_type, location, status, manufacturer, model, serial_number, criticality, created_at, updated_at",
     "parts": "id, name, part_number, quantity_on_hand, minimum_quantity, location, unit_cost, manufacturer, category, is_critical, created_at, updated_at",
@@ -822,6 +822,47 @@ async def get_domain_records(
         # Format records for frontend (include yacht_id for overview attribution)
         formatted = [_format_record(domain, r) for r in records]
 
+        # Work orders: batch-resolve equipment_name + assigned_to_name
+        # (UX sheet `/Users/celeste7/Desktop/lens_card_upgrades.md:305-331` —
+        # UUIDs must not reach the frontend). Single round-trip per resolver.
+        if domain == "work_orders" and records:
+            # Lazy import so reloads/tests don't pay the hit when domain != work_orders
+            from lib.user_resolver import resolve_users, resolve_equipment_batch
+
+            eq_ids = list({r.get("equipment_id") for r in records if r.get("equipment_id")})
+            user_ids = list({r.get("assigned_to") for r in records if r.get("assigned_to")})
+
+            eq_name_map: Dict[str, str] = {}
+            eq_code_map: Dict[str, str] = {}
+            if eq_ids:
+                try:
+                    for eq in resolve_equipment_batch(supabase, yacht_id, eq_ids):
+                        if eq.get("id"):
+                            eq_name_map[eq["id"]] = eq.get("name") or ""
+                            eq_code_map[eq["id"]] = eq.get("code") or ""
+                except Exception as e:
+                    logger.warning(f"[DomainRecords] work_orders equipment resolve failed: {e}")
+
+            user_map: Dict[str, Dict[str, Optional[str]]] = {}
+            if user_ids:
+                try:
+                    user_map = resolve_users(supabase, yacht_id, user_ids)
+                except Exception as e:
+                    logger.warning(f"[DomainRecords] work_orders user resolve failed: {e}")
+
+            for raw, fmt in zip(records, formatted):
+                eid = raw.get("equipment_id")
+                if eid:
+                    fmt["linked_equipment_name"] = eq_name_map.get(eid) or None
+                    fmt["linked_equipment_code"] = eq_code_map.get(eid) or None
+                uid = raw.get("assigned_to")
+                if uid:
+                    u = user_map.get(uid) or {}
+                    name = u.get("name")
+                    if name:
+                        fmt["assigned_to_name"] = name
+                        fmt["assigned_to_role"] = u.get("role")
+
         # Shopping list: batch-resolve requester names from auth_users_profiles
         # (pms_shopping_list_items has no FK to the profiles table, so _format_record
         # cannot do the lookup row-by-row without N+1 queries).
@@ -1020,6 +1061,12 @@ def _format_record(domain: str, record: dict) -> dict:
             "title": record.get("title", ""),
             "status": record.get("status", "open"),
             "priority": record.get("priority", "normal"),
+            "severity": record.get("severity"),
+            # `type` column supersedes `work_order_type`; surface whichever is populated.
+            "wo_type": record.get("type") or record.get("work_order_type"),
+            "frequency": record.get("frequency"),
+            "due_date": record.get("due_date"),
+            "completed_at": record.get("completed_at"),
             "assigned_to": record.get("assigned_to", ""),
             "linked_equipment_id": record.get("equipment_id"),
             "meta": f"{record.get('priority', 'normal').upper()} · {record.get('status', 'open').upper()}",

--- a/apps/web/src/app/work-orders/page.tsx
+++ b/apps/web/src/app/work-orders/page.tsx
@@ -8,6 +8,7 @@ import { EntityLensPage } from '@/components/lens-v2/EntityLensPage';
 import { WorkOrderContent } from '@/components/lens-v2/entity';
 import lensStyles from '@/components/lens-v2/lens.module.css';
 import { workOrderToListResult } from '@/features/work-orders/adapter';
+import { WORK_ORDER_COLUMNS } from '@/features/work-orders/columns';
 import { WORK_ORDER_FILTERS } from '@/features/entity-list/types/filter-config';
 import type { WorkOrder } from '@/features/work-orders/types';
 
@@ -43,13 +44,14 @@ function WorkOrdersPageContent() {
         domain="work-orders"
         queryKey={['work-orders']}
         table="v_work_orders_enriched"
-        columns="id, title, description, status, priority, wo_number, equipment_id, equipment_name, assigned_to, assigned_to_name, due_date, created_at, updated_at"
+        columns="id, title, description, status, priority, severity, type, work_order_type, frequency, wo_number, equipment_id, equipment_name, assigned_to, assigned_to_name, due_date, completed_at, created_at, updated_at"
         adapter={workOrderToListResult}
         filterConfig={WORK_ORDER_FILTERS}
         selectedId={selectedId}
         onSelect={handleSelect}
         emptyMessage="No work orders found"
         sortBy="created_at"
+        tableColumns={WORK_ORDER_COLUMNS}
       />
 
       <EntityDetailOverlay isOpen={!!selectedId} onClose={handleCloseDetail}>

--- a/apps/web/src/features/entity-list/hooks/useFilteredEntityList.ts
+++ b/apps/web/src/features/entity-list/hooks/useFilteredEntityList.ts
@@ -69,9 +69,21 @@ function apiRecordToAdapterInput(record: Record<string, unknown>, domain: string
     wo_number: record.ref?.toString().replace('WO-', ''),
     equipment_id: record.linked_equipment_id,
     equipment_name: record.linked_equipment_name,
+    equipment_code: record.linked_equipment_code,
+    // `assigned_to` may be a UUID or a resolved name depending on backend
+    // revision. `assigned_to_name` is the post-resolver field from
+    // vessel_surface_routes.py work_orders batch enrichment (2026-04-23).
+    // Adapter (adapter.ts:60) already UUID-filters, so passing the raw
+    // assigned_to is safe when the resolved name is absent.
     assigned_to: record.assigned_to,
-    assigned_to_name: record.assigned_to,
+    assigned_to_name: record.assigned_to_name ?? record.assigned_to,
+    assigned_to_role: record.assigned_to_role,
     due_date: record.due_date,
+    completed_at: record.completed_at,
+    frequency: record.frequency,
+    // `type` column supersedes `work_order_type`; surface whichever is set.
+    type: record.wo_type ?? record.type,
+    work_order_type: record.work_order_type,
 
     // Faults
     fault_code: record.ref?.toString().replace('F-', ''),

--- a/apps/web/src/features/work-orders/__tests__/columns.test.tsx
+++ b/apps/web/src/features/work-orders/__tests__/columns.test.tsx
@@ -1,0 +1,143 @@
+// apps/web/src/features/work-orders/__tests__/columns.test.tsx
+//
+// Unit tests for WORK_ORDER_COLUMNS — pure accessor / sortAccessor logic.
+// Render slots intentionally skipped here; they're trivial thin React wrappers
+// around accessor output and are covered implicitly by the EntityTableList
+// integration test suite used by the cohort (documents/shopping/receiving).
+
+import { describe, it, expect } from 'vitest';
+import { WORK_ORDER_COLUMNS } from '../columns';
+import type { EntityListResult } from '@/features/entity-list/types';
+
+function row(over: Partial<EntityListResult> & {
+  meta?: Record<string, unknown>;
+}): EntityListResult {
+  return {
+    id: over.id ?? 'wo-1',
+    type: 'pms_work_orders',
+    title: over.title ?? 'Service main engine',
+    subtitle: '',
+    snippet: '',
+    entityRef: over.entityRef,
+    equipmentRef: undefined,
+    equipmentName: over.equipmentName,
+    assignedTo: over.assignedTo,
+    status: over.status,
+    statusVariant: over.statusVariant,
+    severity: over.severity ?? null,
+    age: over.age,
+    metadata: over.meta ?? {},
+  } as EntityListResult;
+}
+
+function colByKey(key: string) {
+  const c = WORK_ORDER_COLUMNS.find((col) => col.key === key);
+  if (!c) throw new Error(`missing column ${key}`);
+  return c;
+}
+
+describe('WORK_ORDER_COLUMNS', () => {
+  it('exposes every UX-sheet column in the spec order', () => {
+    expect(WORK_ORDER_COLUMNS.map((c) => c.key)).toEqual([
+      'wo_code',
+      'title',
+      'priority',
+      'equipment_name',
+      'assigned_to',
+      'severity',
+      'wo_type',
+      'status',
+      'created_at',
+      'frequency',
+      'due_date',
+      'completed_at',
+    ]);
+  });
+
+  it('wo_code pulls from entityRef and sorts lowercased', () => {
+    const col = colByKey('wo_code');
+    const r = row({ entityRef: 'WO·0074' });
+    expect(col.accessor(r)).toBe('WO·0074');
+    expect(col.sortAccessor!(r)).toBe('wo·0074');
+  });
+
+  it('title wraps and sorts by lowercase, empty → null', () => {
+    const col = colByKey('title');
+    expect(col.wrap).toBe(true);
+    expect(col.sortAccessor!(row({ title: '' }))).toBeNull();
+    expect(col.sortAccessor!(row({ title: 'Alpha' }))).toBe('alpha');
+  });
+
+  it('priority sort follows deliberate rank (emergency before routine)', () => {
+    const col = colByKey('priority');
+    const rank = (p: string) =>
+      col.sortAccessor!(row({ meta: { priority: p } })) as number | null;
+    expect(rank('emergency')).toBeLessThan(rank('routine')!);
+    expect(rank('critical')).toBeLessThan(rank('important')!);
+    expect(rank('gibberish')).toBeNull();
+  });
+
+  it('severity sort rank, null-to-end', () => {
+    const col = colByKey('severity');
+    const rank = (s: string | undefined) =>
+      col.sortAccessor!(row({ meta: { severity: s } }));
+    expect(rank('critical')).toBe(0);
+    expect(rank('low')).toBe(4);
+    expect(rank(undefined)).toBeNull();
+  });
+
+  it('status sort puts in_progress above completed, terminal states last', () => {
+    const col = colByKey('status');
+    const rank = (s: string) =>
+      col.sortAccessor!(row({ meta: { status: s } })) as number | null;
+    expect(rank('in_progress')).toBeLessThan(rank('completed')!);
+    expect(rank('completed')).toBeLessThan(rank('archived')!);
+    expect(rank('overdue')).toBeLessThan(rank('in_progress')!);
+  });
+
+  it('equipment_name prefers row.equipmentName, falls back to meta', () => {
+    const col = colByKey('equipment_name');
+    expect(col.accessor(row({ equipmentName: 'Port Gen' }))).toBe('Port Gen');
+    expect(
+      col.accessor(row({ equipmentName: undefined, meta: { equipment_name: 'Stbd Gen' } })),
+    ).toBe('Stbd Gen');
+  });
+
+  it('assigned_to prefers assignedTo (adapter-filtered), then meta name', () => {
+    const col = colByKey('assigned_to');
+    expect(col.accessor(row({ assignedTo: 'Alex Kapranos' }))).toBe('Alex Kapranos');
+    expect(
+      col.accessor(
+        row({ assignedTo: undefined, meta: { assigned_to_name: 'Paul Thomson' } }),
+      ),
+    ).toBe('Paul Thomson');
+  });
+
+  it('wo_type humanises enum and falls back when absent', () => {
+    const col = colByKey('wo_type');
+    expect(col.accessor(row({ meta: { wo_type: 'scheduled_preventive' } }))).toBe(
+      'Scheduled Preventive',
+    );
+    expect(col.accessor(row({ meta: {} }))).toBe('');
+  });
+
+  it('date columns render — when iso missing, else YYYY-MM-DD, sort raw iso', () => {
+    const cols = ['created_at', 'due_date', 'completed_at'].map(colByKey);
+    for (const col of cols) {
+      expect(col.mono).toBe(true);
+      expect(col.accessor(row({ meta: {} }))).toBe('—');
+      const iso = '2026-03-29T00:00:00Z';
+      expect(col.accessor(row({ meta: { [col.key]: iso } }))).toBe('2026-03-29');
+      expect(col.sortAccessor!(row({ meta: { [col.key]: iso } }))).toBe(iso);
+      expect(col.sortAccessor!(row({ meta: {} }))).toBeNull();
+    }
+  });
+
+  it('frequency humanises enum, empty stays empty', () => {
+    const col = colByKey('frequency');
+    expect(col.accessor(row({ meta: { frequency: 'every_quarter' } }))).toBe(
+      'Every Quarter',
+    );
+    expect(col.accessor(row({ meta: {} }))).toBe('');
+  });
+});

--- a/apps/web/src/features/work-orders/adapter.ts
+++ b/apps/web/src/features/work-orders/adapter.ts
@@ -49,7 +49,15 @@ export function workOrderToListResult(wo: WorkOrder): EntityListResult {
     metadata: {
       status: wo.status,
       priority: wo.priority,
+      severity: wo.severity,
+      // `type` column supersedes `work_order_type`; keep both until cleanup.
+      wo_type: wo.type ?? wo.work_order_type,
+      frequency: wo.frequency,
       equipment_name: wo.equipment_name,
+      assigned_to_name: wo.assigned_to_name,
+      wo_number: wo.wo_number,
+      due_date: wo.due_date,
+      completed_at: wo.completed_at,
       created_at: wo.created_at,
     },
 

--- a/apps/web/src/features/work-orders/columns.tsx
+++ b/apps/web/src/features/work-orders/columns.tsx
@@ -1,0 +1,282 @@
+'use client';
+
+/**
+ * WORK_ORDER_COLUMNS — work-order column spec for the shared EntityTableList.
+ *
+ * Spec: /Users/celeste7/Desktop/lens_card_upgrades.md:492 + 506-522
+ * Cohort component: apps/web/src/features/entity-list/components/EntityTableList.tsx
+ * Reference integration: apps/web/src/components/shopping-list/ShoppingListTableList.tsx
+ *
+ * Column order is fixed by the UX sheet:
+ *   W/O Code · Title · Priority · Equipment · Assigned · Severity · Type ·
+ *   Status · Created · Frequency · Due · Completed
+ *
+ * Sort semantics:
+ *   - Text columns return a lowercased string (or null → end-of-list).
+ *   - Priority / Severity / Status use a *deliberate* rank (Emergency < Critical
+ *     < Important < Routine) so users see the most-urgent rows at the top of
+ *     an ascending sort, not alphabetical noise.
+ *   - Dates return the ISO string (lex-sortable); null rows sort to the end.
+ *
+ * Every style value is a CSS custom property — no hard-coded colours.
+ */
+
+import * as React from 'react';
+import { type EntityTableColumn } from '@/features/entity-list/components/EntityTableList';
+import type { EntityListResult } from '@/features/entity-list/types';
+
+type Row = EntityListResult;
+
+// ── Pullers + formatters ───────────────────────────────────────────────────
+// work-order fields reach the table via `workOrderToListResult`
+// (apps/web/src/features/work-orders/adapter.ts). Top-level EntityListResult
+// exposes a handful of them directly; everything else lives on `row.metadata`.
+
+function meta<T = unknown>(row: Row, key: string): T | undefined {
+  const m = row.metadata as Record<string, unknown> | undefined;
+  return m?.[key] as T | undefined;
+}
+
+function fmtEnum(str?: string | null): string {
+  if (!str) return '';
+  return str.replace(/_/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase());
+}
+
+function formatDate(iso?: string | null): string {
+  if (!iso) return '—';
+  try {
+    const d = new Date(iso);
+    if (isNaN(d.getTime())) return '—';
+    return d.toISOString().slice(0, 10);
+  } catch {
+    return '—';
+  }
+}
+
+// ── Rank arrays (deliberate business order; NOT alphabetical) ──────────────
+
+const PRIORITY_RANK: Record<string, number> = {
+  emergency: 0,
+  critical: 1,
+  important: 2,
+  routine: 3,
+};
+
+const SEVERITY_RANK: Record<string, number> = {
+  critical: 0,
+  high: 1,
+  warning: 2,
+  medium: 3,
+  low: 4,
+};
+
+const STATUS_RANK: Record<string, number> = {
+  // Open-ish / in-flight first, completed/terminal last
+  overdue: 0,
+  in_progress: 1,
+  pending_parts: 2,
+  awaiting_parts: 2,
+  planned: 3,
+  draft: 4,
+  open: 5,
+  completed: 6,
+  closed: 7,
+  cancelled: 8,
+  archived: 9,
+};
+
+// ── Pill palette (tokens only) ─────────────────────────────────────────────
+
+type PillColour = { fg: string; bg: string; bd: string };
+
+const PRIORITY_PILL: Record<string, PillColour> = {
+  emergency: { fg: 'var(--red)',    bg: 'var(--red-bg)',    bd: 'var(--red-border)' },
+  critical:  { fg: 'var(--red)',    bg: 'var(--red-bg)',    bd: 'var(--red-border)' },
+  important: { fg: 'var(--amber)',  bg: 'var(--amber-bg)',  bd: 'var(--amber-border)' },
+  routine:   { fg: 'var(--text-tertiary)', bg: 'var(--surface)', bd: 'var(--border-faint)' },
+};
+
+const SEVERITY_PILL: Record<string, PillColour> = {
+  critical: { fg: 'var(--red)',    bg: 'var(--red-bg)',    bd: 'var(--red-border)' },
+  high:     { fg: 'var(--red)',    bg: 'var(--red-bg)',    bd: 'var(--red-border)' },
+  warning:  { fg: 'var(--amber)',  bg: 'var(--amber-bg)',  bd: 'var(--amber-border)' },
+  medium:   { fg: 'var(--amber)',  bg: 'var(--amber-bg)',  bd: 'var(--amber-border)' },
+  low:      { fg: 'var(--text-tertiary)', bg: 'var(--surface)', bd: 'var(--border-faint)' },
+};
+
+const STATUS_PILL: Record<string, PillColour> = {
+  overdue:         { fg: 'var(--red)',   bg: 'var(--red-bg)',   bd: 'var(--red-border)' },
+  in_progress:     { fg: 'var(--amber)', bg: 'var(--amber-bg)', bd: 'var(--amber-border)' },
+  pending_parts:   { fg: 'var(--amber)', bg: 'var(--amber-bg)', bd: 'var(--amber-border)' },
+  awaiting_parts:  { fg: 'var(--amber)', bg: 'var(--amber-bg)', bd: 'var(--amber-border)' },
+  planned:         { fg: 'var(--mark)',  bg: 'var(--teal-bg)',  bd: 'var(--mark-hover)' },
+  open:            { fg: 'var(--mark)',  bg: 'var(--teal-bg)',  bd: 'var(--mark-hover)' },
+  draft:           { fg: 'var(--text-tertiary)', bg: 'var(--surface)', bd: 'var(--border-faint)' },
+  completed:       { fg: 'var(--green)', bg: 'var(--green-bg)', bd: 'var(--green-border)' },
+  closed:          { fg: 'var(--green)', bg: 'var(--green-bg)', bd: 'var(--green-border)' },
+  cancelled:       { fg: 'var(--text-tertiary)', bg: 'var(--surface)', bd: 'var(--border-faint)' },
+  archived:        { fg: 'var(--text-tertiary)', bg: 'var(--surface)', bd: 'var(--border-faint)' },
+};
+
+function Pill({
+  value,
+  palette,
+}: {
+  value: string;
+  palette: Record<string, PillColour>;
+}) {
+  const key = value.toLowerCase();
+  const style = palette[key] ?? {
+    fg: 'var(--text-tertiary)',
+    bg: 'var(--surface)',
+    bd: 'var(--border-faint)',
+  };
+  return (
+    <span
+      style={{
+        display: 'inline-flex',
+        alignItems: 'center',
+        height: 18,
+        padding: '0 6px',
+        borderRadius: 3,
+        fontSize: 9.5,
+        fontWeight: 600,
+        letterSpacing: '0.04em',
+        textTransform: 'uppercase',
+        whiteSpace: 'nowrap',
+        color: style.fg,
+        background: style.bg,
+        border: `1px solid ${style.bd}`,
+      }}
+    >
+      {fmtEnum(value)}
+    </span>
+  );
+}
+
+// ── Column spec ────────────────────────────────────────────────────────────
+
+export const WORK_ORDER_COLUMNS: EntityTableColumn<Row>[] = [
+  {
+    key: 'wo_code',
+    label: 'W/O Code',
+    accessor: (r) => r.entityRef ?? '',
+    sortAccessor: (r) => (r.entityRef ?? '').toLowerCase() || null,
+    mono: true,
+    minWidth: 110,
+    maxWidth: 150,
+  },
+  {
+    key: 'title',
+    label: 'Title',
+    accessor: (r) => r.title ?? '',
+    sortAccessor: (r) => (r.title ?? '').toLowerCase() || null,
+    minWidth: 240,
+    maxWidth: 420,
+    wrap: true,
+  },
+  {
+    key: 'priority',
+    label: 'Priority',
+    accessor: (r) => (meta<string>(r, 'priority') ?? '').toString(),
+    sortAccessor: (r) => {
+      const p = meta<string>(r, 'priority');
+      return p ? PRIORITY_RANK[p.toLowerCase()] ?? null : null;
+    },
+    render: (r) => {
+      const p = meta<string>(r, 'priority');
+      return p ? <Pill value={p} palette={PRIORITY_PILL} /> : <>—</>;
+    },
+    minWidth: 100,
+  },
+  {
+    key: 'equipment_name',
+    label: 'Equipment',
+    accessor: (r) => r.equipmentName ?? meta<string>(r, 'equipment_name') ?? '',
+    sortAccessor: (r) =>
+      (r.equipmentName ?? meta<string>(r, 'equipment_name') ?? '')
+        .toLowerCase() || null,
+    minWidth: 160,
+    maxWidth: 260,
+  },
+  {
+    key: 'assigned_to',
+    label: 'Assigned',
+    accessor: (r) => r.assignedTo ?? meta<string>(r, 'assigned_to_name') ?? '',
+    sortAccessor: (r) =>
+      (r.assignedTo ?? meta<string>(r, 'assigned_to_name') ?? '')
+        .toLowerCase() || null,
+    minWidth: 130,
+    maxWidth: 200,
+  },
+  {
+    key: 'severity',
+    label: 'Severity',
+    accessor: (r) => (meta<string>(r, 'severity') ?? '').toString(),
+    sortAccessor: (r) => {
+      const s = meta<string>(r, 'severity');
+      return s ? SEVERITY_RANK[s.toLowerCase()] ?? null : null;
+    },
+    render: (r) => {
+      const s = meta<string>(r, 'severity');
+      return s ? <Pill value={s} palette={SEVERITY_PILL} /> : <>—</>;
+    },
+    minWidth: 100,
+  },
+  {
+    key: 'wo_type',
+    label: 'Type',
+    accessor: (r) => fmtEnum(meta<string>(r, 'wo_type')),
+    sortAccessor: (r) =>
+      (meta<string>(r, 'wo_type') ?? '').toLowerCase() || null,
+    minWidth: 110,
+    maxWidth: 140,
+  },
+  {
+    key: 'status',
+    label: 'Status',
+    accessor: (r) => (meta<string>(r, 'status') ?? '').toString(),
+    sortAccessor: (r) => {
+      const s = meta<string>(r, 'status');
+      return s ? STATUS_RANK[s.toLowerCase()] ?? null : null;
+    },
+    render: (r) => {
+      const s = meta<string>(r, 'status');
+      return s ? <Pill value={s} palette={STATUS_PILL} /> : <>—</>;
+    },
+    minWidth: 120,
+  },
+  {
+    key: 'created_at',
+    label: 'Created',
+    accessor: (r) => formatDate(meta<string>(r, 'created_at')),
+    sortAccessor: (r) => meta<string>(r, 'created_at') ?? null,
+    mono: true,
+    minWidth: 110,
+  },
+  {
+    key: 'frequency',
+    label: 'Freq',
+    accessor: (r) => fmtEnum(meta<string>(r, 'frequency')),
+    sortAccessor: (r) =>
+      (meta<string>(r, 'frequency') ?? '').toLowerCase() || null,
+    minWidth: 90,
+    maxWidth: 120,
+  },
+  {
+    key: 'due_date',
+    label: 'Due',
+    accessor: (r) => formatDate(meta<string>(r, 'due_date')),
+    sortAccessor: (r) => meta<string>(r, 'due_date') ?? null,
+    mono: true,
+    minWidth: 110,
+  },
+  {
+    key: 'completed_at',
+    label: 'Completed',
+    accessor: (r) => formatDate(meta<string>(r, 'completed_at')),
+    sortAccessor: (r) => meta<string>(r, 'completed_at') ?? null,
+    mono: true,
+    minWidth: 110,
+  },
+];

--- a/apps/web/src/features/work-orders/types.ts
+++ b/apps/web/src/features/work-orders/types.ts
@@ -5,12 +5,22 @@ export interface WorkOrder {
   description?: string;
   status: string;
   priority: string;
+  /** Logical sub-type — preventive / corrective / scheduled / unplanned. */
+  type?: string;
+  /** Deprecated alias for `type` on older rows; keep both until DB is cleaned. */
+  work_order_type?: string;
+  /** Crit assessment — distinct from priority. UX sheet line 340. */
+  severity?: string;
+  /** Recurrence cadence (daily / weekly / monthly / annual). UX line 316. */
+  frequency?: string;
   equipment_id?: string;
   equipment_name?: string;
   assigned_to?: string;
   assigned_to_id?: string;
   assigned_to_name?: string;
   due_date?: string;
+  /** Exact datetime the WO was marked complete. UX line 334. */
+  completed_at?: string;
   created_at: string;
   updated_at?: string;
 }

--- a/docs/ongoing_work/work_orders/PLAN.md
+++ b/docs/ongoing_work/work_orders/PLAN.md
@@ -12,8 +12,8 @@ Working alongside WORKORDER05 / HANDOVER08 / EQUIPMENT05 / FAULT05 / SHOPPINGLIS
 
 | PR | Subject | Status | Notes |
 |----|---------|--------|-------|
-| PR-WO-1 | Dedupe prefill + wire KEEP action buttons | OPEN | Kills 400s on dropdown actions |
-| PR-WO-2 | Tabulated list view on shared `EntityTableList` | PENDING | Adopts DOCUMENTS04's cohort component (PR #673) |
+| PR-WO-1 | Dedupe prefill + wire KEEP action buttons | MERGED #686 | 400s on work-order dropdown dead |
+| PR-WO-2 | Tabulated list view on shared `EntityTableList` | OPEN | 12 cols per UX sheet; backend batch resolvers for equipment_name + assigned_to_name |
 | PR-WO-3 | Lens card redesign — horizontal tabs + metadata de-UUID | PENDING | Safety / Checklist / Docs / Faults / Equipment / Parts / Uploads / Notes / Audit / History |
 | PR-WO-4 | Checklist overhaul (DB audit + bucket wiring) | PENDING | `pms_work_order_checklist` + `pms_checklist` + `pms_checklist_items` audit first |
 | PR-WO-5 | Calendar tab (List / Calendar toggle) | PENDING | Seahub-style; clickable cards; colour by type/criticality |
@@ -69,4 +69,36 @@ upload_photo                                                 — duplicate of ad
 
 ---
 
-## PR-WO-2..7 — detailed scope will be filled in as each opens.
+## PR-WO-2 — list-view tabulation (shipped 2026-04-23)
+
+### Goal
+UX sheet `/Users/celeste7/Desktop/lens_card_upgrades.md:492 + 506-522` — move `/work-orders` from `SpotlightResultRow` cards to columnar tabulated view using the cohort-shared `EntityTableList` (introduced by DOCUMENTS04 in PR #673, receiving opt-in via `tableColumns?` prop in PR #674).
+
+### Column order (fixed by UX sheet)
+`W/O Code · Title · Priority · Equipment · Assigned · Severity · Type · Status · Created · Frequency · Due · Completed`
+
+### Changes
+- **`apps/api/routes/vessel_surface_routes.py`** —
+  - `DOMAIN_SELECT.work_orders` extended: added `type, work_order_type, frequency, completed_at`.
+  - `_format_record(domain="work_orders")` now emits `severity, wo_type, frequency, due_date, completed_at` (previously only the bare card-row fields).
+  - Added a work-orders batch-enrichment block mirroring the PO/shopping-list pattern: `resolve_equipment_batch` + `resolve_users` run as two IN queries per list fetch, returning `linked_equipment_name`, `linked_equipment_code`, `assigned_to_name`, `assigned_to_role`. No client-side N+1.
+- **`apps/web/src/features/entity-list/hooks/useFilteredEntityList.ts`** — `apiRecordToAdapterInput` now forwards the enriched fields + stops the silent double-read of `assigned_to_name: record.assigned_to` (which displayed UUIDs whenever the backend didn't resolve the name). Field-contract matches what the backend emits after the enrichment block.
+- **`apps/web/src/features/work-orders/types.ts`** — `WorkOrder` gained `type, work_order_type, severity, frequency, completed_at`.
+- **`apps/web/src/features/work-orders/adapter.ts`** — adapter metadata now surfaces `severity, wo_type, frequency, assigned_to_name, wo_number, due_date, completed_at` for column accessors.
+- **`apps/web/src/features/work-orders/columns.tsx` (new)** — `WORK_ORDER_COLUMNS` spec, tokenised pill palettes, deliberate-rank sorts (Emergency < Critical < Important < Routine; in_progress before completed; terminal states last). Mirrors `SHOPPING_LIST_COLUMNS` structure.
+- **`apps/web/src/app/work-orders/page.tsx`** — SELECT list extended; `tableColumns={WORK_ORDER_COLUMNS}` passed to `FilteredEntityList`. One line of UX migration; everything else (filters, pagination, vessel attribution, Subbar sort/chip) keeps working.
+- **`apps/web/src/features/work-orders/__tests__/columns.test.tsx` (new)** — 11 unit tests covering column order, accessor fallbacks, sort-rank correctness (including null-to-end + unknown-enum-to-null).
+
+### Verification
+- `vitest run src/features/work-orders/__tests__/columns.test.tsx` → 11/11 green
+- `pytest apps/api/tests/test_entity_prefill.py` → 36/36 green (regression)
+- `npx tsc --noEmit` on apps/web → clean
+- Python AST parse on `vessel_surface_routes.py` → clean
+
+### Deferred
+- Column-visibility toggles / multi-column sort / virtualisation — cohort-frozen per DOCUMENTS04 (extensions require co-signed PR).
+- The deliberate-rank maps (`PRIORITY_RANK`, `SEVERITY_RANK`, `STATUS_RANK`) live in `columns.tsx` for MVP. If two lenses end up needing the same rank map, extract to `features/work-orders/status-ranks.ts`.
+
+---
+
+## PR-WO-3..7 — detailed scope will be filled in as each opens.


### PR DESCRIPTION
## Summary
- UX sheet `/Users/celeste7/Desktop/lens_card_upgrades.md:492,506-522` — migrate `/work-orders` from `SpotlightResultRow` cards to the cohort-shared columnar `EntityTableList` (introduced by DOCUMENTS04 PR #673, opt-in via `tableColumns?` shipped by RECEIVING05 PR #674).
- Column order fixed by CEO: **W/O Code · Title · Priority · Equipment · Assigned · Severity · Type · Status · Created · Frequency · Due · Completed**.
- Single round-trip per list fetch — backend batch-resolves `equipment_name` + `assigned_to_name` via `resolve_equipment_batch` + `resolve_users`. No client-side N+1.

## Files
- `apps/api/routes/vessel_surface_routes.py` — extended `DOMAIN_SELECT.work_orders`, `_format_record` emit, and new work-orders batch-enrichment block mirroring PO/shopping-list template.
- `apps/web/src/features/entity-list/hooks/useFilteredEntityList.ts` — `apiRecordToAdapterInput` now forwards enriched fields + stops the silent double-read of `assigned_to_name: record.assigned_to` that displayed UUIDs when the backend hadn't resolved names.
- `apps/web/src/features/work-orders/types.ts` — `WorkOrder` gained `type, work_order_type, severity, frequency, completed_at`.
- `apps/web/src/features/work-orders/adapter.ts` — metadata surfaces the new fields.
- `apps/web/src/features/work-orders/columns.tsx` **(new)** — `WORK_ORDER_COLUMNS`, tokenised pill palettes (no hardcoded colours), deliberate-rank sorts (Emergency < Critical < Important < Routine; overdue < in_progress < completed < archived). Unknown enum values sort to end.
- `apps/web/src/features/work-orders/__tests__/columns.test.tsx` **(new)** — 11 vitest specs.
- `apps/web/src/app/work-orders/page.tsx` — one-line migration (`tableColumns={WORK_ORDER_COLUMNS}`); filters/pagination/vessel attribution/Subbar sort+chip all unchanged.
- `docs/ongoing_work/work_orders/PLAN.md` — root-cause writeup + deferred list.

## Test plan
- [x] `vitest run src/features/work-orders/__tests__/columns.test.tsx` → 11/11 green
- [x] `pytest apps/api/tests/test_entity_prefill.py` → 36/36 green (regression)
- [x] `npx tsc --noEmit` on apps/web → clean
- [x] `python3 ast.parse` on `vessel_surface_routes.py` → clean
- [ ] Post-merge: visual check on `app.celeste7.ai/work-orders` — confirm 12 columns render, pills coloured via tokens, sort-rank correct (Emergency first on ascending Priority sort)
- [ ] Post-merge: confirm equipment/assigned columns show names (not UUIDs) for real-world rows

## Deferred (captured in `docs/ongoing_work/work_orders/PLAN.md`)
- Column-visibility toggles, multi-column sort, virtualisation — cohort-frozen per DOCUMENTS04 (additive extensions require co-signed PR).
- Rank maps stay local to `columns.tsx`; extract if a second lens needs the same constants.
- Lens-card redesign (horizontal tabs, metadata de-UUID) → PR-WO-3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)