### PR TITLE
feat(work-orders): checklist overhaul — Safety tab + add_checklist_item + upsert_sop

### DIFF
--- a/apps/api/action_router/dispatchers/internal_dispatcher.py
+++ b/apps/api/action_router/dispatchers/internal_dispatcher.py
@@ -2641,6 +2641,36 @@ async def _approve_purchase(params: Dict[str, Any]) -> Dict[str, Any]:
 # ============================================================================
 
 
+async def _p2_add_checklist_item(params: Dict[str, Any]) -> Dict[str, Any]:
+    """Wrapper for P2 add_checklist_item handler (PR-WO-4)."""
+    handlers = _get_p2_handlers()
+    return await handlers.add_checklist_item_execute(
+        work_order_id=params.get("work_order_id") or params.get("entity_id"),
+        yacht_id=params["yacht_id"],
+        user_id=params.get("user_id"),
+        title=params.get("title") or "",
+        description=params.get("description"),
+        instructions=params.get("instructions"),
+        is_required=bool(params.get("is_required", True)),
+        requires_photo=bool(params.get("requires_photo", False)),
+        requires_signature=bool(params.get("requires_signature", False)),
+        category=params.get("category") or "general",
+        sequence=params.get("sequence"),
+    )
+
+
+async def _p2_upsert_sop(params: Dict[str, Any]) -> Dict[str, Any]:
+    """Wrapper for P2 upsert_sop handler (PR-WO-4)."""
+    handlers = _get_p2_handlers()
+    return await handlers.upsert_sop_execute(
+        work_order_id=params.get("work_order_id") or params.get("entity_id"),
+        yacht_id=params["yacht_id"],
+        user_id=params.get("user_id"),
+        sop_text=params.get("sop_text"),
+        sop_document_id=params.get("sop_document_id"),
+    )
+
+
 async def _p2_add_checklist_note(params: Dict[str, Any]) -> Dict[str, Any]:
     """Wrapper for P2 add_checklist_note handler."""
     handlers = _get_p2_handlers()
