### PR TITLE
feat(work-orders): schema additions — system linkage + running hours

### DIFF
--- a/apps/api/action_router/registry.py
+++ b/apps/api/action_router/registry.py
@@ -3599,6 +3599,24 @@ ACTION_REGISTRY: Dict[str, ActionDefinition] = {
                           description="Linked fault (if created from a fault)"),
             FieldMetadata("severity", FieldClassification.OPTIONAL, description="Severity assessment"),
             FieldMetadata("work_order_type", FieldClassification.OPTIONAL, description="Sub-type classification"),
+            # PR-WO-7 schema additions. UX sheet /Users/celeste7/Desktop/
+            # lens_card_upgrades.md:354-356. Parent-system denormalised for
+            # frontend ergonomics; running-hours present on every WO with
+            # opt-in via `running_hours_required` (no keyword inference per
+            # CEO spec line 356).
+            FieldMetadata("system_id", FieldClassification.OPTIONAL,
+                          lookup_required=True,
+                          description="Parent system (top-level equipment this WO belongs to)"),
+            FieldMetadata("system_name", FieldClassification.OPTIONAL,
+                          description="Denormalised parent system name"),
+            FieldMetadata("frequency", FieldClassification.OPTIONAL,
+                          description="Recurrence cadence (daily, weekly, monthly, quarterly, annual)"),
+            FieldMetadata("running_hours_required", FieldClassification.OPTIONAL,
+                          description="Whether this WO tracks running hours (rotating machinery)"),
+            FieldMetadata("running_hours_current", FieldClassification.OPTIONAL,
+                          description="Current running-hours reading at WO creation"),
+            FieldMetadata("running_hours_checkpoint", FieldClassification.OPTIONAL,
+                          description="Running-hours checkpoint at which service is due"),
         ],
     ),
 

--- a/apps/web/src/features/work-orders/types.ts
+++ b/apps/web/src/features/work-orders/types.ts
@@ -21,6 +21,17 @@ export interface WorkOrder {
   due_date?: string;
   /** Exact datetime the WO was marked complete. UX line 334. */
   completed_at?: string;
+  // ── PR-WO-7 schema additions (UX sheet lines 354-356) ──────────────────
+  /** Parent system UUID. FK → pms_equipment.id (top-level). */
+  system_id?: string;
+  /** Denormalised parent system name for frontend ergonomics. */
+  system_name?: string;
+  /** Whether this WO tracks running hours (rotating machinery). */
+  running_hours_required?: boolean;
+  /** Current running-hours reading at WO creation. */
+  running_hours_current?: number;
+  /** Running-hours checkpoint at which service is due. */
+  running_hours_checkpoint?: number;
   created_at: string;
   updated_at?: string;
 }

--- a/docs/ongoing_work/work_orders/PLAN.md
+++ b/docs/ongoing_work/work_orders/PLAN.md
@@ -18,7 +18,7 @@ Working alongside WORKORDER05 / HANDOVER08 / EQUIPMENT05 / FAULT05 / SHOPPINGLIS
 | PR-WO-4 | Checklist overhaul (DB audit + bucket wiring) | PENDING | `pms_work_order_checklist` + `pms_checklist` + `pms_checklist_items` audit first |
 | PR-WO-5 | Calendar tab (List / Calendar toggle) | PENDING | Seahub-style; clickable cards; colour by type/criticality |
 | PR-WO-6 | Fault→WO bridge + WO-complete→fault auto-resolve | OPEN | Migration + dispatcher bridge + ledger emission; graceful if FK column absent |
-| PR-WO-7 | Schema additions — `system_id`, running hours columns | PENDING | Strictly optional; no keyword inference |
+| PR-WO-7 | Schema additions — `system_id`, running hours columns | OPEN | Strictly optional; no keyword inference; migration + TS + registry |
 
 ---
 
