### PR TITLE
feat(equipment): migrate /equipment list to EntityTableList (Issue 4 PR-EQ-1)

### DIFF
--- a/apps/api/routes/vessel_surface_routes.py
+++ b/apps/api/routes/vessel_surface_routes.py
@@ -60,7 +60,7 @@ DOMAIN_TABLE_MAP = {
 DOMAIN_SELECT = {
     "work_orders": "id, title, wo_number, status, priority, assigned_to, equipment_id, due_date, severity, type, work_order_type, frequency, completed_at, created_at, updated_at",
     "faults": "id, title, fault_code, status, severity, equipment_id, created_at, updated_at",
-    "equipment": "id, name, code, system_type, location, status, manufacturer, model, serial_number, criticality, created_at, updated_at",
+    "equipment": "id, name, code, system_type, location, status, manufacturer, model, serial_number, criticality, running_hours, deleted_at, created_at, updated_at",
     "parts": "id, name, part_number, quantity_on_hand, minimum_quantity, location, unit_cost, manufacturer, category, is_critical, created_at, updated_at",
     # domain + person_name added so crew cert rows surface the owner name
     # in the register and list views (v_certificates_enriched exposes both).
@@ -1083,12 +1083,20 @@ def _format_record(domain: str, record: dict) -> dict:
         })
     elif domain == "equipment":
         base.update({
-            "ref": f"E-{str(record.get('id', ''))[:6]}",
+            "ref": record.get("code") or f"E-{str(record.get('id', ''))[:6]}",
             "title": record.get("name", ""),
+            "code": record.get("code"),
             "status": record.get("status", "active"),
-            "system": record.get("system", ""),
+            "system": record.get("system_type") or record.get("system", ""),
+            "system_type": record.get("system_type"),
+            "manufacturer": record.get("manufacturer"),
+            "model": record.get("model"),
+            "serial_number": record.get("serial_number"),
+            "criticality": record.get("criticality"),
+            "running_hours": record.get("running_hours"),
             "location": record.get("location", ""),
-            "meta": f"{record.get('system', '')} · {record.get('location', '')}",
+            "deleted_at": record.get("deleted_at"),
+            "meta": f"{record.get('system_type') or record.get('system', '')} · {record.get('location', '')}",
         })
     elif domain == "parts":
         stock = record.get("quantity_on_hand", 0) or 0

--- a/apps/web/src/app/equipment/page.tsx
+++ b/apps/web/src/app/equipment/page.tsx
@@ -9,6 +9,7 @@ import { EquipmentContent } from '@/components/lens-v2/entity';
 import lensStyles from '@/components/lens-v2/lens.module.css';
 import { equipmentToListResult } from '@/features/equipment/adapter';
 import { EQUIPMENT_FILTERS } from '@/features/entity-list/types/filter-config';
