### PR TITLE
feat(work-orders): lens card redesign — LensTabBar + header metadata de-UUID

### DIFF
--- a/apps/web/src/components/lens-v2/LensTabBar.tsx
+++ b/apps/web/src/components/lens-v2/LensTabBar.tsx
@@ -1,0 +1,188 @@
+'use client';
+
+/**
+ * LensTabBar — horizontal tabbed navigation for entity lens cards.
+ *
+ * Replaces the vertical-stacked ScrollReveal pattern on dense lenses (work
+ * orders, equipment, faults) where users need to land on a specific
+ * sub-domain of the entity (Checklist, Safety, Notes, etc.) without scrolling
+ * past everything.
+ *
+ * Design contract
+ *   - Sticky under the IdentityStrip; keyboard navigable (←/→).
+ *   - Active tab marked by an underline + token-coloured label.
+ *   - Counts render in a muted pill after the label ("Notes · 3").
+ *   - Disabled tabs render muted, aria-disabled, non-focusable.
+ *   - 100% tokenised (no hard-coded colours / sizes).
+ *
+ * Consumer owns tab body rendering — pass `renderBody(activeKey)`.
+ */
+
+import * as React from 'react';
+
+export interface LensTab {
+  /** Stable key — used for state + React key. */
+  key: string;
+  /** Display label. */
+  label: string;
+  /** Optional count rendered as a muted pill after the label. */
+  count?: number;
+  /** Optional: disable the tab (renders muted, not focusable). */
+  disabled?: boolean;
+  /** Optional disabled-reason tooltip text (title attr). */
+  disabledReason?: string;
+}
+
+export interface LensTabBarProps {
+  tabs: LensTab[];
+  /** Controlled active tab key (omit for uncontrolled = first enabled). */
+  activeKey?: string;
+  /** Default tab key for uncontrolled mode. */
+  defaultActiveKey?: string;
+  onChange?: (key: string) => void;
+  /** Render function for the active tab body. */
+  renderBody: (activeKey: string) => React.ReactNode;
+  /** Aria label for the tablist (default: "Lens sections"). */
+  'aria-label'?: string;
+}
+
+export function LensTabBar({
+  tabs,
+  activeKey: controlledKey,
+  defaultActiveKey,
+  onChange,
+  renderBody,
+  'aria-label': ariaLabel = 'Lens sections',
+}: LensTabBarProps) {
+  const firstEnabled = tabs.find((t) => !t.disabled)?.key ?? tabs[0]?.key ?? '';
+  const [uncontrolledKey, setUncontrolledKey] = React.useState<string>(
+    defaultActiveKey ?? firstEnabled,
+  );
+  const activeKey = controlledKey ?? uncontrolledKey;
+
+  const handleSelect = React.useCallback(
+    (key: string) => {
+      const tab = tabs.find((t) => t.key === key);
+      if (!tab || tab.disabled) return;
+      if (controlledKey === undefined) setUncontrolledKey(key);
+      onChange?.(key);
+    },
+    [tabs, controlledKey, onChange],
+  );
+
+  // ← / → keyboard nav between enabled tabs
+  const enabledKeys = React.useMemo(
+    () => tabs.filter((t) => !t.disabled).map((t) => t.key),
+    [tabs],
+  );
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
+    if (e.key !== 'ArrowRight' && e.key !== 'ArrowLeft') return;
+    const idx = enabledKeys.indexOf(activeKey);
+    if (idx < 0) return;
+    const next =
+      e.key === 'ArrowRight'
+        ? enabledKeys[(idx + 1) % enabledKeys.length]
+        : enabledKeys[(idx - 1 + enabledKeys.length) % enabledKeys.length];
+    handleSelect(next);
+    e.preventDefault();
+  };
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', minHeight: 0 }}>
+      <div
+        role="tablist"
+        aria-label={ariaLabel}
+        onKeyDown={handleKeyDown}
+        style={{
+          position: 'sticky',
+          top: 0,
+          zIndex: 2,
+          display: 'flex',
+          gap: 2,
+          padding: '0 4px',
+          borderBottom: '1px solid var(--border-faint)',
+          background: 'var(--surface-base)',
+          overflowX: 'auto',
+          scrollbarWidth: 'none',
+        }}
+      >
+        {tabs.map((tab) => {
+          const isActive = tab.key === activeKey;
+          return (
+            <button
+              key={tab.key}
+              role="tab"
+              type="button"
+              id={`tab-${tab.key}`}
+              aria-selected={isActive}
+              aria-controls={`tabpanel-${tab.key}`}
+              aria-disabled={tab.disabled || undefined}
+              tabIndex={isActive ? 0 : -1}
+              title={tab.disabledReason}
+              onClick={() => handleSelect(tab.key)}
+              disabled={tab.disabled}
+              style={{
+                appearance: 'none',
+                WebkitAppearance: 'none',
+                background: 'transparent',
+                border: 'none',
+                padding: '10px 14px',
+                cursor: tab.disabled ? 'not-allowed' : 'pointer',
+                fontSize: 13,
+                fontWeight: isActive ? 600 : 500,
+                color: tab.disabled
+                  ? 'var(--text-tertiary)'
+                  : isActive
+                    ? 'var(--txt)'
+                    : 'var(--txt2)',
+                borderBottom: `2px solid ${
+                  isActive ? 'var(--mark)' : 'transparent'
+                }`,
+                marginBottom: -1,
+                whiteSpace: 'nowrap',
+                display: 'inline-flex',
+                alignItems: 'center',
+                gap: 6,
+                opacity: tab.disabled ? 0.5 : 1,
+                transition: 'color 120ms ease, border-color 120ms ease',
+              }}
+            >
+              {tab.label}
+              {typeof tab.count === 'number' && tab.count > 0 && (
+                <span
+                  aria-hidden="true"
+                  style={{
+                    display: 'inline-flex',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                    minWidth: 18,
+                    height: 18,
+                    padding: '0 6px',
+                    borderRadius: 9,
+                    fontSize: 11,
+                    fontWeight: 600,
+                    color: 'var(--txt2)',
+                    background: 'var(--neutral-bg)',
+                    border: '1px solid var(--border-faint)',
+                  }}
+                >
+                  {tab.count}
+                </span>
+              )}
+            </button>
+          );
+        })}
+      </div>
+
+      <div
+        role="tabpanel"
+        id={`tabpanel-${activeKey}`}
+        aria-labelledby={`tab-${activeKey}`}
+        style={{ flex: 1, minHeight: 0, padding: '16px 0' }}
+      >
+        {renderBody(activeKey)}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/lens-v2/__tests__/LensTabBar.test.tsx
+++ b/apps/web/src/components/lens-v2/__tests__/LensTabBar.test.tsx
@@ -1,0 +1,128 @@
+// apps/web/src/components/lens-v2/__tests__/LensTabBar.test.tsx
+//
+// LensTabBar contract tests — the component is shared across lenses
+// (work-orders adopts first in PR-WO-3) so regressions must be caught early.
+
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import * as React from 'react';
+import { LensTabBar, type LensTab } from '../LensTabBar';
+
+function fixture(over: Partial<LensTab>[] = []): LensTab[] {
+  const defaults: LensTab[] = [
+    { key: 'checklist', label: 'Checklist', count: 4 },
+    { key: 'notes',     label: 'Notes',     count: 0 },
+    { key: 'safety',    label: 'Safety',    disabled: true, disabledReason: 'PR-WO-4' },
+  ];
+  // merge
+  return defaults.map((d, i) => ({ ...d, ...(over[i] ?? {}) }));
+}
+
+describe('LensTabBar', () => {
+  it('renders every tab with aria-selected and aria-controls wired', () => {
+    render(
+      <LensTabBar
+        tabs={fixture()}
+        renderBody={(key) => <div data-testid="body">{key}</div>}
+      />,
+    );
+    expect(screen.getAllByRole('tab')).toHaveLength(3);
+    expect(screen.getByRole('tab', { name: /Checklist/ }).getAttribute('aria-selected')).toBe('true');
+    expect(screen.getByRole('tab', { name: /Notes/ }).getAttribute('aria-selected')).toBe('false');
+    // body shows initial active tab
+    expect(screen.getByTestId('body').textContent).toBe('checklist');
+  });
+
+  it('suppresses count badge when count === 0', () => {
+    render(<LensTabBar tabs={fixture()} renderBody={() => null} />);
+    // Checklist count=4 should render the badge
+    const checklistBtn = screen.getByRole('tab', { name: /Checklist/ });
+    expect(checklistBtn.textContent).toContain('4');
+    // Notes count=0 should NOT render a badge
+    const notesBtn = screen.getByRole('tab', { name: /^Notes$/ });
+    expect(notesBtn.textContent).toBe('Notes');
+  });
+
+  it('renders disabled tabs with aria-disabled and does not activate on click', () => {
+    const onChange = vi.fn();
+    render(
+      <LensTabBar tabs={fixture()} onChange={onChange} renderBody={() => null} />,
+    );
+    const safety = screen.getByRole('tab', { name: /Safety/ }) as HTMLButtonElement;
+    expect(safety.getAttribute('aria-disabled')).toBe('true');
+    expect(safety.disabled).toBe(true);
+    fireEvent.click(safety);
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it('fires onChange and switches body when a tab is clicked', () => {
+    const onChange = vi.fn();
+    render(
+      <LensTabBar
+        tabs={fixture()}
+        onChange={onChange}
+        renderBody={(key) => <div data-testid="body">{key}</div>}
+      />,
+    );
+    fireEvent.click(screen.getByRole('tab', { name: /^Notes$/ }));
+    expect(onChange).toHaveBeenCalledWith('notes');
+    expect(screen.getByTestId('body').textContent).toBe('notes');
+  });
+
+  it('ArrowRight/ArrowLeft wrap through enabled tabs, skipping disabled', () => {
+    render(
+      <LensTabBar
+        tabs={fixture()}
+        renderBody={(key) => <div data-testid="body">{key}</div>}
+      />,
+    );
+    const tablist = screen.getByRole('tablist');
+    fireEvent.keyDown(tablist, { key: 'ArrowRight' });
+    expect(screen.getByTestId('body').textContent).toBe('notes');
+    // ArrowRight from last enabled tab wraps to first; disabled Safety skipped
+    fireEvent.keyDown(tablist, { key: 'ArrowRight' });
+    expect(screen.getByTestId('body').textContent).toBe('checklist');
+    fireEvent.keyDown(tablist, { key: 'ArrowLeft' });
+    expect(screen.getByTestId('body').textContent).toBe('notes');
+  });
+
+  it('controlled mode reflects activeKey prop and ignores internal state', () => {
+    const { rerender } = render(
+      <LensTabBar
+        tabs={fixture()}
+        activeKey="notes"
+        renderBody={(key) => <div data-testid="body">{key}</div>}
+      />,
+    );
+    expect(screen.getByTestId('body').textContent).toBe('notes');
+    // Clicking in controlled mode calls onChange but doesn't flip state unless parent updates
+    const onChange = vi.fn();
+    rerender(
+      <LensTabBar
+        tabs={fixture()}
+        activeKey="notes"
+        onChange={onChange}
+        renderBody={(key) => <div data-testid="body">{key}</div>}
+      />,
+    );
+    fireEvent.click(screen.getByRole('tab', { name: /Checklist/ }));
+    expect(onChange).toHaveBeenCalledWith('checklist');
+    // body still shows notes because parent didn't re-render with new activeKey
+    expect(screen.getByTestId('body').textContent).toBe('notes');
+  });
+
+  it('falls back to first enabled tab if defaultActiveKey is absent', () => {
+    const onlyFirstDisabled: LensTab[] = [
+      { key: 'a', label: 'A', disabled: true },
+      { key: 'b', label: 'B' },
+      { key: 'c', label: 'C' },
+    ];
+    render(
+      <LensTabBar
+        tabs={onlyFirstDisabled}
+        renderBody={(key) => <div data-testid="body">{key}</div>}
+      />,
+    );
+    expect(screen.getByTestId('body').textContent).toBe('b');
+  });
+});

--- a/apps/web/src/components/lens-v2/entity/WorkOrderContent.tsx
+++ b/apps/web/src/components/lens-v2/entity/WorkOrderContent.tsx
@@ -22,6 +22,7 @@ import styles from '../lens.module.css';
 import { IdentityStrip, type PillDef, type DetailLine } from '../IdentityStrip';
 import { SplitButton, type DropdownItem } from '../SplitButton';
 import { ScrollReveal } from '../ScrollReveal';
+import { LensTabBar, type LensTab } from '../LensTabBar';
 import { useEntityLensContext } from '@/contexts/EntityLensContext';
 import { getEntityRoute } from '@/lib/entityRoutes';
 import { AddNoteModal } from '@/components/lens-v2/actions/AddNoteModal';
@@ -94,15 +95,25 @@ export function WorkOrderContent() {
   const description = (entity?.description ?? payload.description) as string | undefined;
   const status = ((entity?.status ?? payload.status) as string | undefined) ?? 'draft';
   const priority = ((entity?.priority ?? payload.priority) as string | undefined) ?? 'medium';
+  const severity = (entity?.severity ?? payload.severity) as string | undefined;
   const equipment_id = (entity?.equipment_id ?? payload.equipment_id) as string | undefined;
   const equipment_name = (entity?.equipment_name ?? payload.equipment_name) as string | undefined;
   const equipment_code = (entity?.equipment_code ?? payload.equipment_code) as string | undefined;
+  // assigned_to may arrive as a resolved name (from the work-orders batch
+  // enrichment in vessel_surface_routes.py) OR as a raw UUID if the entity
+  // endpoint hasn't been enriched yet. Prefer the resolved form.
   const assigned_to = (entity?.assigned_to_name ?? payload.assigned_to_name ?? entity?.assigned_to ?? payload.assigned_to) as string | undefined;
+  const assigned_to_role = (entity?.assigned_to_role ?? payload.assigned_to_role) as string | undefined;
   const location = (entity?.location ?? payload.location) as string | undefined;
   const due_date = (entity?.due_date ?? payload.due_date) as string | undefined;
-  const wo_type = (entity?.type ?? payload.type) as string | undefined;
-  const est_hours = (entity?.estimated_hours ?? payload.estimated_hours) as number | undefined;
+  const due_at = (entity?.due_at ?? payload.due_at) as string | undefined;
+  const created_at = (entity?.created_at ?? payload.created_at) as string | undefined;
+  const wo_type = (entity?.type ?? payload.type ?? entity?.work_order_type ?? payload.work_order_type) as string | undefined;
+  const frequency = (entity?.frequency ?? payload.frequency) as string | undefined;
+  const completed_at = (entity?.completed_at ?? payload.completed_at) as string | undefined;
+  const est_hours = (entity?.estimated_hours ?? payload.estimated_hours ?? entity?.estimated_duration_minutes) as number | undefined;
   const actual_hours = (entity?.actual_hours ?? payload.actual_hours) as number | undefined;
+  const faults = ((entity?.faults ?? payload.faults ?? entity?.linked_faults ?? payload.linked_faults) as Array<Record<string, unknown>> | undefined) ?? [];
 
   // Section data
   const notes = ((entity?.notes ?? payload.notes) as Array<Record<string, unknown>> | undefined) ?? [];
@@ -139,37 +150,72 @@ export function WorkOrderContent() {
   const statusLabel = formatLabel(status);
   const priorityLabel = formatLabel(priority);
 
+  // Pills — UX sheet lines 374-380: status + priority + severity + wo_type
+  // all surfaced in the header. Severity is distinct from priority (UX line
+  // 340: "highly valuable, not visible").
   const pills: PillDef[] = [
     { label: statusLabel, variant: statusToPillVariant(status) },
   ];
-  if (priority !== 'medium') {
+  if (priority !== 'medium' && priority !== 'normal') {
     pills.push({ label: priorityLabel, variant: priorityToPillVariant(priority) });
   }
+  if (severity) {
+    const sev = severity.toLowerCase();
+    const sevVariant: PillDef['variant'] =
+      sev === 'critical' || sev === 'high' ? 'red' : sev === 'warning' || sev === 'medium' ? 'amber' : 'neutral';
+    pills.push({ label: formatLabel(severity), variant: sevVariant });
+  }
+  if (wo_type) {
+    pills.push({ label: formatLabel(wo_type), variant: 'neutral' });
+  }
 
+  // Detail lines — UX sheet lines 374-381: wo_number and title in header,
+  // then assigned_to, created_at, due_date+due_at, severity as key/value.
   const details: DetailLine[] = [];
   if (equipment_name) {
     details.push({ label: 'Equipment', value: `${equipment_code ?? ''} ${equipment_name}`.trim() });
   }
-  if (due_date) {
-    details.push({ label: 'Due', value: due_date, mono: true });
+  if (due_date || due_at) {
+    const dueValue = [due_date, due_at].filter(Boolean).join(' · ');
+    details.push({ label: 'Due', value: dueValue, mono: true });
+  }
+  if (created_at) {
+    // "YYYY-MM-DD" is legible and stable. If consumer wants humanised, that's
+    // a later UX polish — don't break the mono column for it.
+    details.push({ label: 'Created', value: String(created_at).slice(0, 10), mono: true });
+  }
+  if (frequency) {
+    details.push({ label: 'Frequency', value: formatLabel(frequency) });
+  }
+  if (completed_at) {
+    details.push({ label: 'Completed', value: String(completed_at).slice(0, 10), mono: true });
   }
   if (est_hours !== undefined || actual_hours !== undefined) {
     const parts: string[] = [];
-    if (est_hours !== undefined) parts.push(`Est: ${est_hours} hrs`);
-    if (actual_hours !== undefined) parts.push(`Actual: ${actual_hours} hrs`);
-    details.push({ label: 'Time', value: parts.join(' · ') });
+    if (est_hours !== undefined) parts.push(`Est: ${est_hours}`);
+    if (actual_hours !== undefined) parts.push(`Actual: ${actual_hours}`);
+    details.push({ label: 'Hours', value: parts.join(' · ') });
   }
 
-  // Context line
+  // Context line — UUIDs must never render. If assigned_to came through as a
+  // raw UUID (entity endpoint hasn't been enriched) suppress rather than
+  // displaying it.
+  const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+  const assignedDisplay =
+    assigned_to && !UUID_RE.test(assigned_to)
+      ? assigned_to_role
+        ? `${assigned_to} (${formatLabel(assigned_to_role)})`
+        : assigned_to
+      : undefined;
   const contextParts: string[] = [];
   if (location) contextParts.push(location);
   const contextNode = (
     <>
       {contextParts.join(' · ')}
-      {assigned_to && (
+      {assignedDisplay && (
         <>
           {contextParts.length > 0 && ' · '}
-          Assigned to <span className={styles.crewLink}>{assigned_to}</span>
+          Assigned to <span className={styles.crewLink}>{assignedDisplay}</span>
         </>
       )}
     </>
@@ -249,12 +295,22 @@ export function WorkOrderContent() {
     'upload_photo',
   ]);
 
+  // Dropdown-display label overrides.
+  // Issue 6 line 238: rename "Update Worklist Progress" → "Change Status".
+  // Renaming at the display layer keeps the backend action_id stable
+  // (update_worklist_progress), so in-flight callers / tests don't break.
+  const LABEL_OVERRIDES: Record<string, string> = {
+    update_worklist_progress: 'Change Status',
+    assign_work_order: 'Assign',
+    archive_work_order: 'Archive',
+  };
+
   const primaryActionId = canStart ? 'start_work_order' : 'close_work_order';
   const dropdownItems: DropdownItem[] = availableActions
     .filter((a) => a.action_id !== primaryActionId)
     .filter((a) => !HIDDEN_FROM_DROPDOWN.has(a.action_id))
     .map((a) => ({
-      label: a.label,
+      label: LABEL_OVERRIDES[a.action_id] ?? a.label,
       onClick: SPECIAL_HANDLERS[a.action_id]
         ? SPECIAL_HANDLERS[a.action_id]
         : () => executeAction(a.action_id),
@@ -350,9 +406,84 @@ export function WorkOrderContent() {
     []
   );
 
+  // ── Tab contract (UX sheet line 382) ──
+  //   Checklist · Documents · Faults · Equipment · Parts · Uploads · Notes ·
+  //   Audit Trail · History · Safety
+  //
+  // Safety is a placeholder in PR-WO-3 — LOTO/SOP + Checklist overhaul land
+  // in PR-WO-4, where the `pms_work_order_checklist` / `pms_checklist` /
+  // `pms_checklist_items` table audit unlocks the real content.
+  const tabs: LensTab[] = [
+    { key: 'checklist', label: 'Checklist', count: checklistItems.length },
+    { key: 'documents', label: 'Documents', count: docItems.length },
+    { key: 'faults',    label: 'Faults',    count: faults.length },
+    { key: 'equipment', label: 'Equipment', count: equipment_name ? 1 : 0 },
+    { key: 'parts',     label: 'Parts',     count: partItems.length },
+    { key: 'uploads',   label: 'Uploads',   count: attachmentItems.length },
+    { key: 'notes',     label: 'Notes',     count: noteItems.length },
+    { key: 'audit',     label: 'Audit Trail', count: auditEvents.length },
+    { key: 'history',   label: 'History',   count: historyPeriods.length },
+    { key: 'safety',    label: 'Safety',    disabled: true, disabledReason: 'LOTO + SOP attachments land with PR-WO-4 checklist overhaul' },
+  ];
+
+  const renderTabBody = (activeKey: string): React.ReactNode => {
+    switch (activeKey) {
+      case 'checklist':
+        return <ChecklistSection items={checklistItems} onToggle={handleChecklistToggle} />;
+      case 'documents':
+        return docItems.length > 0 ? (
+          <DocRowsSection title="Official Documents" docs={docItems} />
+        ) : (
+          <EmptyTab message="No supporting documents linked to this work order." />
+        );
+      case 'faults':
+        return faults.length > 0 ? (
+          <FaultsTabBody faults={faults} onOpen={(faultId) => router.push(getEntityRoute('faults' as Parameters<typeof getEntityRoute>[0], faultId))} />
+        ) : (
+          <EmptyTab message="No linked faults. Use 'Report Fault' from the Equipment lens to link one." />
+        );
+      case 'equipment':
+        return equipment_id && equipment_name ? (
+          <EquipmentTabBody
+            equipmentId={equipment_id}
+            equipmentName={equipment_name}
+            equipmentCode={equipment_code}
+            onOpen={() => router.push(getEntityRoute('equipment' as Parameters<typeof getEntityRoute>[0], equipment_id))}
+          />
+        ) : (
+          <EmptyTab message="No equipment linked." />
+        );
+      case 'parts':
+        return (
+          <PartsSection
+            parts={partItems}
+            onAddPart={handleAddPart}
+            canAddPart
+          />
+        );
+      case 'uploads':
+        return (
+          <AttachmentsSection
+            attachments={attachmentItems}
+            onAddFile={() => {/* wired in PR-WO-4 with the photo+comment flow */}}
+            canAddFile
+          />
+        );
+      case 'notes':
+        return <NotesSection notes={noteItems} onAddNote={handleAddNote} canAddNote />;
+      case 'audit':
+        return <AuditTrailSection events={auditEvents} />;
+      case 'history':
+        return <HistorySection periods={historyPeriods} />;
+      case 'safety':
+      default:
+        return <EmptyTab message="Safety (LOTO + SOP) ships with PR-WO-4." />;
+    }
+  };
+
   return (
     <>
-      {/* Identity Strip */}
+      {/* Identity Strip — UX lines 373-381: wo_number overline, title, type/status/priority/severity pills, assigned_to + due + created + frequency + completed details */}
       <IdentityStrip
         overline={wo_number}
         title={title}
@@ -373,55 +504,12 @@ export function WorkOrderContent() {
         }
       />
 
-      {/* Official Documents */}
-      {docItems.length > 0 && (
-        <ScrollReveal>
-          <DocRowsSection title="Official Documents" docs={docItems} />
-        </ScrollReveal>
-      )}
-
-      {/* Checklist */}
-      {checklistItems.length > 0 && (
-        <ScrollReveal>
-          <ChecklistSection items={checklistItems} onToggle={handleChecklistToggle} />
-        </ScrollReveal>
-      )}
-
-      {/* Notes */}
+      {/* Tab bar replaces the legacy stacked ScrollReveal sections. */}
       <ScrollReveal>
-        <NotesSection
-          notes={noteItems}
-          onAddNote={handleAddNote}
-          canAddNote
-        />
-      </ScrollReveal>
-
-      {/* History — prior periods of the same work order */}
-      <ScrollReveal>
-        <HistorySection periods={historyPeriods} defaultCollapsed />
-      </ScrollReveal>
-
-      {/* Audit Trail — user actions on this entity */}
-      <ScrollReveal>
-        <AuditTrailSection events={auditEvents} defaultCollapsed />
-      </ScrollReveal>
-
-      {/* Attachments */}
-      <ScrollReveal>
-        <AttachmentsSection
-          attachments={attachmentItems}
-          onAddFile={() => {/* TODO: wire to file upload modal */}}
-          canAddFile
-        />
-      </ScrollReveal>
-
-      {/* Parts */}
-      <ScrollReveal>
-        <PartsSection
-          parts={partItems}
-          onAddPart={handleAddPart}
-          canAddPart
-          defaultCollapsed
+        <LensTabBar
+          tabs={tabs}
+          defaultActiveKey="checklist"
+          renderBody={renderTabBody}
         />
       </ScrollReveal>
 
@@ -433,5 +521,125 @@ export function WorkOrderContent() {
         isLoading={isLoading}
       />
     </>
+  );
+}
+
+// ── Tab body helpers ───────────────────────────────────────────────────────
+
+function EmptyTab({ message }: { message: string }) {
+  return (
+    <div
+      style={{
+        padding: '24px 16px',
+        textAlign: 'center',
+        color: 'var(--txt3)',
+        fontSize: 13,
+      }}
+    >
+      {message}
+    </div>
+  );
+}
+
+interface FaultRow {
+  id: string;
+  fault_code?: string;
+  title?: string;
+  status?: string;
+  severity?: string;
+}
+
+function FaultsTabBody({
+  faults,
+  onOpen,
+}: {
+  faults: Array<Record<string, unknown>>;
+  onOpen: (faultId: string) => void;
+}) {
+  const rows: FaultRow[] = faults.map((f, i) => ({
+    id: (f.id as string) ?? `fault-${i}`,
+    fault_code: (f.fault_code ?? f.code) as string | undefined,
+    title: (f.title ?? f.description) as string | undefined,
+    status: f.status as string | undefined,
+    severity: f.severity as string | undefined,
+  }));
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+      {rows.map((r) => (
+        <button
+          key={r.id}
+          type="button"
+          onClick={() => onOpen(r.id)}
+          style={{
+            appearance: 'none',
+            WebkitAppearance: 'none',
+            textAlign: 'left',
+            background: 'var(--surface)',
+            border: '1px solid var(--border-faint)',
+            borderRadius: 6,
+            padding: '10px 12px',
+            cursor: 'pointer',
+            color: 'var(--txt)',
+          }}
+        >
+          <div style={{ display: 'flex', alignItems: 'center', gap: 8, fontSize: 12 }}>
+            {r.fault_code && (
+              <span style={{ fontFamily: 'var(--font-mono)', color: 'var(--txt2)' }}>
+                {r.fault_code}
+              </span>
+            )}
+            <span style={{ fontWeight: 600 }}>{r.title ?? 'Fault'}</span>
+          </div>
+          {(r.status || r.severity) && (
+            <div style={{ marginTop: 4, fontSize: 11, color: 'var(--txt3)' }}>
+              {[r.severity, r.status].filter(Boolean).join(' · ')}
+            </div>
+          )}
+        </button>
+      ))}
+    </div>
+  );
+}
+
+function EquipmentTabBody({
+  equipmentId: _equipmentId,
+  equipmentName,
+  equipmentCode,
+  onOpen,
+}: {
+  equipmentId: string;
+  equipmentName: string;
+  equipmentCode?: string;
+  onOpen: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onOpen}
+      style={{
+        appearance: 'none',
+        WebkitAppearance: 'none',
+        textAlign: 'left',
+        background: 'var(--surface)',
+        border: '1px solid var(--border-faint)',
+        borderRadius: 6,
+        padding: '12px 14px',
+        cursor: 'pointer',
+        color: 'var(--txt)',
+        width: '100%',
+      }}
+    >
+      <div style={{ display: 'flex', alignItems: 'center', gap: 8, fontSize: 13 }}>
+        {equipmentCode && (
+          <span style={{ fontFamily: 'var(--font-mono)', color: 'var(--txt2)' }}>
+            {equipmentCode}
+          </span>
+        )}
+        <span style={{ fontWeight: 600 }}>{equipmentName}</span>
+      </div>
+      <div style={{ marginTop: 4, fontSize: 11, color: 'var(--txt3)' }}>
+        Open equipment lens →
+      </div>
+    </button>
   );
 }

--- a/apps/web/src/components/lens-v2/index.ts
+++ b/apps/web/src/components/lens-v2/index.ts
@@ -13,6 +13,7 @@ export { LensGlassHeader, type LensGlassHeaderProps } from './LensGlassHeader';
 export { IdentityStrip, type IdentityStripProps, type DetailLine, type PillDef } from './IdentityStrip';
 export { SplitButton, type SplitButtonProps, type DropdownItem } from './SplitButton';
 export { CollapsibleSection, type CollapsibleSectionProps } from './CollapsibleSection';
+export { LensTabBar, type LensTab, type LensTabBarProps } from './LensTabBar';
 export { LensPill, type LensPillProps, type PillVariant } from './LensPill';
 export { ScrollReveal, type ScrollRevealProps } from './ScrollReveal';
 

--- a/docs/ongoing_work/work_orders/PLAN.md
+++ b/docs/ongoing_work/work_orders/PLAN.md
@@ -13,8 +13,8 @@ Working alongside WORKORDER05 / HANDOVER08 / EQUIPMENT05 / FAULT05 / SHOPPINGLIS
 | PR | Subject | Status | Notes |
 |----|---------|--------|-------|
 | PR-WO-1 | Dedupe prefill + wire KEEP action buttons | MERGED #686 | 400s on work-order dropdown dead |
-| PR-WO-2 | Tabulated list view on shared `EntityTableList` | OPEN | 12 cols per UX sheet; backend batch resolvers for equipment_name + assigned_to_name |
-| PR-WO-3 | Lens card redesign — horizontal tabs + metadata de-UUID | PENDING | Safety / Checklist / Docs / Faults / Equipment / Parts / Uploads / Notes / Audit / History |
+| PR-WO-2 | Tabulated list view on shared `EntityTableList` | MERGED #687 | 12 cols live; backend batch resolvers in place |
+| PR-WO-3 | Lens card redesign — horizontal tabs + metadata de-UUID | OPEN | 10-tab LensTabBar; extended header metadata; "Change Status" rename |
 | PR-WO-4 | Checklist overhaul (DB audit + bucket wiring) | PENDING | `pms_work_order_checklist` + `pms_checklist` + `pms_checklist_items` audit first |
 | PR-WO-5 | Calendar tab (List / Calendar toggle) | PENDING | Seahub-style; clickable cards; colour by type/criticality |
 | PR-WO-6 | Fault→WO bridge + WO-complete→fault auto-resolve | PENDING | Coord with FAULT05 (`wq0prarm`); needs `pms_faults.resolved_by_work_order_id` migration |
@@ -101,4 +101,35 @@ UX sheet `/Users/celeste7/Desktop/lens_card_upgrades.md:492 + 506-522` — move 
 
 ---
 
-## PR-WO-3..7 — detailed scope will be filled in as each opens.
+## PR-WO-3 — card redesign (shipped 2026-04-23)
+
+### Scope
+UX sheet `/Users/celeste7/Desktop/lens_card_upgrades.md:300-405` — the legacy work-order card "reads like a receipt". CEO asks for a deeper, tabbed card with safety / sop / LOTO visibility, reverse-linked equipment + faults, and all the hidden header metadata (severity, type, due_date + due_at, frequency, completed_at).
+
+### Changes
+- **`apps/web/src/components/lens-v2/LensTabBar.tsx` (new)** — shared horizontal tab-bar component. Sticky, keyboard-navigable (←/→ skip disabled tabs), aria-compliant (`role=tablist`/`tab`/`tabpanel`, `aria-selected`, `aria-controls`, `aria-disabled`), tokenised only. Count badges suppress when count = 0. Controlled + uncontrolled modes. Cohort-shared — available for FAULT05, EQUIPMENT05, HANDOVER08 to adopt.
+- **`apps/web/src/components/lens-v2/index.ts`** — export barrel updated.
+- **`apps/web/src/components/lens-v2/entity/WorkOrderContent.tsx`** —
+  - Extended header metadata: `wo_number` overline, title, status/priority/severity/type pills (UX lines 374-380). Details now include Equipment, Due (`due_date` + `due_at`), Created, Frequency, Completed, Hours. Severity is now distinct from priority.
+  - Added `LABEL_OVERRIDES` so `update_worklist_progress` renders as "Change Status" in the dropdown (UX line 238) without breaking the backend action_id.
+  - Added UUID-guard on `assigned_to` display — if the entity endpoint hasn't been enriched and the value is still a raw UUID, the Assigned link suppresses entirely rather than leaking the id. Role (`assigned_to_role`) appended when present, e.g. "Alex Kapranos (Chief Engineer)".
+  - Replaced the legacy stacked `ScrollReveal` sections with a 10-tab `LensTabBar`: Checklist · Documents · Faults · Equipment · Parts · Uploads · Notes · Audit Trail · History · Safety.
+  - Each tab either renders its existing section component or an `EmptyTab` with a clear next-step message. `FaultsTabBody` + `EquipmentTabBody` helpers render minimal linked-entity cards that navigate to the corresponding lens on click.
+  - `Safety` tab is `disabled: true` with `disabledReason="LOTO + SOP attachments land with PR-WO-4 checklist overhaul"` — no dead tab, no silent failure.
+- **`apps/web/src/components/lens-v2/__tests__/LensTabBar.test.tsx` (new)** — 7 specs: tab rendering + aria wiring, count-badge suppression, disabled aria + click-ignore, onChange + body switch, ←/→ keyboard wrap skipping disabled, controlled-mode passivity, first-enabled-default fallback.
+
+### Verification
+- `vitest run src/components/lens-v2/__tests__/LensTabBar.test.tsx` → 7/7 green
+- `vitest run src/features/work-orders/__tests__/columns.test.tsx` → 11/11 green (regression)
+- `npx tsc --noEmit` on apps/web → clean
+
+### Deferred (PR-WO-4..7)
+- Safety tab content (LOTO + SOP attachments) → PR-WO-4.
+- Checklist custom K/V, photo+comment upload, bucket wiring, soft-delete 30d → PR-WO-4.
+- Calendar tab (List / Calendar toggle) → PR-WO-5.
+- Fault→WO bridge + WO-complete→fault auto-resolve → PR-WO-6 (needs `pms_faults.resolved_by_work_order_id` migration; FAULT05 confirmed column absent + enum is `open/investigating/acknowledged/work_ordered/resolved/closed`).
+- `system_id` + running-hours columns → PR-WO-7.
+
+---
+
+## PR-WO-4..7 — detailed scope will be filled in as each opens.


### PR DESCRIPTION
## Summary
- UX sheet `/Users/celeste7/Desktop/lens_card_upgrades.md:300-405` — legacy card "reads like a receipt"; redesign with horizontal tabs + full header metadata + UUID-free Assigned display.
- Introduces shared `LensTabBar` (cohort-reusable by FAULT05 / EQUIPMENT05 / HANDOVER08) — sticky, keyboard-navigable, aria-compliant, tokenised.
- Renames `Update Worklist Progress` → `Change Status` at the display layer (Issue 6 line 238) without touching the backend `update_worklist_progress` action_id.

## Files
- `apps/web/src/components/lens-v2/LensTabBar.tsx` **(new)** — shared tabs component with 7-spec unit coverage.
- `apps/web/src/components/lens-v2/__tests__/LensTabBar.test.tsx` **(new)** — 7 vitest specs.
- `apps/web/src/components/lens-v2/index.ts` — barrel export.
- `apps/web/src/components/lens-v2/entity/WorkOrderContent.tsx` — extended header (pills for status/priority/severity/type, details for due_date+due_at, created_at, frequency, completed_at, hours), 10-tab layout, UUID-guard on Assigned, label overrides.
- `docs/ongoing_work/work_orders/PLAN.md` — PR-WO-3 writeup + deferred list.

## Tabs
Checklist · Documents · Faults · Equipment · Parts · Uploads · Notes · Audit Trail · History · **Safety** (disabled until PR-WO-4 delivers LOTO + SOP).

## Header metadata now visible (UX sheet lines 374-381)
- Pills: Status, Priority (if non-default), Severity, Type
- Details: Equipment (code + name), Due (due_date + due_at), Created, Frequency, Completed, Hours (Est + Actual)
- Context line: `location · Assigned to {name} ({role})` with UUID-guard

## Test plan
- [x] `vitest run LensTabBar.test.tsx` → 7/7 green
- [x] `vitest run columns.test.tsx` → 11/11 green (regression)
- [x] `npx tsc --noEmit` on apps/web → clean
- [ ] Post-merge: visual check on `app.celeste7.ai/work-orders` — open any WO, verify all 10 tabs render, Safety is disabled, keyboard arrow-nav works, Assigned line shows name (not UUID) or nothing

## Deferred (PR-WO-4..7)
Safety LOTO/SOP content, checklist overhaul (DB + bucket + soft-delete + K/V), calendar tab, fault↔WO bridge, schema additions (system_id, running hours).

🤖 Generated with [Claude Code](https://claude.com/claude-code)