### PR TITLE
feat(work-orders): fault auto-resolve bridge on close_work_order

### DIFF
--- a/apps/api/action_router/dispatchers/internal_dispatcher.py
+++ b/apps/api/action_router/dispatchers/internal_dispatcher.py
@@ -303,25 +303,115 @@ async def close_work_order(params: Dict[str, Any]) -> Dict[str, Any]:
         - yacht_id: UUID
         - work_order_id: UUID
         - user_id: UUID (from JWT)
+
+    Side effect (PR-WO-6, 2026-04-23):
+        If the work order was created from a fault (fault_id IS NOT NULL) and
+        the linked fault is not yet terminal (status NOT IN {resolved, closed}),
+        transition the fault to status='resolved', stamp resolved_at + the FK
+        resolved_by_work_order_id, and emit a `fault_auto_resolved` ledger
+        event so FAULT05's lens can refetch.
+
+        The FK column write is gated by the 20260423 migration. If the column
+        does not exist yet (migration not applied in this environment) the
+        status + timestamp still flow and the FK write is skipped — no 500.
     """
     supabase = get_supabase_client()
+    wo_id = params["work_order_id"]
+    yacht_id = params["yacht_id"]
+    user_id = params["user_id"]
+
+    # Pre-read: need the fault_id to know whether to bridge. One extra read
+    # is cheap; the alternative (returning fault_id from the UPDATE ... RETURNING)
+    # needs supabase-py support we don't have here.
+    wo_pre = supabase.table("pms_work_orders").select(
+        "id, fault_id"
+    ).eq("id", wo_id).eq("yacht_id", yacht_id).limit(1).execute()
+    fault_id = (wo_pre.data[0].get("fault_id") if wo_pre.data else None)
 
     # Update work order status
+    now_iso = datetime.utcnow().isoformat()
     result = supabase.table("pms_work_orders").update({
         "status": "completed",
-        "completed_at": datetime.utcnow().isoformat(),
-        "completed_by": params["user_id"],
-    }).eq("id", params["work_order_id"]).eq(
-        "yacht_id", params["yacht_id"]
-    ).execute()
+        "completed_at": now_iso,
+        "completed_by": user_id,
+    }).eq("id", wo_id).eq("yacht_id", yacht_id).execute()
 
     if not result.data:
-        raise ValueError(f"Work order {params['work_order_id']} not found or access denied")
+        raise ValueError(f"Work order {wo_id} not found or access denied")
+
+    # ── Fault auto-resolve bridge ──
+    fault_auto_resolved = False
+    if fault_id:
+        try:
+            # Inspect current fault state — only transition if not terminal.
+            fr = supabase.table("pms_faults").select(
+                "id, status"
+            ).eq("id", fault_id).eq("yacht_id", yacht_id).limit(1).execute()
+            current_status = (fr.data[0].get("status") if fr.data else None)
+
+            if current_status and current_status not in ("resolved", "closed"):
+                update_payload: Dict[str, Any] = {
+                    "status": "resolved",
+                    "resolved_at": now_iso,
+                    "resolved_by": user_id,
+                }
+                # Try to include the FK — guarded because the 20260423
+                # migration may not be applied in every environment.
+                try:
+                    supabase.table("pms_faults").update({
+                        **update_payload,
+                        "resolved_by_work_order_id": wo_id,
+                    }).eq("id", fault_id).eq("yacht_id", yacht_id).execute()
+                except Exception as col_err:
+                    logger.warning(
+                        "close_work_order: fault FK write failed (column "
+                        "likely absent; retrying without FK): %s", col_err
+                    )
+                    supabase.table("pms_faults").update(update_payload).eq(
+                        "id", fault_id
+                    ).eq("yacht_id", yacht_id).execute()
+
+                fault_auto_resolved = True
+
+                # Ledger emission — FAULT05's lens reacts to this to refetch.
+                try:
+                    from routes.handlers.ledger_utils import build_ledger_event
+                    ev = build_ledger_event(
+                        yacht_id=yacht_id,
+                        user_id=user_id,
+                        event_type="status_change",
+                        entity_type="fault",
+                        entity_id=fault_id,
+                        action="fault_auto_resolved",
+                        change_summary=f"Auto-resolved by WO {wo_id} completion",
+                        metadata={
+                            "resolved_by_work_order_id": wo_id,
+                            "previous_status": current_status,
+                            "new_status": "resolved",
+                        },
+                    )
+                    supabase.table("ledger_events").insert(ev).execute()
+                except Exception as ledger_err:
+                    logger.warning(
+                        "close_work_order: fault_auto_resolved ledger "
+                        "emission failed (fault=%s, wo=%s): %s",
+                        fault_id, wo_id, ledger_err
+                    )
+        except Exception as bridge_err:
+            # Bridge is best-effort; don't fail the WO close just because the
+            # fault side couldn't transition. Operator will see the ledger
+            # gap and can fix manually.
+            logger.warning(
+                "close_work_order: fault bridge failed (fault=%s, wo=%s): %s",
+                fault_id, wo_id, bridge_err
+            )
 
     return {
         "work_order_id": result.data[0]["id"],
         "status": result.data[0]["status"],
         "completed_at": result.data[0]["completed_at"],
+        "fault_auto_resolved": fault_auto_resolved,
+        "linked_fault_id": fault_id,
     }
 
 

--- a/apps/api/tests/test_close_work_order_bridge.py
+++ b/apps/api/tests/test_close_work_order_bridge.py
@@ -1,0 +1,243 @@
+# apps/api/tests/test_close_work_order_bridge.py
+"""
+Unit tests for the close_work_order → fault auto-resolve bridge (PR-WO-6).
+
+Verifies:
+    * WO with no fault_id → no fault mutation, no ledger emission.
+    * WO with fault_id + fault already resolved → no re-write (idempotent).
+    * WO with fault_id + fault open → fault.status='resolved' + ledger row +
+      resolved_by_work_order_id FK written.
+    * FK write fails (column missing) → retries without FK, bridge still
+      transitions fault status and emits ledger.
+    * Bridge exceptions never fail the WO close.
+
+All supabase-py interactions are mocked via a fake client that records calls.
+No DB, no network.
+"""
+
+import sys
+import os
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+
+YACHT = "yacht-uuid-1"
+USER = "user-uuid-1"
+WO = "wo-uuid-1"
+FAULT = "fault-uuid-1"
+
+
+# ── Fake supabase client ───────────────────────────────────────────────────
+
+
+class _Query:
+    """Fluent query stub that records operations and returns canned data."""
+
+    def __init__(self, parent, table_name):
+        self.parent = parent
+        self.table_name = table_name
+        self._filters = []
+        self._op = None
+        self._payload = None
+
+    # chainable filter methods (all no-ops recording filter state)
+    def select(self, _cols):
+        self._op = "select"
+        return self
+
+    def update(self, payload):
+        self._op = "update"
+        self._payload = payload
+        return self
+
+    def insert(self, payload):
+        self._op = "insert"
+        self._payload = payload
+        return self
+
+    def eq(self, k, v):
+        self._filters.append(("eq", k, v))
+        return self
+
+    def limit(self, _n):
+        return self
+
+    def execute(self):
+        self.parent.calls.append({
+            "table": self.table_name,
+            "op": self._op,
+            "payload": self._payload,
+            "filters": tuple(self._filters),
+        })
+        if self._op == "update" and self.parent.update_raises_on.get(self.table_name):
+            err = self.parent.update_raises_on[self.table_name]
+            # Raise only the first time — mimic "column does not exist"
+            self.parent.update_raises_on[self.table_name] = None
+            raise err
+
+        canned_key = (self.table_name, self._op)
+        canned = self.parent.canned.get(canned_key, {"data": [], "count": 0})
+        return MagicMock(data=canned["data"], count=canned["count"])
+
+
+class FakeClient:
+    def __init__(self):
+        self.calls = []
+        self.canned = {}
+        self.update_raises_on = {}
+
+    def table(self, name):
+        return _Query(self, name)
+
+
+# ── Test harness ───────────────────────────────────────────────────────────
+
+
+def _import_close_handler():
+    from action_router.dispatchers.internal_dispatcher import close_work_order
+    return close_work_order
+
+
+def _base_canned(wo_fault_id=None, fault_status="open"):
+    """Canned responses for: pre-read WO, read fault, update WO."""
+    return {
+        ("pms_work_orders", "select"): {
+            "data": [{"id": WO, "fault_id": wo_fault_id}], "count": 1,
+        },
+        ("pms_faults", "select"): {
+            "data": [{"id": FAULT, "status": fault_status}], "count": 1,
+        },
+        ("pms_work_orders", "update"): {
+            "data": [{"id": WO, "status": "completed", "completed_at": "2026-04-23T21:00:00"}],
+            "count": 1,
+        },
+        ("pms_faults", "update"): {
+            "data": [{"id": FAULT, "status": "resolved"}], "count": 1,
+        },
+        ("ledger_events", "insert"): {"data": [{"id": "ledger-1"}], "count": 1},
+    }
+
+
+async def _invoke(client):
+    fn = _import_close_handler()
+    with patch(
+        "action_router.dispatchers.internal_dispatcher.get_supabase_client",
+        return_value=client,
+    ):
+        return await fn({
+            "yacht_id": YACHT,
+            "work_order_id": WO,
+            "user_id": USER,
+        })
+
+
+# ── Tests ──────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_wo_with_no_fault_id_does_not_touch_faults_or_ledger():
+    client = FakeClient()
+    client.canned = _base_canned(wo_fault_id=None)
+    out = await _invoke(client)
+
+    assert out["fault_auto_resolved"] is False
+    assert out["linked_fault_id"] is None
+    tables_hit = [c["table"] for c in client.calls]
+    assert "pms_faults" not in tables_hit
+    assert "ledger_events" not in tables_hit
+
+
+@pytest.mark.asyncio
+async def test_wo_with_open_fault_transitions_and_emits_ledger():
+    client = FakeClient()
+    client.canned = _base_canned(wo_fault_id=FAULT, fault_status="open")
+    out = await _invoke(client)
+
+    assert out["fault_auto_resolved"] is True
+    assert out["linked_fault_id"] == FAULT
+
+    fault_updates = [
+        c for c in client.calls
+        if c["table"] == "pms_faults" and c["op"] == "update"
+    ]
+    assert len(fault_updates) == 1, "fault should be updated exactly once"
+    payload = fault_updates[0]["payload"]
+    assert payload["status"] == "resolved"
+    assert payload["resolved_by"] == USER
+    assert payload["resolved_by_work_order_id"] == WO, (
+        "FK write must be present when the column exists"
+    )
+
+    ledger_inserts = [
+        c for c in client.calls
+        if c["table"] == "ledger_events" and c["op"] == "insert"
+    ]
+    assert len(ledger_inserts) == 1
+    ev = ledger_inserts[0]["payload"]
+    assert ev["action"] == "fault_auto_resolved"
+    assert ev["entity_type"] == "fault"
+    assert ev["entity_id"] == FAULT
+
+
+@pytest.mark.asyncio
+async def test_fault_already_resolved_is_not_re_written():
+    for terminal in ("resolved", "closed"):
+        client = FakeClient()
+        client.canned = _base_canned(wo_fault_id=FAULT, fault_status=terminal)
+        out = await _invoke(client)
+
+        assert out["fault_auto_resolved"] is False, terminal
+        fault_updates = [
+            c for c in client.calls
+            if c["table"] == "pms_faults" and c["op"] == "update"
+        ]
+        assert fault_updates == [], f"idempotent on terminal status={terminal}"
+        ledger_inserts = [
+            c for c in client.calls
+            if c["table"] == "ledger_events" and c["op"] == "insert"
+        ]
+        assert ledger_inserts == [], "no ledger row when fault untouched"
+
+
+@pytest.mark.asyncio
+async def test_fk_column_absent_falls_back_without_fk():
+    client = FakeClient()
+    client.canned = _base_canned(wo_fault_id=FAULT, fault_status="open")
+    # First update on pms_faults raises (simulating missing column); second call succeeds.
+    client.update_raises_on["pms_faults"] = Exception(
+        'column "resolved_by_work_order_id" of relation "pms_faults" does not exist'
+    )
+
+    out = await _invoke(client)
+
+    assert out["fault_auto_resolved"] is True
+
+    fault_updates = [
+        c for c in client.calls
+        if c["table"] == "pms_faults" and c["op"] == "update"
+    ]
+    assert len(fault_updates) == 2, "first call with FK raises; retry without FK"
+    assert "resolved_by_work_order_id" in fault_updates[0]["payload"]
+    assert "resolved_by_work_order_id" not in fault_updates[1]["payload"]
+    # Ledger event still emitted
+    assert any(c["table"] == "ledger_events" for c in client.calls)
+
+
+@pytest.mark.asyncio
+async def test_wo_not_found_raises_before_bridge_runs():
+    client = FakeClient()
+    client.canned = _base_canned(wo_fault_id=FAULT)
+    client.canned[("pms_work_orders", "update")] = {"data": [], "count": 0}
+
+    with pytest.raises(ValueError, match="not found"):
+        await _invoke(client)
+
+    # Bridge must not have fired
+    fault_updates = [
+        c for c in client.calls
+        if c["table"] == "pms_faults" and c["op"] == "update"
+    ]
+    assert fault_updates == []

--- a/docs/ongoing_work/work_orders/PLAN.md
+++ b/docs/ongoing_work/work_orders/PLAN.md
@@ -17,7 +17,7 @@ Working alongside WORKORDER05 / HANDOVER08 / EQUIPMENT05 / FAULT05 / SHOPPINGLIS
 | PR-WO-3 | Lens card redesign — horizontal tabs + metadata de-UUID | OPEN | 10-tab LensTabBar; extended header metadata; "Change Status" rename |
 | PR-WO-4 | Checklist overhaul (DB audit + bucket wiring) | PENDING | `pms_work_order_checklist` + `pms_checklist` + `pms_checklist_items` audit first |
 | PR-WO-5 | Calendar tab (List / Calendar toggle) | PENDING | Seahub-style; clickable cards; colour by type/criticality |
-| PR-WO-6 | Fault→WO bridge + WO-complete→fault auto-resolve | PENDING | Coord with FAULT05 (`wq0prarm`); needs `pms_faults.resolved_by_work_order_id` migration |
+| PR-WO-6 | Fault→WO bridge + WO-complete→fault auto-resolve | OPEN | Migration + dispatcher bridge + ledger emission; graceful if FK column absent |
 | PR-WO-7 | Schema additions — `system_id`, running hours columns | PENDING | Strictly optional; no keyword inference |
 
 ---
@@ -132,4 +132,41 @@ UX sheet `/Users/celeste7/Desktop/lens_card_upgrades.md:300-405` — the legacy 
 
 ---
 
-## PR-WO-4..7 — detailed scope will be filled in as each opens.
+## PR-WO-6 — fault bridge (shipped 2026-04-23)
+
+### Scope
+Data-continuity USP. When a work order created from a fault (`pms_work_orders.fault_id IS NOT NULL`) reaches `status='completed'`, the linked fault must auto-transition to `status='resolved'` with a `resolved_at` timestamp, a `resolved_by_work_order_id` FK, and a `fault_auto_resolved` ledger row that FAULT05's lens reacts to. Coordinated with FAULT05 (`wq0prarm`) who confirmed the fault-status enum (`open / investigating / acknowledged / work_ordered / resolved / closed`) and the column absence.
+
+### Changes
+- **`supabase/migrations/20260423_pms_faults_resolved_by_work_order.sql` (new, temporary)** — adds nullable `resolved_by_work_order_id uuid REFERENCES pms_work_orders(id) ON DELETE SET NULL` + partial index. Per `feedback_migration_convention.md`, apply manually and delete the file afterwards.
+- **`apps/api/action_router/dispatchers/internal_dispatcher.py::close_work_order`** —
+  - Pre-reads `pms_work_orders.fault_id` before the status update (single extra select — supabase-py doesn't expose `RETURNING`).
+  - After WO status update succeeds, if `fault_id` is set and the linked fault's current status is NOT in `('resolved', 'closed')` (idempotent guard), writes `pms_faults.status='resolved'` + `resolved_at=now()` + `resolved_by=<user_id>` + `resolved_by_work_order_id=<wo_id>`.
+  - **FK write is guarded**: if the column doesn't exist yet (migration not applied), the bridge catches the exception and retries the same update without the FK. Fault status + ledger still flow; the FK just stays null until the migration lands.
+  - Emits a `fault_auto_resolved` ledger row via `routes.handlers.ledger_utils.build_ledger_event` with `event_type='status_change'`, `entity_type='fault'`, `metadata={resolved_by_work_order_id, previous_status, new_status}`. Ledger emission is try/except — never fails the WO close.
+  - Return envelope extended: adds `fault_auto_resolved: bool` and `linked_fault_id: str | null` so the frontend can render a post-close toast without a refetch.
+- **`apps/api/tests/test_close_work_order_bridge.py` (new)** — 5 pytest-asyncio cases covering:
+  - no `fault_id` → zero fault writes, zero ledger inserts
+  - open fault → single fault update with FK + ledger insert
+  - already-resolved / closed fault → idempotent, no writes
+  - FK column absent → first update raises, handler retries without FK, status still flips, ledger still fires
+  - WO update returns empty → `ValueError`, bridge never runs
+
+### Verification
+- `pytest tests/test_close_work_order_bridge.py` → 5/5 green
+- `python3 ast.parse` on `internal_dispatcher.py` → clean
+- Migration SQL includes verification query for CEO to run post-apply
+
+### Deploy steps (CEO owns DB apply)
+1. Merge this PR to `main`; Render deploys the handler. Frontend no-op.
+2. Apply the migration SQL (pooler auth currently failing from both WORKORDER05 and FAULT05 agents — CEO runs via Supabase dashboard SQL editor or proper psql env).
+3. Verify column: `SELECT column_name FROM information_schema.columns WHERE table_name='pms_faults' AND column_name='resolved_by_work_order_id';`
+4. Delete the migration file per `feedback_migration_convention.md`.
+5. Close any WO with a linked fault and inspect `ledger_events` for `fault_auto_resolved`.
+
+### Deferred
+- `pms_faults` frontend: FAULT05 will refetch on ledger change in their own PR.
+
+---
+
+## PR-WO-4, 5, 7 — detailed scope will be filled in as each opens.

--- a/supabase/migrations/20260423_pms_faults_resolved_by_work_order.sql
+++ b/supabase/migrations/20260423_pms_faults_resolved_by_work_order.sql
@@ -1,0 +1,38 @@
+-- Migration: add resolved_by_work_order_id FK column to pms_faults
+-- Owner: WORKORDER05 (PR-WO-6)
+-- Applied: <manual — delete this file after running>
+--
+-- Why: when a work order linked to a fault reaches status=completed, the
+-- close_work_order dispatcher now transitions the fault to status=resolved
+-- and stamps this FK column so the bridge is auditable. Prior to this
+-- migration the relationship was one-way (pms_work_orders.fault_id) and the
+-- fault had no record of which WO resolved it.
+--
+-- Schema change is additive + nullable + indexed. No backfill needed — rows
+-- predating the migration remain NULL.
+--
+-- Per /Users/celeste7/.claude/projects/-Users-celeste7/memory/feedback_migration_convention.md
+-- migration files are temporary: apply to Supabase, verify, then DELETE this
+-- file.
+
+BEGIN;
+
+ALTER TABLE public.pms_faults
+  ADD COLUMN IF NOT EXISTS resolved_by_work_order_id uuid
+  REFERENCES public.pms_work_orders(id) ON DELETE SET NULL;
+
+-- Query hot path: "which faults did this WO close?" — rare enough that an
+-- index is optional, but cheap to have given the column nullability skews
+-- most rows away from the value. Partial index keeps the b-tree small.
+CREATE INDEX IF NOT EXISTS idx_pms_faults_resolved_by_wo
+  ON public.pms_faults (resolved_by_work_order_id)
+  WHERE resolved_by_work_order_id IS NOT NULL;
+
+COMMIT;
+
+-- Verify (run in psql after apply):
+--   SELECT column_name, data_type, is_nullable
+--     FROM information_schema.columns
+--    WHERE table_name = 'pms_faults' AND column_name = 'resolved_by_work_order_id';
+--
+--   \d public.pms_faults


### PR DESCRIPTION
## Summary
Data-continuity USP. When a WO created from a fault reaches `status=completed`, auto-transition the linked fault to `status=resolved` with `resolved_at`, a new `resolved_by_work_order_id` FK, and a `fault_auto_resolved` ledger row. FAULT05's lens reacts to the ledger row — no polling.

Coordinated with FAULT05 (`wq0prarm`): confirmed fault-status enum is `open / investigating / acknowledged / work_ordered / resolved / closed` and that `pms_faults.resolved_by_work_order_id` does not yet exist.

## Files
- `supabase/migrations/20260423_pms_faults_resolved_by_work_order.sql` **(new, temporary)** — adds the FK column + partial index. Apply then delete per `feedback_migration_convention.md`.
- `apps/api/action_router/dispatchers/internal_dispatcher.py::close_work_order` — bridge logic (pre-read fault_id, idempotent guard, FK-absent fallback, ledger emission, extended return envelope).
- `apps/api/tests/test_close_work_order_bridge.py` **(new)** — 5 pytest-asyncio specs.
- `docs/ongoing_work/work_orders/PLAN.md` — writeup + deploy steps.

## FK-absent safety
If the migration hasn't been applied in an environment, the first fault-update call raises (column doesn't exist); the handler catches and retries the same update without the FK. Status + ledger still flow. Ships safely to all environments.

## Test plan
- [x] `pytest apps/api/tests/test_close_work_order_bridge.py` → 5/5 green
- [x] `python3 ast.parse` on `internal_dispatcher.py` → clean
- [ ] Post-merge: CEO applies the migration SQL via Supabase dashboard
- [ ] Post-merge: smoke — close a WO with `fault_id`, inspect `ledger_events` for `fault_auto_resolved`, then delete the migration file

## Cases covered by tests
| Scenario | Expected |
|---|---|
| WO has no `fault_id` | No fault writes, no ledger |
| WO → fault(open) | Fault update with FK + 1 ledger row |
| WO → fault(resolved/closed) | Idempotent, no writes |
| WO → fault(open), FK column absent | Retries without FK, status flips, ledger still fires |
| WO update returns empty | `ValueError`, bridge never runs |

🤖 Generated with [Claude Code](https://claude.com/claude-code)