+import { EQUIPMENT_COLUMNS } from '@/features/equipment/columns';
 import type { Equipment } from '@/features/equipment/types';
 
 function LensContent() {
@@ -43,13 +44,14 @@ function EquipmentPageContent() {
         domain="equipment"
         queryKey={['equipment']}
         table="v_equipment_enriched"
-        columns="id, name, description, location, manufacturer, model, serial_number, status, criticality, attention_flag, attention_reason, created_at, updated_at"
+        columns="id, name, description, code, system_type, location, manufacturer, model, serial_number, status, criticality, running_hours, attention_flag, attention_reason, deleted_at, created_at, updated_at"
         adapter={equipmentToListResult}
         filterConfig={EQUIPMENT_FILTERS}
         selectedId={selectedId}
         onSelect={handleSelect}
         emptyMessage="No equipment found"
         sortBy="name"
+        tableColumns={EQUIPMENT_COLUMNS}
       />
 
       <EntityDetailOverlay isOpen={!!selectedId} onClose={handleCloseDetail}>

--- a/apps/web/src/features/equipment/adapter.ts
+++ b/apps/web/src/features/equipment/adapter.ts
@@ -13,10 +13,17 @@ export function equipmentToListResult(equipment: Equipment): EntityListResult {
     metadata: {
       status: equipment.status,
       category: equipment.category,
+      code: equipment.code ?? null,
+      system_type: equipment.system_type ?? null,
+      criticality: equipment.criticality ?? null,
+      running_hours: equipment.running_hours ?? null,
+      serial_number: equipment.serial_number ?? null,
       location: equipment.location,
       manufacturer: equipment.manufacturer,
       model: equipment.model,
+      deleted_at: equipment.deleted_at ?? null,
       created_at: equipment.created_at,
+      updated_at: equipment.updated_at ?? null,
     },
 
     // Extended fields for EntityRecordRow

--- a/apps/web/src/features/equipment/columns.tsx
+++ b/apps/web/src/features/equipment/columns.tsx
@@ -1,0 +1,353 @@
+/**
+ * EQUIPMENT_COLUMNS — tabulated list-view column spec for /equipment.
+ *
+ * Contract: apps/web/src/features/entity-list/components/EntityTableList.tsx
+ * Pattern: mirrors certificate-columns.tsx (Pattern B — accessors off metadata).
+ * Pill idiom: ported from ShoppingListTableList (STATUS_PILL_COLOR + Pill fn).
+ *
+ * Rendered via `FilteredEntityList` when the `tableColumns` prop is passed
+ * from `app/equipment/page.tsx`. Every accessor reads from `row.metadata`
+ * (the equipment row piped through `equipmentToListResult`) because
+ * `EntityListResult` doesn't carry equipment-specific DB columns.
+ *
+ * Tokens only — no raw hex, no named colours, no inline rgba. See
+ * apps/web/src/styles/tokens.css. This constraint is a CEO standing rule.
+ */
+import * as React from 'react';
+import type { EntityTableColumn } from '../entity-list/components/EntityTableList';
+import type { EntityListResult } from '../entity-list/types';
+import { formatRelativeTime } from '@/lib/utils';
+
+// ── Metadata shape (matches equipmentToListResult's metadata block) ─────────
+
+interface EquipmentRowMeta {
+  code?: string | null;
+  system_type?: string | null;
+  manufacturer?: string | null;
+  model?: string | null;
+  criticality?: string | null;
+  status?: string | null;
+  running_hours?: number | null;
+  location?: string | null;
+  deleted_at?: string | null;
+  updated_at?: string | null;
+}
+
+function meta(r: EntityListResult): EquipmentRowMeta {
+  return (r.metadata ?? {}) as EquipmentRowMeta;
+}
+
+function isArchived(r: EntityListResult): boolean {
+  return Boolean(meta(r).deleted_at);
+}
+
+// ── Sort ranks (deliberate order — failed/critical first, then degrading) ───
+
+const CRITICALITY_RANK: Record<string, number> = {
+  critical: 0,
+  high: 1,
+  medium: 2,
+  low: 3,
+};
+
+const STATUS_RANK: Record<string, number> = {
+  failed: 0,
+  degraded: 1,
+  maintenance: 2,
+  operational: 3,
+  decommissioned: 4,
+};
+
+// ── Pill palette (token-only, mirrors shopping list idiom) ──────────────────
+
+interface PillStyle { fg: string; bg: string; bd: string }
+
+const CRITICALITY_PILL: Record<string, PillStyle> = {
+  critical: { fg: 'var(--red)',            bg: 'var(--red-bg)',    bd: 'var(--red-border)' },
+  high:     { fg: 'var(--amber)',          bg: 'var(--amber-bg)',  bd: 'var(--amber-border)' },
+  medium:   { fg: 'var(--text-tertiary)',  bg: 'var(--surface)',   bd: 'var(--border-faint)' },
+  low:      { fg: 'var(--text-tertiary)',  bg: 'var(--surface)',   bd: 'var(--border-faint)' },
+};
+
+const STATUS_PILL: Record<string, PillStyle> = {
+  failed:          { fg: 'var(--red)',            bg: 'var(--red-bg)',    bd: 'var(--red-border)' },
+  degraded:        { fg: 'var(--amber)',          bg: 'var(--amber-bg)',  bd: 'var(--amber-border)' },
+  maintenance:     { fg: 'var(--mark)',           bg: 'var(--teal-bg)',   bd: 'var(--mark-hover)' },
+  operational:     { fg: 'var(--green)',          bg: 'var(--green-bg)',  bd: 'var(--green-border)' },
+  decommissioned:  { fg: 'var(--text-tertiary)',  bg: 'var(--surface)',   bd: 'var(--border-faint)' },
+};
+
+const ARCHIVED_PILL: PillStyle = {
+  fg: 'var(--text-tertiary)',
+  bg: 'var(--surface)',
+  bd: 'var(--border-faint)',
+};
+
+function fmtEnum(v: string): string {
+  return v.replace(/_/g, ' ');
+}
+
+function Pill({ value, palette }: { value: string; palette: Record<string, PillStyle> }) {
+  const style = palette[value.toLowerCase()] ?? {
+    fg: 'var(--text-tertiary)',
+    bg: 'var(--surface)',
+    bd: 'var(--border-faint)',
+  };
+  return (
+    <span
+      style={{
+        display: 'inline-flex',
+        alignItems: 'center',
+        height: 18,
+        padding: '0 6px',
+        borderRadius: 3,
+        fontSize: 9.5,
+        fontWeight: 600,
+        letterSpacing: '0.04em',
+        textTransform: 'uppercase',
+        whiteSpace: 'nowrap',
+        color: style.fg,
+        background: style.bg,
+        border: `1px solid ${style.bd}`,
+      }}
+    >
+      {fmtEnum(value)}
+    </span>
+  );
+}
+
+function ArchivedBadge() {
+  return (
+    <span
+      style={{
+        display: 'inline-flex',
+        alignItems: 'center',
+        height: 18,
+        padding: '0 6px',
+        borderRadius: 3,
+        fontSize: 9.5,
+        fontWeight: 600,
+        letterSpacing: '0.04em',
+        textTransform: 'uppercase',
+        whiteSpace: 'nowrap',
+        color: ARCHIVED_PILL.fg,
+        background: ARCHIVED_PILL.bg,
+        border: `1px solid ${ARCHIVED_PILL.bd}`,
+      }}
+    >
+      Archived
+    </span>
+  );
+}
+
+// ── Accessor helpers ────────────────────────────────────────────────────────
+
+function codeOf(r: EntityListResult): string | null {
+  // Prefer top-level entityRef (adapter sets this from equipment_number);
+  // fall back to metadata.code for the enriched-view path.
+  const top = r.entityRef && r.entityRef.trim() ? r.entityRef : null;
+  if (top) return top;
+  const m = meta(r).code;
+  return m && m.trim() ? m : null;
+}
+
+function updatedAtOf(r: EntityListResult): string | null {
+  const m = meta(r);
+  // EntityListResult doesn't carry a flat updatedAt; the adapter tunnels
+  // it via metadata.updated_at (and falls through to created_at).
+  return m.updated_at ?? (m as { created_at?: string | null }).created_at ?? null;
+}
+
+// ── Cell renderers (row-aware so they can apply archived-row treatment) ─────
+
+function NameCell({ row }: { row: EntityListResult }) {
+  const archived = isArchived(row);
+  return (
+    <span
+      style={{
+        textDecoration: archived ? 'line-through' : 'none',
+        color: archived ? 'var(--text-tertiary)' : 'var(--text-primary)',
+        opacity: archived ? 0.6 : 1,
+      }}
+    >
+      {row.title}
+    </span>
+  );
+}
+
+/** Wrap any plain-text accessor so archived rows get reduced opacity. */
+function DimIfArchived({ row, children }: { row: EntityListResult; children: React.ReactNode }) {
+  const archived = isArchived(row);
+  if (!archived) return <>{children}</>;
+  return (
+    <span style={{ opacity: 0.6, color: 'var(--text-tertiary)' }}>{children}</span>
+  );
+}
+
+function textOrDash(v: string | number | null | undefined): React.ReactNode {
+  if (v === null || v === undefined || v === '') {
+    return <span style={{ color: 'var(--text-tertiary)' }}>—</span>;
+  }
+  return <>{v}</>;
+}
+
+function StatusCell({ row }: { row: EntityListResult }) {
+  if (isArchived(row)) return <ArchivedBadge />;
+  const v = meta(row).status;
+  if (!v) return <span style={{ color: 'var(--text-tertiary)' }}>—</span>;
+  return <Pill value={v} palette={STATUS_PILL} />;
+}
+
+function CriticalityCell({ row }: { row: EntityListResult }) {
+  const v = meta(row).criticality;
+  if (!v) return <span style={{ color: 'var(--text-tertiary)' }}>—</span>;
+  const archived = isArchived(row);
+  return (
+    <span style={{ opacity: archived ? 0.6 : 1 }}>
+      <Pill value={v} palette={CRITICALITY_PILL} />
+    </span>
+  );
+}
+
+function UpdatedCell({ row }: { row: EntityListResult }) {
+  const iso = updatedAtOf(row);
+  if (!iso) return <span style={{ color: 'var(--text-tertiary)' }}>—</span>;
+  return <DimIfArchived row={row}><span>{formatRelativeTime(iso)}</span></DimIfArchived>;
+}
+
+// ── Column spec ─────────────────────────────────────────────────────────────
+
+export const EQUIPMENT_COLUMNS: EntityTableColumn<EntityListResult>[] = [
+  {
+    key: 'code',
+    label: 'Code',
+    accessor: (r) => codeOf(r) ?? '',
+    sortAccessor: (r) => {
+      const c = codeOf(r);
+      return c ? c.toLowerCase() : null;
+    },
+    render: (r) => <DimIfArchived row={r}>{textOrDash(codeOf(r))}</DimIfArchived>,
+    mono: true,
+    minWidth: 110,
+  },
+  {
+    key: 'name',
+    label: 'Name',
+    accessor: (r) => r.title,
+    sortAccessor: (r) => r.title.toLowerCase(),
+    render: (r) => <NameCell row={r} />,
+    wrap: true,
+    minWidth: 240,
+    maxWidth: 520,
+  },
+  {
+    key: 'system_type',
+    label: 'System',
+    accessor: (r) => meta(r).system_type ?? '',
+    sortAccessor: (r) => {
+      const v = meta(r).system_type;
+      return v ? v.toLowerCase() : null;
+    },
+    render: (r) => <DimIfArchived row={r}>{textOrDash(meta(r).system_type)}</DimIfArchived>,
+    minWidth: 120,
+  },
+  {
+    key: 'manufacturer',
+    label: 'Manufacturer',
+    accessor: (r) => meta(r).manufacturer ?? '',
+    sortAccessor: (r) => {
+      const v = meta(r).manufacturer;
+      return v ? v.toLowerCase() : null;
+    },
+    render: (r) => <DimIfArchived row={r}>{textOrDash(meta(r).manufacturer)}</DimIfArchived>,
+    minWidth: 140,
+    maxWidth: 220,
+  },
+  {
+    key: 'model',
+    label: 'Model',
+    accessor: (r) => meta(r).model ?? '',
+    sortAccessor: (r) => {
+      const v = meta(r).model;
+      return v ? v.toLowerCase() : null;
+    },
+    render: (r) => <DimIfArchived row={r}>{textOrDash(meta(r).model)}</DimIfArchived>,
+    mono: true,
+    minWidth: 120,
+    maxWidth: 200,
+  },
+  {
+    key: 'criticality',
+    label: 'Criticality',
+    accessor: (r) => meta(r).criticality ?? '',
+    sortAccessor: (r) => {
+      const v = meta(r).criticality;
+      if (!v) return null;
+      const rank = CRITICALITY_RANK[v.toLowerCase()];
+      return rank === undefined ? null : rank;
+    },
+    render: (r) => <CriticalityCell row={r} />,
+    minWidth: 110,
+  },
+  {
+    key: 'status',
+    label: 'Status',
+    accessor: (r) => meta(r).status ?? r.status ?? '',
+    sortAccessor: (r) => {
+      if (isArchived(r)) return null;
+      const v = meta(r).status ?? r.status;
+      if (!v) return null;
+      const rank = STATUS_RANK[v.toLowerCase()];
+      return rank === undefined ? null : rank;
+    },
+    render: (r) => <StatusCell row={r} />,
+    minWidth: 130,
+  },
+  {
+    key: 'running_hours',
+    label: 'Hrs',
+    accessor: (r) => {
+      const v = meta(r).running_hours;
+      return v === null || v === undefined ? '' : v;
+    },
+    sortAccessor: (r) => {
+      const v = meta(r).running_hours;
+      if (v === null || v === undefined) return null;
+      const n = typeof v === 'number' ? v : Number(v);
+      return Number.isFinite(n) ? n : null;
+    },
+    align: 'right',
+    mono: true,
+    minWidth: 80,
+    render: (r) => {
+      const v = meta(r).running_hours;
+      return (
+        <DimIfArchived row={r}>
+          {textOrDash(v === null || v === undefined ? '' : v)}
+        </DimIfArchived>
+      );
+    },
+  },
+  {
+    key: 'location',
+    label: 'Location',
+    accessor: (r) => meta(r).location ?? '',
+    sortAccessor: (r) => {
+      const v = meta(r).location;
+      return v ? v.toLowerCase() : null;
+    },
+    render: (r) => <DimIfArchived row={r}>{textOrDash(meta(r).location)}</DimIfArchived>,
+    minWidth: 140,
+    maxWidth: 220,
+  },
+  {
+    key: 'updated_at',
+    label: 'Updated',
+    accessor: (r) => updatedAtOf(r) ?? '',
+    sortAccessor: (r) => updatedAtOf(r) ?? null,
+    render: (r) => <UpdatedCell row={r} />,
+    align: 'right',
+    mono: true,
+    minWidth: 120,
+  },
+];

--- a/apps/web/src/features/equipment/types.ts
+++ b/apps/web/src/features/equipment/types.ts
@@ -1,16 +1,21 @@
 export interface Equipment {
   id: string;
   equipment_number?: string;
+  code?: string | null;
   name: string;
   description?: string;
   category?: string;
+  system_type?: string | null;
   location?: string;
   manufacturer?: string;
   model?: string;
   serial_number?: string;
   status: string;
+  criticality?: string | null;
+  running_hours?: number | null;
   last_service_date?: string;
   next_service_date?: string;
+  deleted_at?: string | null;
   created_at: string;
   updated_at?: string;
 }


### PR DESCRIPTION
## Summary
Migrates `/equipment` list view from legacy card-stack (SpotlightResultRow) to the shared `EntityTableList` using **Pattern B** (tableColumns prop on the existing `FilteredEntityList<Equipment>` — matches CERTIFICATE04 / WORKORDER05 shape, not SHOPPING05's direct-hook split-column Pattern A).

Part of Issue 4 (Equipment lens refactor). First of ~6 PRs. Plan: `docs/ongoing_work/equipment/PLAN_2026-04-24_issue4.md`.

## Columns (10, sortable)
Code (mono) · Name (wrap) · System · Manufacturer · Model (mono) · Criticality (pill + deliberate rank) · Status (pill + deliberate rank) · Hrs (mono, right) · Location · Updated (mono, right, relative).

Archived rows (`deleted_at IS NOT NULL`) render dimmed with strikethrough name and "Archived" badge in the Status cell.

## What changed
- **NEW** `apps/web/src/features/equipment/columns.tsx` — EQUIPMENT_COLUMNS spec + pill idiom ported from ShoppingListTableList.tsx:80-122, token-only palette, deliberate rank maps for criticality/status.
- `apps/web/src/app/equipment/page.tsx` — pass `tableColumns={EQUIPMENT_COLUMNS}`; widen Supabase select to include `code, system_type, running_hours, deleted_at`.
- `apps/web/src/features/equipment/adapter.ts` — surface `code, system_type, criticality, running_hours, serial_number, deleted_at, updated_at` into `row.metadata` so accessors have data.
- `apps/web/src/features/equipment/types.ts` — extend Equipment with optional new fields.
- `apps/api/routes/vessel_surface_routes.py` — equipment branch of `_format_record` now surfaces full set into metadata; SELECT widened. Additive, no contract break, mirrors certificates branch shape.

## Not touched
- `EntityTableList.tsx` (shared — DOCUMENTS04 owns)
- `ShoppingListTableList.tsx` / `certificate-columns.tsx` (reference only)
- Action registry / router (EQ-2 territory)

## What to look for on app.celeste7.ai/equipment after deploy
- List shows a proper table with clickable column headers (click cycles asc → desc → unset, state persists per-domain in sessionStorage).
- Criticality + Status pills use brand tokens (no stray colours).
- Sorting by Criticality puts Critical first, then High, Medium, Low; nulls at the end.
- Archived equipment (if any in yacht 85fe1119…) render dimmed with strikethrough + Archived badge.
- Running Hours, Manufacturer, Model, System all render (were previously invisible on the list).
- Narrow viewport: table scrolls horizontally, sticky header stays visible.

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `npm run build` on apps/web — `/equipment` route builds at 2.71 kB / 284 kB first-load
- [ ] Live check on app.celeste7.ai/equipment after Vercel auto-deploy
- [ ] Live check backend: `curl https://pipeline-core.int.celeste7.ai/healthz` + hit an equipment list endpoint to confirm `metadata` payload carries the new fields

## Follow-up (not this PR)
- Provisional `DimIfArchived` per-cell wrapper can be stripped if cohort later adds a row-level `archived` flag to `EntityTableList` (discuss with DOCUMENTS04 before changing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>