@@ -4242,8 +4272,10 @@ INTERNAL_HANDLERS: Dict[str, Any] = {
     # =========================================================================
     # P2 Mutation Light Handlers (from p2_mutation_light_handlers.py)
     # =========================================================================
+    "add_checklist_item": _p2_add_checklist_item,
     "add_checklist_note": _p2_add_checklist_note,
     "add_checklist_photo": _p2_add_checklist_photo,
+    "upsert_sop": _p2_upsert_sop,
     "add_document_to_handover": _p2_add_document_to_handover,
     "add_equipment_note": _p2_add_equipment_note,
     "add_item_to_purchase": _p2_add_item_to_purchase,

--- a/apps/api/action_router/entity_prefill.py
+++ b/apps/api/action_router/entity_prefill.py
@@ -101,6 +101,9 @@ CONTEXT_PREFILL_MAP: Dict[Tuple[str, str], Dict[str, str]] = {
     ("work_order", "add_checklist_note"):        {"work_order_id": "id"},
     ("work_order", "add_checklist_photo"):       {"work_order_id": "id"},
     ("work_order", "mark_checklist_item_complete"): {"work_order_id": "id"},
+    # PR-WO-4
+    ("work_order", "add_checklist_item"):        {"work_order_id": "id"},
+    ("work_order", "upsert_sop"):                {"work_order_id": "id"},
     ("work_order", "update_worklist_progress"):  {"work_order_id": "id"},
     ("work_order", "view_work_order_detail"):    {"work_order_id": "id"},
     ("work_order", "view_work_order_history"):   {"work_order_id": "id"},

--- a/apps/api/action_router/registry.py
+++ b/apps/api/action_router/registry.py
@@ -189,6 +189,63 @@ ACTION_REGISTRY: Dict[str, ActionDefinition] = {
         search_keywords=["view", "checklist", "tasks", "work", "order", "wo"],
     ),
 
+    # PR-WO-4: user A adds a checkpoint to the WO checklist.
+    "add_checklist_item": ActionDefinition(
+        action_id="add_checklist_item",
+        label="Add Checklist Item",
+        endpoint="/v1/actions/execute",
+        handler_type=HandlerType.INTERNAL,
+        method="POST",
+        allowed_roles=["engineer", "eto", "chief_engineer", "chief_officer", "captain", "manager"],
+        required_fields=["yacht_id", "work_order_id", "title"],
+        domain="work_orders",
+        variant=ActionVariant.MUTATE,
+        search_keywords=["add", "checklist", "item", "checkpoint", "step", "task", "work", "order", "wo"],
+        field_metadata=[
+            FieldMetadata("yacht_id", FieldClassification.CONTEXT),
+            FieldMetadata("work_order_id", FieldClassification.CONTEXT),
+            FieldMetadata("title", FieldClassification.REQUIRED, description="Checkpoint label (e.g. 'Lock out breaker 17B')"),
+            FieldMetadata("description", FieldClassification.OPTIONAL, description="Detailed guidance for this step"),
+            FieldMetadata("instructions", FieldClassification.OPTIONAL, description="How-to instructions"),
+            FieldMetadata("category", FieldClassification.OPTIONAL,
+                          options=["general", "safety", "loto", "sop"],
+                          description="Routes the item to a specific card tab (safety/loto → Safety tab)"),
+            FieldMetadata("is_required", FieldClassification.OPTIONAL,
+                          description="Must be ticked before WO can be marked complete"),
+            FieldMetadata("requires_photo", FieldClassification.OPTIONAL,
+                          description="Executor must attach a photo to complete this item"),
+            FieldMetadata("requires_signature", FieldClassification.OPTIONAL,
+                          description="Executor must sign to complete this item"),
+            FieldMetadata("sequence", FieldClassification.OPTIONAL,
+                          description="Display order (auto-assigned when omitted)"),
+        ],
+    ),
+
+    # PR-WO-4: upsert the WO's SOP (Standard Operating Procedure).
+    #   sop_text        — inline description typed by crew
+    #   sop_document_id — FK to doc_metadata for an uploaded PDF
+    # Either / both may be supplied.
+    "upsert_sop": ActionDefinition(
+        action_id="upsert_sop",
+        label="Update SOP",
+        endpoint="/v1/actions/execute",
+        handler_type=HandlerType.INTERNAL,
+        method="POST",
+        allowed_roles=["engineer", "eto", "chief_engineer", "chief_officer", "captain", "manager"],
+        required_fields=["yacht_id", "work_order_id"],
+        domain="work_orders",
+        variant=ActionVariant.MUTATE,
+        search_keywords=["sop", "procedure", "safety", "upload", "work", "order", "wo"],
+        field_metadata=[
+            FieldMetadata("yacht_id", FieldClassification.CONTEXT),
+            FieldMetadata("work_order_id", FieldClassification.CONTEXT),
+            FieldMetadata("sop_text", FieldClassification.OPTIONAL, description="Inline SOP description"),
+            FieldMetadata("sop_document_id", FieldClassification.OPTIONAL,
+                          lookup_required=True,
+                          description="Linked SOP PDF (uploaded via Documents)"),
+        ],
+    ),
+
     "assign_work_order": ActionDefinition(
         action_id="assign_work_order",
         label="Assign Work Order",

--- a/apps/api/handlers/p2_mutation_light_handlers.py
+++ b/apps/api/handlers/p2_mutation_light_handlers.py
@@ -1083,6 +1083,225 @@ class P2MutationLightHandlers:
             }
 
     # =========================================================================
+    # PR-WO-4: add_checklist_item (append a user-generated checkpoint to a WO)
+    # =========================================================================
+
+    async def add_checklist_item_execute(
+        self,
+        work_order_id: str,
+        yacht_id: str,
+        user_id: str,
+        title: str,
+        description: Optional[str] = None,
+        instructions: Optional[str] = None,
+        is_required: bool = True,
+        requires_photo: bool = False,
+        requires_signature: bool = False,
+        category: str = "general",
+        sequence: Optional[int] = None,
+    ) -> Dict:
+        """
+        Append a user-generated checkpoint to a work order's metadata.checklist[].
+
+        Used by user A (task author) to lay out the checkpoints user B (executor)
+        will work through. Matches the CEO's MVP contract in
+        /Users/celeste7/Desktop/lens_card_upgrades.md:390-403:
+        free-form label + description + optional photo/signature requirement,
+        check-off by the executor.
+
+        `category` drives the Safety tab filter — values:
+            "general" (default, main checklist)
+            "safety"  (LOTO / hazard-specific checkpoints — surface in Safety tab)
+            "loto"    (legacy alias; frontend treats same as safety)
+            "sop"     (SOP-anchored checkpoint)
+        """
+        import uuid
+
+        if not title or not title.strip():
+            return {
+                "status": "error",
+                "error_code": "INVALID_TITLE",
+                "message": "Checklist item title cannot be empty",
+            }
+
+        try:
+            wo_result = self.db.table("pms_work_orders").select(
+                "id, wo_number, metadata"
+            ).eq("id", work_order_id).eq("yacht_id", yacht_id).limit(1).execute()
+
+            if not wo_result.data:
+                return {
+                    "status": "error",
+                    "error_code": "WORK_ORDER_NOT_FOUND",
+                    "message": f"Work order not found: {work_order_id}",
+                }
+
+            wo = wo_result.data[0]
+            metadata = wo.get("metadata") or {}
+            checklist = list(metadata.get("checklist") or [])
+
+            # Auto-sequence if caller didn't supply one — keeps order stable.
+            if sequence is None:
+                sequence = (
+                    max((it.get("sequence", 0) for it in checklist), default=0) + 1
+                )
+
+            now = datetime.now(timezone.utc).isoformat()
+            item_id = str(uuid.uuid4())
+            item = {
+                "id": item_id,
+                "title": title.strip(),
+                "description": description,
+                "instructions": instructions,
+                "category": category,
+                "sequence": sequence,
+                "is_required": bool(is_required),
+                "requires_photo": bool(requires_photo),
+                "requires_signature": bool(requires_signature),
+                "is_completed": False,
+                "completed_by": None,
+                "completed_at": None,
+                "completion_notes": None,
+                "photo_url": None,
+                "created_at": now,
+                "created_by": user_id,
+            }
+            checklist.append(item)
+            metadata["checklist"] = checklist
+
+            self.db.table("pms_work_orders").update({
+                "metadata": metadata,
+                "updated_at": now,
+            }).eq("id", work_order_id).eq("yacht_id", yacht_id).execute()
+
+            await self._create_audit_log(
+                yacht_id=yacht_id,
+                action="add_checklist_item",
+                entity_type="work_order",
+                entity_id=work_order_id,
+                user_id=user_id,
+                new_values={
+                    "checklist_item_id": item_id,
+                    "title": item["title"],
+                    "category": category,
+                    "is_required": item["is_required"],
+                },
+            )
+
+            return {
+                "status": "success",
+                "action": "add_checklist_item",
+                "result": {
+                    "work_order_id": work_order_id,
+                    "checklist_item_id": item_id,
+                    "title": item["title"],
+                    "category": category,
+                    "sequence": sequence,
+                    "total_items": len(checklist),
+                },
+                "message": "Checklist item added",
+            }
+
+        except Exception as e:
+            logger.error(
+                f"add_checklist_item_execute failed: {e}", exc_info=True
+            )
+            return {
+                "status": "error",
+                "error_code": "INTERNAL_ERROR",
+                "message": str(e),
+            }
+
+    # =========================================================================
+    # PR-WO-4: upsert_sop (store SOP text OR link a document for the WO)
+    # =========================================================================
+
+    async def upsert_sop_execute(
+        self,
+        work_order_id: str,
+        yacht_id: str,
+        user_id: str,
+        sop_text: Optional[str] = None,
+        sop_document_id: Optional[str] = None,
+    ) -> Dict:
+        """
+        Store a Standard Operating Procedure on a work order.
+
+        Two mutually-complementary inputs per UX sheet:
+          * `sop_text`        — inline description typed by the crew.
+          * `sop_document_id` — FK to doc_metadata for an uploaded PDF.
+
+        Stored on `pms_work_orders.metadata.sop` = {text, document_id, updated_at,
+        updated_by}. Either or both fields may be populated; passing None leaves
+        the existing value untouched (partial update).
+        """
+        if sop_text is None and sop_document_id is None:
+            return {
+                "status": "error",
+                "error_code": "NOTHING_TO_UPDATE",
+                "message": "Supply sop_text or sop_document_id (or both)",
+            }
+
+        try:
+            wo_result = self.db.table("pms_work_orders").select(
+                "id, metadata"
+            ).eq("id", work_order_id).eq("yacht_id", yacht_id).limit(1).execute()
+
+            if not wo_result.data:
+                return {
+                    "status": "error",
+                    "error_code": "WORK_ORDER_NOT_FOUND",
+                    "message": f"Work order not found: {work_order_id}",
+                }
+
+            metadata = wo_result.data[0].get("metadata") or {}
+            sop = dict(metadata.get("sop") or {})
+            if sop_text is not None:
+                sop["text"] = sop_text
+            if sop_document_id is not None:
+                sop["document_id"] = sop_document_id
+
+            now = datetime.now(timezone.utc).isoformat()
+            sop["updated_at"] = now
+            sop["updated_by"] = user_id
+            metadata["sop"] = sop
+
+            self.db.table("pms_work_orders").update({
+                "metadata": metadata,
+                "updated_at": now,
+            }).eq("id", work_order_id).eq("yacht_id", yacht_id).execute()
+
+            await self._create_audit_log(
+                yacht_id=yacht_id,
+                action="upsert_sop",
+                entity_type="work_order",
+                entity_id=work_order_id,
+                user_id=user_id,
+                new_values={
+                    "has_text": sop_text is not None,
+                    "has_document": sop_document_id is not None,
+                },
+            )
+
+            return {
+                "status": "success",
+                "action": "upsert_sop",
+                "result": {
+                    "work_order_id": work_order_id,
+                    "sop": sop,
+                },
+                "message": "SOP updated",
+            }
+
+        except Exception as e:
+            logger.error(f"upsert_sop_execute failed: {e}", exc_info=True)
+            return {
+                "status": "error",
+                "error_code": "INTERNAL_ERROR",
+                "message": str(e),
+            }
+
+    # =========================================================================
     # P2 #35: tag_for_survey
     # =========================================================================
 

--- a/apps/api/tests/test_checklist_item_sop_handlers.py
+++ b/apps/api/tests/test_checklist_item_sop_handlers.py
@@ -1,0 +1,237 @@
+# apps/api/tests/test_checklist_item_sop_handlers.py
+"""
+Unit tests for PR-WO-4 additions on P2MutationLightHandlers:
+    * add_checklist_item_execute — user A appends a checkpoint to the WO's
+      metadata.checklist[] array.
+    * upsert_sop_execute         — stores SOP text and/or linked document id
+      on the WO's metadata.sop{} object.
+
+Both handlers read + write `pms_work_orders.metadata` as a JSON blob (the
+canonical storage path today — see p3_read_only_handlers.view_checklist_execute
++ p2_mutation_light_handlers.mark_checklist_item_complete_execute). The real
+`pms_checklists` / `pms_checklist_items` tables are unused by the live code
+path; migration to them is deferred (documented in
+docs/ongoing_work/work_orders/PLAN.md).
+"""
+
+import sys
+import os
+from unittest.mock import MagicMock, AsyncMock
+
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+
+YACHT = "yacht-uuid-1"
+USER = "user-uuid-1"
+WO = "wo-uuid-1"
+
+
+class _Q:
+    """Minimal fluent supabase stub."""
+
+    def __init__(self, parent, tbl):
+        self.parent = parent
+        self.tbl = tbl
+        self._op = None
+        self._payload = None
+        self._filters = []
+
+    def select(self, _cols): self._op = "select"; return self
+    def update(self, p):     self._op = "update"; self._payload = p; return self
+    def insert(self, p):     self._op = "insert"; self._payload = p; return self
+    def eq(self, k, v):      self._filters.append(("eq", k, v)); return self
+    def limit(self, _):      return self
+
+    def execute(self):
+        self.parent.calls.append({
+            "table": self.tbl, "op": self._op,
+            "payload": self._payload, "filters": tuple(self._filters),
+        })
+        canned = self.parent.canned.get((self.tbl, self._op), {"data": [], "count": 0})
+        return MagicMock(data=canned["data"], count=canned["count"])
+
+
+class _DB:
+    def __init__(self):
+        self.calls = []
+        self.canned = {}
+    def table(self, n): return _Q(self, n)
+
+
+def _make_handler(db, initial_metadata):
+    from handlers.p2_mutation_light_handlers import P2MutationLightHandlers
+    db.canned = {
+        ("pms_work_orders", "select"): {
+            "data": [{"id": WO, "wo_number": "WO-0001", "metadata": initial_metadata}],
+            "count": 1,
+        },
+        ("pms_work_orders", "update"): {
+            "data": [{"id": WO}], "count": 1,
+        },
+    }
+    h = P2MutationLightHandlers(supabase_client=db)
+    # _create_audit_log is async and off-critical-path for this test surface.
+    h._create_audit_log = AsyncMock(return_value=None)
+    return h
+
+
+# ── add_checklist_item ─────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_add_checklist_item_appends_to_metadata_array():
+    db = _DB()
+    handler = _make_handler(db, {"checklist": []})
+
+    result = await handler.add_checklist_item_execute(
+        work_order_id=WO, yacht_id=YACHT, user_id=USER,
+        title="Lock out breaker 17B",
+        description="Behind portside dresser back panel",
+        category="safety",
+        is_required=True,
+        requires_photo=True,
+    )
+
+    assert result["status"] == "success"
+    assert result["result"]["title"] == "Lock out breaker 17B"
+    assert result["result"]["category"] == "safety"
+    assert result["result"]["total_items"] == 1
+    assert result["result"]["sequence"] == 1  # first item gets seq 1
+
+    # The UPDATE call carries the full checklist with our new item.
+    updates = [c for c in db.calls if c["op"] == "update"]
+    assert len(updates) == 1
+    written = updates[0]["payload"]["metadata"]["checklist"]
+    assert len(written) == 1
+    item = written[0]
+    assert item["title"] == "Lock out breaker 17B"
+    assert item["category"] == "safety"
+    assert item["is_required"] is True
+    assert item["requires_photo"] is True
+    assert item["is_completed"] is False
+    assert item["created_by"] == USER
+
+
+@pytest.mark.asyncio
+async def test_add_checklist_item_auto_increments_sequence():
+    db = _DB()
+    existing = [
+        {"id": "a", "title": "Step 1", "sequence": 1, "is_completed": True},
+        {"id": "b", "title": "Step 2", "sequence": 2, "is_completed": False},
+    ]
+    handler = _make_handler(db, {"checklist": existing})
+
+    result = await handler.add_checklist_item_execute(
+        work_order_id=WO, yacht_id=YACHT, user_id=USER,
+        title="Step 3",
+    )
+    assert result["result"]["sequence"] == 3
+    assert result["result"]["total_items"] == 3
+
+
+@pytest.mark.asyncio
+async def test_add_checklist_item_rejects_empty_title():
+    db = _DB()
+    handler = _make_handler(db, {"checklist": []})
+    result = await handler.add_checklist_item_execute(
+        work_order_id=WO, yacht_id=YACHT, user_id=USER,
+        title="   ",  # whitespace-only
+    )
+    assert result["status"] == "error"
+    assert result["error_code"] == "INVALID_TITLE"
+    # No writes should have fired.
+    assert [c for c in db.calls if c["op"] == "update"] == []
+
+
+@pytest.mark.asyncio
+async def test_add_checklist_item_preserves_existing_metadata_keys():
+    db = _DB()
+    handler = _make_handler(db, {
+        "checklist": [],
+        "sop": {"text": "Don't electrocute yourself", "updated_by": USER},
+        "custom_field": 42,
+    })
+    await handler.add_checklist_item_execute(
+        work_order_id=WO, yacht_id=YACHT, user_id=USER, title="X",
+    )
+    updates = [c for c in db.calls if c["op"] == "update"]
+    meta = updates[0]["payload"]["metadata"]
+    # Append must not clobber sibling keys.
+    assert meta["sop"]["text"] == "Don't electrocute yourself"
+    assert meta["custom_field"] == 42
+
+
+@pytest.mark.asyncio
+async def test_add_checklist_item_wo_not_found():
+    db = _DB()
+    db.canned = {
+        ("pms_work_orders", "select"): {"data": [], "count": 0},
+    }
+    from handlers.p2_mutation_light_handlers import P2MutationLightHandlers
+    handler = P2MutationLightHandlers(supabase_client=db)
+    result = await handler.add_checklist_item_execute(
+        work_order_id=WO, yacht_id=YACHT, user_id=USER, title="X",
+    )
+    assert result["status"] == "error"
+    assert result["error_code"] == "WORK_ORDER_NOT_FOUND"
+
+
+# ── upsert_sop ─────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_upsert_sop_text_only():
+    db = _DB()
+    handler = _make_handler(db, {})
+    result = await handler.upsert_sop_execute(
+        work_order_id=WO, yacht_id=YACHT, user_id=USER,
+        sop_text="Isolate both breakers before opening unit.",
+    )
+    assert result["status"] == "success"
+    sop = result["result"]["sop"]
+    assert sop["text"] == "Isolate both breakers before opening unit."
+    assert "document_id" not in sop
+    assert sop["updated_by"] == USER
+
+
+@pytest.mark.asyncio
+async def test_upsert_sop_document_only():
+    db = _DB()
+    handler = _make_handler(db, {})
+    result = await handler.upsert_sop_execute(
+        work_order_id=WO, yacht_id=YACHT, user_id=USER,
+        sop_document_id="doc-uuid-99",
+    )
+    assert result["result"]["sop"]["document_id"] == "doc-uuid-99"
+    assert "text" not in result["result"]["sop"]
+
+
+@pytest.mark.asyncio
+async def test_upsert_sop_partial_update_keeps_other_field():
+    db = _DB()
+    handler = _make_handler(db, {
+        "sop": {"text": "old text", "document_id": "old-doc", "updated_by": "old-user"},
+    })
+    # Update only document_id; text must be preserved.
+    result = await handler.upsert_sop_execute(
+        work_order_id=WO, yacht_id=YACHT, user_id=USER,
+        sop_document_id="new-doc",
+    )
+    sop = result["result"]["sop"]
+    assert sop["text"] == "old text"
+    assert sop["document_id"] == "new-doc"
+    assert sop["updated_by"] == USER
+
+
+@pytest.mark.asyncio
+async def test_upsert_sop_rejects_empty_input():
+    db = _DB()
+    handler = _make_handler(db, {})
+    result = await handler.upsert_sop_execute(
+        work_order_id=WO, yacht_id=YACHT, user_id=USER,
+    )
+    assert result["status"] == "error"
+    assert result["error_code"] == "NOTHING_TO_UPDATE"
+    assert [c for c in db.calls if c["op"] == "update"] == []

--- a/apps/web/src/components/lens-v2/entity/WorkOrderContent.tsx
+++ b/apps/web/src/components/lens-v2/entity/WorkOrderContent.tsx
@@ -125,8 +125,17 @@ export function WorkOrderContent() {
   const auditTrail = ((entity?.audit_trail ?? payload.audit_trail ?? entity?.audit_history ?? payload.audit_history) as Array<Record<string, unknown>> | undefined) ?? [];
   // History = prior periods of the same entity (year-grouped)
   const priorPeriods = ((entity?.prior_periods ?? payload.prior_periods ?? entity?.history_periods ?? payload.history_periods ?? entity?.history ?? payload.history) as Array<Record<string, unknown>> | undefined) ?? [];
-  const checklist = ((entity?.checklist ?? payload.checklist ?? entity?.checklist_items ?? payload.checklist_items) as Array<Record<string, unknown>> | undefined) ?? [];
+  // Checklist lives on `payload.metadata.checklist[]` today (see p2_mutation_light_handlers.add_checklist_item_execute).
+  // We accept both top-level `checklist` (if an adapter flattens it) and the metadata path, plus a few legacy aliases.
+  const metadataBlob = ((payload.metadata ?? entity?.metadata) as Record<string, unknown> | undefined) ?? {};
+  const checklist = (
+    (entity?.checklist ?? payload.checklist ?? entity?.checklist_items ?? payload.checklist_items ?? metadataBlob.checklist) as Array<Record<string, unknown>> | undefined
+  ) ?? [];
   const documents = ((entity?.documents ?? payload.documents ?? entity?.official_documents ?? payload.official_documents) as Array<Record<string, unknown>> | undefined) ?? [];
+  // SOP (PR-WO-4) — inline text + optional linked PDF document.
+  const sopBlob = (metadataBlob.sop as Record<string, unknown> | undefined) ?? {};
+  const sopText = (sopBlob.text ?? entity?.sop_text ?? payload.sop_text) as string | undefined;
+  const sopDocumentId = (sopBlob.document_id ?? entity?.sop_document_id ?? payload.sop_document_id) as string | undefined;
 
   // ── Action gates ──
   // Canonical long-form action_ids matching registry + entity_prefill.
@@ -383,6 +392,48 @@ export function WorkOrderContent() {
     [executeAction]
   );
 
+  // ── PR-WO-4 Safety tab callbacks ──
+  // MVP: use native browser prompt() for title/text capture. Replace with a
+  // tokenised modal in PR-WO-4b once the pattern from AddNoteModal is
+  // extracted into a generic AddEntityModal.
+  const handleAddSafetyCheckpoint = React.useCallback(async () => {
+    if (typeof window === 'undefined') return;
+    const title = window.prompt('New safety checkpoint (e.g. "Lock out breaker 17B")');
+    if (!title || !title.trim()) return;
+    const description = window.prompt('Optional guidance / instructions') ?? undefined;
+    await executeAction('add_checklist_item', {
+      title: title.trim(),
+      description: description || undefined,
+      category: 'safety',
+      is_required: true,
+    });
+  }, [executeAction]);
+
+  const handleAddGeneralCheckpoint = React.useCallback(async () => {
+    if (typeof window === 'undefined') return;
+    const title = window.prompt('New checklist item');
+    if (!title || !title.trim()) return;
+    const description = window.prompt('Optional guidance') ?? undefined;
+    await executeAction('add_checklist_item', {
+      title: title.trim(),
+      description: description || undefined,
+      category: 'general',
+      is_required: true,
+    });
+  }, [executeAction]);
+
+  const handleEditSOP = React.useCallback(async () => {
+    if (typeof window === 'undefined') return;
+    const current = sopText ?? '';
+    const next = window.prompt(
+      'Standard Operating Procedure (free text). Leave blank to keep existing.',
+      current,
+    );
+    // prompt() returns null on cancel; empty string means user cleared — honour it.
+    if (next === null) return;
+    await executeAction('upsert_sop', { sop_text: next });
+  }, [executeAction, sopText]);
+
   const handleAddNote = React.useCallback(
     () => setAddNoteOpen(true),
     []
@@ -413,6 +464,12 @@ export function WorkOrderContent() {
   // Safety is a placeholder in PR-WO-3 — LOTO/SOP + Checklist overhaul land
   // in PR-WO-4, where the `pms_work_order_checklist` / `pms_checklist` /
   // `pms_checklist_items` table audit unlocks the real content.
+  // Safety tab badge: count of safety/loto checklist items (UX sheet line 382).
+  const safetyItems = checklist.filter((c) => {
+    const cat = ((c.category as string | undefined) ?? 'general').toLowerCase();
+    return cat === 'safety' || cat === 'loto';
+  });
+
   const tabs: LensTab[] = [
     { key: 'checklist', label: 'Checklist', count: checklistItems.length },
     { key: 'documents', label: 'Documents', count: docItems.length },
@@ -423,13 +480,18 @@ export function WorkOrderContent() {
     { key: 'notes',     label: 'Notes',     count: noteItems.length },
     { key: 'audit',     label: 'Audit Trail', count: auditEvents.length },
     { key: 'history',   label: 'History',   count: historyPeriods.length },
-    { key: 'safety',    label: 'Safety',    disabled: true, disabledReason: 'LOTO + SOP attachments land with PR-WO-4 checklist overhaul' },
+    { key: 'safety',    label: 'Safety',    count: safetyItems.length + (sopText ? 1 : 0) },
   ];
 
   const renderTabBody = (activeKey: string): React.ReactNode => {
     switch (activeKey) {
       case 'checklist':
-        return <ChecklistSection items={checklistItems} onToggle={handleChecklistToggle} />;
+        return (
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
+            <ChecklistSection items={checklistItems} onToggle={handleChecklistToggle} />
+            <AddCheckpointButton onClick={handleAddGeneralCheckpoint} label="+ Add Checklist Item" />
+          </div>
+        );
       case 'documents':
         return docItems.length > 0 ? (
           <DocRowsSection title="Official Documents" docs={docItems} />
@@ -476,8 +538,25 @@ export function WorkOrderContent() {
       case 'history':
         return <HistorySection periods={historyPeriods} />;
       case 'safety':
+        return (
+          <SafetyTabBody
+            sopText={sopText}
+            sopDocumentId={sopDocumentId}
+            safetyItems={safetyItems}
+            onToggle={handleChecklistToggle}
+            onAddCheckpoint={handleAddSafetyCheckpoint}
+            onEditSOP={handleEditSOP}
+            onOpenSOPDoc={
+              sopDocumentId
+                ? () => router.push(
+                    getEntityRoute('documents' as Parameters<typeof getEntityRoute>[0], sopDocumentId),
+                  )
+                : undefined
+            }
+          />
+        );
       default:
-        return <EmptyTab message="Safety (LOTO + SOP) ships with PR-WO-4." />;
+        return <EmptyTab message="Coming soon." />;
     }
   };
 
@@ -641,5 +720,295 @@ function EquipmentTabBody({
         Open equipment lens →
       </div>
     </button>
+  );
+}
+
+// ── PR-WO-4 Safety tab helpers ─────────────────────────────────────────────
+
+function AddCheckpointButton({
+  onClick,
+  label,
+}: {
+  onClick: () => void;
+  label: string;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      style={{
+        appearance: 'none',
+        WebkitAppearance: 'none',
+        alignSelf: 'flex-start',
+        background: 'var(--neutral-bg)',
+        border: '1px dashed var(--border-sub)',
+        borderRadius: 6,
+        padding: '8px 12px',
+        cursor: 'pointer',
+        color: 'var(--txt2)',
+        fontSize: 12,
+        fontWeight: 500,
+      }}
+    >
+      {label}
+    </button>
+  );
+}
+
+interface SafetyRow {
+  id: string;
+  title?: string;
+  description?: string;
+  instructions?: string;
+  is_completed?: boolean;
+  completed_by?: string;
+  completed_at?: string;
+  category?: string;
+}
+
+function SafetyTabBody({
+  sopText,
+  sopDocumentId,
+  safetyItems,
+  onToggle,
+  onAddCheckpoint,
+  onEditSOP,
+  onOpenSOPDoc,
+}: {
+  sopText?: string;
+  sopDocumentId?: string;
+  safetyItems: Array<Record<string, unknown>>;
+  onToggle: (itemId: string) => void;
+  onAddCheckpoint: () => void;
+  onEditSOP: () => void;
+  onOpenSOPDoc?: () => void;
+}) {
+  const rows: SafetyRow[] = safetyItems.map((i) => ({
+    id: (i.id as string) ?? '',
+    title: (i.title as string) ?? (i.description as string),
+    description: i.description as string | undefined,
+    instructions: i.instructions as string | undefined,
+    is_completed: Boolean(i.is_completed ?? i.completed),
+    completed_by: (i.completed_by_name ?? i.completed_by) as string | undefined,
+    completed_at: i.completed_at as string | undefined,
+    category: (i.category as string) ?? 'safety',
+  }));
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 16 }}>
+      {/* SOP block */}
+      <section
+        style={{
+          background: 'var(--surface)',
+          border: '1px solid var(--border-faint)',
+          borderRadius: 8,
+          padding: '14px 16px',
+        }}
+      >
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'space-between',
+            marginBottom: 8,
+          }}
+        >
+          <div
+            style={{
+              fontSize: 11,
+              fontWeight: 600,
+              letterSpacing: '0.06em',
+              textTransform: 'uppercase',
+              color: 'var(--txt2)',
+            }}
+          >
+            Standard Operating Procedure
+          </div>
+          <div style={{ display: 'flex', gap: 8 }}>
+            {sopDocumentId && onOpenSOPDoc && (
+              <button
+                type="button"
+                onClick={onOpenSOPDoc}
+                style={{
+                  appearance: 'none',
+                  WebkitAppearance: 'none',
+                  background: 'var(--teal-bg)',
+                  color: 'var(--mark)',
+                  border: '1px solid var(--mark-hover)',
+                  borderRadius: 4,
+                  padding: '4px 10px',
+                  cursor: 'pointer',
+                  fontSize: 11,
+                  fontWeight: 600,
+                }}
+              >
+                Open SOP PDF
+              </button>
+            )}
+            <button
+              type="button"
+              onClick={onEditSOP}
+              style={{
+                appearance: 'none',
+                WebkitAppearance: 'none',
+                background: 'transparent',
+                border: '1px solid var(--border-sub)',
+                borderRadius: 4,
+                padding: '4px 10px',
+                cursor: 'pointer',
+                fontSize: 11,
+                fontWeight: 500,
+                color: 'var(--txt2)',
+              }}
+            >
+              {sopText ? 'Edit' : 'Add SOP'}
+            </button>
+          </div>
+        </div>
+        {sopText ? (
+          <div
+            style={{
+              fontSize: 13,
+              lineHeight: 1.55,
+              color: 'var(--txt)',
+              whiteSpace: 'pre-wrap',
+            }}
+          >
+            {sopText}
+          </div>
+        ) : (
+          <div style={{ fontSize: 12, color: 'var(--txt3)', fontStyle: 'italic' }}>
+            No SOP recorded. Click &quot;Add SOP&quot; to type one, or attach a PDF via the
+            Documents tab then link it here.
+          </div>
+        )}
+      </section>
+
+      {/* Safety checklist block */}
+      <section>
+        <div
+          style={{
+            fontSize: 11,
+            fontWeight: 600,
+            letterSpacing: '0.06em',
+            textTransform: 'uppercase',
+            color: 'var(--txt2)',
+            marginBottom: 8,
+          }}
+        >
+          Safety Checklist &amp; Lock-Out-Tag-Out
+        </div>
+        {rows.length === 0 ? (
+          <div
+            style={{
+              fontSize: 12,
+              color: 'var(--txt3)',
+              fontStyle: 'italic',
+              marginBottom: 8,
+            }}
+          >
+            No safety checkpoints yet. Add LOTO / isolation / test-for-dead steps
+            below so the executor cannot complete the work order until each is
+            ticked.
+          </div>
+        ) : (
+          <div
+            style={{ display: 'flex', flexDirection: 'column', gap: 6 }}
+            data-testid="safety-checklist-list"
+          >
+            {rows.map((r) => (
+              <button
+                key={r.id}
+                type="button"
+                onClick={!r.is_completed ? () => onToggle(r.id) : undefined}
+                disabled={r.is_completed}
+                style={{
+                  appearance: 'none',
+                  WebkitAppearance: 'none',
+                  textAlign: 'left',
+                  background: r.is_completed
+                    ? 'var(--green-bg)'
+                    : 'var(--surface)',
+                  border: `1px solid ${
+                    r.is_completed ? 'var(--green-border)' : 'var(--border-faint)'
+                  }`,
+                  borderRadius: 6,
+                  padding: '10px 12px',
+                  cursor: r.is_completed ? 'default' : 'pointer',
+                  color: 'var(--txt)',
+                  display: 'flex',
+                  alignItems: 'flex-start',
+                  gap: 10,
+                }}
+              >
+                <span
+                  aria-hidden="true"
+                  style={{
+                    display: 'inline-flex',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                    width: 18,
+                    height: 18,
+                    borderRadius: 3,
+                    border: `1.5px solid ${
+                      r.is_completed ? 'var(--green)' : 'var(--border-sub)'
+                    }`,
+                    background: r.is_completed ? 'var(--green)' : 'transparent',
+                    color: 'white',
+                    fontSize: 11,
+                    fontWeight: 700,
+                    flexShrink: 0,
+                    marginTop: 1,
+                  }}
+                >
+                  {r.is_completed ? '✓' : ''}
+                </span>
+                <div style={{ flex: 1, minWidth: 0 }}>
+                  <div
+                    style={{
+                      fontSize: 13,
+                      fontWeight: 500,
+                      color: r.is_completed ? 'var(--txt2)' : 'var(--txt)',
+                      textDecoration: r.is_completed ? 'line-through' : undefined,
+                    }}
+                  >
+                    {r.title ?? 'Safety step'}
+                  </div>
+                  {r.description && (
+                    <div
+                      style={{
+                        fontSize: 11,
+                        color: 'var(--txt3)',
+                        marginTop: 2,
+                      }}
+                    >
+                      {r.description}
+                    </div>
+                  )}
+                  {r.is_completed && r.completed_by && (
+                    <div
+                      style={{
+                        fontSize: 10,
+                        color: 'var(--txt3)',
+                        marginTop: 4,
+                      }}
+                    >
+                      Completed by {r.completed_by}
+                      {r.completed_at && ` · ${String(r.completed_at).slice(0, 10)}`}
+                    </div>
+                  )}
+                </div>
+              </button>
+            ))}
+          </div>
+        )}
+        <div style={{ marginTop: 8 }}>
+          <AddCheckpointButton
+            onClick={onAddCheckpoint}
+            label="+ Add Safety Checkpoint"
+          />
+        </div>
+      </section>
+    </div>
   );
 }

--- a/docs/ongoing_work/work_orders/PLAN.md
+++ b/docs/ongoing_work/work_orders/PLAN.md
@@ -15,7 +15,7 @@ Working alongside WORKORDER05 / HANDOVER08 / EQUIPMENT05 / FAULT05 / SHOPPINGLIS
 | PR-WO-1 | Dedupe prefill + wire KEEP action buttons | MERGED #686 | 400s on work-order dropdown dead |
 | PR-WO-2 | Tabulated list view on shared `EntityTableList` | MERGED #687 | 12 cols live; backend batch resolvers in place |
 | PR-WO-3 | Lens card redesign — horizontal tabs + metadata de-UUID | OPEN | 10-tab LensTabBar; extended header metadata; "Change Status" rename |
-| PR-WO-4 | Checklist overhaul (DB audit + bucket wiring) | PENDING | `pms_work_order_checklist` + `pms_checklist` + `pms_checklist_items` audit first |
+| PR-WO-4 | Checklist overhaul — Safety tab activation + add-item + SOP | OPEN | 2 new backend actions + Safety tab live; table-migration deferred |
 | PR-WO-5 | Calendar tab (List / Calendar toggle) | PENDING | Seahub-style; clickable cards; colour by type/criticality |
 | PR-WO-6 | Fault→WO bridge + WO-complete→fault auto-resolve | MERGED #689 → CORRECTED in PR-WO-6b | DB trigger owns status cascade; handler now writes reverse-link + ledger only |
 | PR-WO-7 | Schema additions — `system_id`, running hours columns | OPEN | Strictly optional; no keyword inference; migration + TS + registry |
@@ -230,6 +230,51 @@ My PR-WO-6 (a) added a duplicate `resolved_by_work_order_id` column via migratio
 
 ---
 
-## PR-WO-4 + PR-WO-5 — remaining scope
+## PR-WO-4 — checklist + Safety tab (shipped 2026-04-24)
 
-Both deferred. PR-WO-4 (checklist) begins next (confirmed via CEO priority). PR-WO-5 (calendar) follows.
+### DB reality check (via direct psql)
+Two parallel checklist systems exist:
+- **`pms_work_orders.metadata.checklist[]`** — JSON array on each WO row. Live code path: read by `p3_read_only_handlers.view_checklist_execute`; written by `p2_mutation_light_handlers.mark_checklist_item_complete_execute`.
+- **`pms_checklists` (parent, plural) + `pms_checklist_items`** — real tables with `checklist_type` enum (maintenance / safety / inspection / departure / arrival / watch / custom), is_template flag, richer value_type/unit/min/max fields. 29 items exist from seed; no active code reads or writes these tables.
+
+MVP call: enhance the JSON path (where the live data and handlers are). Table migration is deferred — a separate follow-up PR can port the JSON blob to the relational tables once UX is settled. Documented at `docs/ongoing_work/work_orders/PLAN.md` so the next engineer knows.
+
+### Changes
+- **`apps/api/handlers/p2_mutation_light_handlers.py`** — two new handlers:
+  - `add_checklist_item_execute` — user A appends `{id, title, description, instructions, category, sequence, is_required, requires_photo, requires_signature, is_completed, created_by, created_at}` to `metadata.checklist[]`. Auto-increments sequence. Rejects empty title. Preserves sibling metadata keys (no clobber).
+  - `upsert_sop_execute` — writes `metadata.sop = {text, document_id, updated_at, updated_by}`. Partial update (either field may be None leaves the other intact). Rejects fully-empty input.
+- **`apps/api/action_router/dispatchers/internal_dispatcher.py`** — two new wrappers `_p2_add_checklist_item` + `_p2_upsert_sop`; wired into `HANDLER_MAP` with keys `add_checklist_item` / `upsert_sop`.
+- **`apps/api/action_router/registry.py`** — two new `ActionDefinition` entries with full `field_metadata` (including `category` enum `general/safety/loto/sop` so the frontend form UI surfaces the right controls).
+- **`apps/api/action_router/entity_prefill.py`** — added the two `(work_order, ...)` prefill entries.
+- **`apps/api/tests/test_checklist_item_sop_handlers.py` (new)** — 9 pytest-asyncio specs:
+  - Append with all fields surfaces correctly / auto-sequences / empty-title rejected / sibling metadata preserved / WO-not-found
+  - SOP: text only / document only / partial update / empty input rejected
+- **`apps/web/src/components/lens-v2/entity/WorkOrderContent.tsx`** —
+  - Reads `metadata.checklist[]` + `metadata.sop{}` off the entity payload.
+  - Three new callbacks: `handleAddSafetyCheckpoint`, `handleAddGeneralCheckpoint`, `handleEditSOP` (MVP uses native `window.prompt()` — a tokenised modal lands in PR-WO-4b).
+  - Checklist tab: existing section + `+ Add Checklist Item` button.
+  - **Safety tab activated** (was `disabled: true`). New `SafetyTabBody` component renders:
+    - SOP block — text display + `Edit/Add SOP` button + `Open SOP PDF` button (when a document_id is linked).
+    - Safety checklist — filtered `category IN {safety, loto}` items with token-coloured completion state (`var(--green-bg)` when done, `var(--surface)` otherwise), click to toggle, `+ Add Safety Checkpoint` button.
+  - Tab count badge surfaces `safetyItems.length + (sopText ? 1 : 0)`.
+
+### Verification
+- `pytest test_checklist_item_sop_handlers.py + test_close_work_order_bridge.py + test_entity_prefill.py` → 51/51 green
+- `vitest run src/features/work-orders src/components/lens-v2` → 29/29 green (regression)
+- `npx tsc --noEmit` on apps/web → clean
+- `python3 ast.parse` on all 4 touched Python files → clean
+
+### Deferred to PR-WO-4b
+- Tokenised `AddChecklistItemModal` + `EditSOPModal` (replace native `window.prompt()` — same pattern as `AddNoteModal`).
+- Require-photo flow: if a checklist item has `requires_photo=true`, mark-complete should first open the photo-upload modal wired to the `pms-work-order-photos` bucket.
+- Require-signature flow: PIN+TOTP signature via existing ActionPopup SIGNED pattern.
+- Close-work-order guard: refuse close if any required + non-deleted checklist item is incomplete.
+
+### Deferred to PR-WO-4c
+- Port the JSON checklist to `pms_checklists` + `pms_checklist_items` tables (queryable, templatable, shared across WOs). Requires data migration of existing `metadata.checklist[]` rows.
+
+---
+
+## PR-WO-5 — remaining scope
+
+Calendar tab (List / Calendar toggle). ~6-10h focused work. Begins after PR-WO-4 is merged to main.


### PR DESCRIPTION
## Summary
Activates the **Safety** tab (was disabled from PR-WO-3), adds two new backend actions to let user A build custom checkpoints + attach SOPs, ships a safety-filtered checklist view in the card.

Confirms via direct psql probe that the live checklist storage is `pms_work_orders.metadata.checklist[]` (JSON array), not the relational `pms_checklists` / `pms_checklist_items` tables (29 seed rows, no active writers). MVP enhances the JSON path; relational migration is deferred to PR-WO-4c.

## Files
- `apps/api/handlers/p2_mutation_light_handlers.py` — `add_checklist_item_execute` + `upsert_sop_execute`.
- `apps/api/action_router/dispatchers/internal_dispatcher.py` — two new wrappers + HANDLER_MAP entries (`add_checklist_item`, `upsert_sop`).
- `apps/api/action_router/registry.py` — two new `ActionDefinition` entries with full `field_metadata` (category enum: general / safety / loto / sop).
- `apps/api/action_router/entity_prefill.py` — two new prefill entries.
- `apps/api/tests/test_checklist_item_sop_handlers.py` **(new)** — 9 pytest-asyncio specs.
- `apps/web/src/components/lens-v2/entity/WorkOrderContent.tsx` — Safety tab activated; `SafetyTabBody` component renders SOP block + safety checklist + add-checkpoint button.
- `docs/ongoing_work/work_orders/PLAN.md` — DB reality writeup + deferred items.

## What the user sees
- **Safety tab** now shows a Standard Operating Procedure panel (text display, `Edit`/`Add SOP` button, `Open SOP PDF` when a document is linked) and a Safety Checklist panel (safety/loto filtered items, click to tick, `+ Add Safety Checkpoint` button).
- **Checklist tab** gets an `+ Add Checklist Item` button so user A can build the list from scratch.
- Tokens only — `var(--green-bg)` on completed items, `var(--teal-bg)` on SOP open button, etc.

## MVP limitation flagged in PR body + PLAN
Add/Edit uses native `window.prompt()` for text capture. A tokenised `AddChecklistItemModal` + `EditSOPModal` (same pattern as `AddNoteModal`) lands in PR-WO-4b. Also deferred: require-photo on mark-complete, require-signature flow, close-WO guard on required-items.

## Test plan
- [x] `pytest test_checklist_item_sop_handlers.py + test_close_work_order_bridge.py + test_entity_prefill.py` → 51/51
- [x] `vitest run src/features/work-orders src/components/lens-v2` → 29/29
- [x] `npx tsc --noEmit` on apps/web → clean
- [x] `python3 ast.parse` on all 4 touched .py files → clean
- [ ] Post-merge: open a WO, click Safety tab, add a safety checkpoint, verify it appears + ticks green on completion; add SOP text, verify it persists across reload

🤖 Generated with [Claude Code](https://claude.com/claude-code)