@@ -169,4 +169,35 @@ Data-continuity USP. When a work order created from a fault (`pms_work_orders.fa
 
 ---
 
-## PR-WO-4, 5, 7 — detailed scope will be filled in as each opens.
+## PR-WO-7 — schema additions (shipped 2026-04-23)
+
+### Scope
+UX sheet `/Users/celeste7/Desktop/lens_card_upgrades.md:354-356`. Two additions:
+1. **System linkage** — denormalised `system_id` (FK → `pms_equipment.id`) + `system_name` (text). Frontend doesn't have to walk the self-referential `pms_equipment.parent_id` tree to label "Propulsion · HVAC · Electrical · Navigation".
+2. **Running hours** — `running_hours_required` (bool, default false), `running_hours_current` (numeric), `running_hours_checkpoint` (numeric). Rotating machinery (engines / gens / HVAC compressors / winches / nav motors) is scheduled against hours, not calendar. CEO spec line 356 explicitly forbids keyword inference ("if WO contains 'motor', 'crane', 'engine' then list hours") — every WO carries the columns and users opt in via the boolean.
+
+### Changes
+- **`supabase/migrations/20260423_pms_work_orders_system_running_hours.sql` (new, temporary)** — ADD COLUMN IF NOT EXISTS for all five columns, partial index on `system_id`, `CHECK (running_hours_* >= 0)` sanity constraints. Apply manually, verify, delete.
+- **`apps/api/action_router/registry.py`** — `create_work_order` field_metadata extended with six new OPTIONAL entries (system_id + system_name + frequency + running_hours_{required,current,checkpoint}). `update_work_order` is a pass-through handler and doesn't need field_metadata additions; the new columns flow through on UPDATE.
+- **`apps/web/src/features/work-orders/types.ts`** — `WorkOrder` interface extended with the five new optional fields.
+
+### Verification
+- `python3 ast.parse` on `registry.py` → clean
+- `npx tsc --noEmit` on apps/web → clean
+- `pytest apps/api/tests/test_entity_prefill.py + test_close_work_order_bridge.py` → 41/41 green (regression)
+
+### Deploy steps (CEO)
+1. Merge → Render deploys.
+2. Apply `supabase/migrations/20260423_pms_work_orders_system_running_hours.sql` via Supabase dashboard.
+3. Verify columns: `SELECT column_name, data_type, column_default FROM information_schema.columns WHERE table_name='pms_work_orders' AND column_name LIKE 'system_%' OR column_name LIKE 'running_hours_%';`
+4. Delete the migration file.
+
+### Deferred (UI polish)
+- Running-hours edit form on the WO card — lands with PR-WO-4 (checklist overhaul) or a PR-WO-8 follow-up.
+- System picker modal — equipment-lens concern; EQUIPMENT05 owns it.
+
+---
+
+## PR-WO-4 + PR-WO-5 — remaining scope
+
+Both deferred pending DB probe (PR-WO-4 checklist table audit) and a longer design pass (PR-WO-5 calendar). Not blocking the MVP.

--- a/supabase/migrations/20260423_pms_work_orders_system_running_hours.sql
+++ b/supabase/migrations/20260423_pms_work_orders_system_running_hours.sql
@@ -1,0 +1,76 @@
+-- Migration: add system_id + system_name + running-hours columns to pms_work_orders
+-- Owner: WORKORDER05 (PR-WO-7)
+-- Applied: <manual — delete this file after running>
+--
+-- Why: UX sheet /Users/celeste7/Desktop/lens_card_upgrades.md:354-356.
+--
+--   1. `system_id` + `system_name` — the parent system the equipment is part
+--      of (propulsion, HVAC, electrical, navigation, etc). Denormalised
+--      because the UI frequently needs the label without an extra join, and
+--      because pms_equipment is itself self-referential (equipment.parent_id)
+--      so resolving "system" is an N-up tree walk otherwise.
+--
+--   2. `running_hours_current` + `running_hours_checkpoint` +
+--      `running_hours_required` — rotating machinery (engines, generators,
+--      HVAC compressors, winches) is scheduled against running hours, not
+--      calendar dates. Adding all three columns to every WO (not just
+--      rotating-machinery ones) and defaulting `running_hours_required` to
+--      false matches the CEO's MVP rule (spec line 356):
+--        "We **cannot** run script for 'if work order contain motor, crane,
+--         engine, then list hours'. This is wrong and forbidden. Instead we
+--         need to add to all work orders, and leave blank if not required,
+--         or mark as 'not required' via user."
+--
+-- Schema change is additive + nullable / defaulted. No backfill needed.
+--
+-- Per feedback_migration_convention.md: apply to Supabase, verify, then
+-- DELETE this file.
+
+BEGIN;
+
+-- ── System linkage (denormalised for frontend ergonomics) ──────────────────
+ALTER TABLE public.pms_work_orders
+  ADD COLUMN IF NOT EXISTS system_id uuid
+    REFERENCES public.pms_equipment(id) ON DELETE SET NULL;
+
+ALTER TABLE public.pms_work_orders
+  ADD COLUMN IF NOT EXISTS system_name text;
+
+CREATE INDEX IF NOT EXISTS idx_pms_work_orders_system_id
+  ON public.pms_work_orders (system_id)
+  WHERE system_id IS NOT NULL;
+
+-- ── Running-hours (rotating machinery) ─────────────────────────────────────
+ALTER TABLE public.pms_work_orders
+  ADD COLUMN IF NOT EXISTS running_hours_required boolean NOT NULL DEFAULT false;
+
+ALTER TABLE public.pms_work_orders
+  ADD COLUMN IF NOT EXISTS running_hours_current numeric(12, 2);
+
+ALTER TABLE public.pms_work_orders
+  ADD COLUMN IF NOT EXISTS running_hours_checkpoint numeric(12, 2);
+
+-- Sanity constraints — negative values are nonsensical.
+ALTER TABLE public.pms_work_orders
+  DROP CONSTRAINT IF EXISTS pms_work_orders_running_hours_current_nonneg;
+ALTER TABLE public.pms_work_orders
+  ADD CONSTRAINT pms_work_orders_running_hours_current_nonneg
+  CHECK (running_hours_current IS NULL OR running_hours_current >= 0);
+
+ALTER TABLE public.pms_work_orders
+  DROP CONSTRAINT IF EXISTS pms_work_orders_running_hours_checkpoint_nonneg;
+ALTER TABLE public.pms_work_orders
+  ADD CONSTRAINT pms_work_orders_running_hours_checkpoint_nonneg
+  CHECK (running_hours_checkpoint IS NULL OR running_hours_checkpoint >= 0);
+
+COMMIT;
+
+-- Verify (run in psql after apply):
+--   SELECT column_name, data_type, is_nullable, column_default
+--     FROM information_schema.columns
+--    WHERE table_name = 'pms_work_orders'
+--      AND column_name IN (
+--        'system_id', 'system_name',
+--        'running_hours_required', 'running_hours_current', 'running_hours_checkpoint'
+--      )
+--    ORDER BY column_name;


### PR DESCRIPTION
## Summary
UX sheet `/Users/celeste7/Desktop/lens_card_upgrades.md:354-356`. Two additive nullable changes on `pms_work_orders`:

1. **System linkage** — `system_id uuid` (FK → `pms_equipment.id`) + `system_name text`. Denormalised so the frontend can label "Propulsion / HVAC / Electrical / Navigation" without walking the `pms_equipment.parent_id` self-ref tree.
2. **Running hours** — `running_hours_required bool default false`, `running_hours_current numeric`, `running_hours_checkpoint numeric`. Rotating machinery is scheduled against hours, not dates. CEO spec line 356 forbids keyword inference — every WO carries the columns, user opts in via the boolean.

## Files
- `supabase/migrations/20260423_pms_work_orders_system_running_hours.sql` **(new, temporary — apply then delete)**
- `apps/api/action_router/registry.py` — `create_work_order.field_metadata` extended with six new OPTIONAL entries.
- `apps/web/src/features/work-orders/types.ts` — `WorkOrder` gains five new optional fields.
- `docs/ongoing_work/work_orders/PLAN.md` — PR-WO-7 writeup.

## Test plan
- [x] `python3 ast.parse registry.py` → clean
- [x] `npx tsc --noEmit` on apps/web → clean
- [x] `pytest test_entity_prefill.py + test_close_work_order_bridge.py` → 41/41 (regression)
- [ ] Post-merge: CEO applies migration via Supabase dashboard, verifies columns, deletes migration file

## Deferred
- Running-hours edit form on the card → PR-WO-4 or PR-WO-8.
- System picker modal → EQUIPMENT05 (equipment-lens concern).

🤖 Generated with [Claude Code](https://claude.com/claude-code)