### PR TITLE
feat(attachments): pms_attachment_comments — threaded cohort-shared comments

### DIFF
--- a/apps/api/action_router/dispatchers/internal_dispatcher.py
+++ b/apps/api/action_router/dispatchers/internal_dispatcher.py
@@ -32,6 +32,7 @@ from handlers.equipment_handlers import get_equipment_handlers as _get_equipment
 from handlers.shopping_list_handlers import get_shopping_list_handlers as _get_shopping_list_handlers_raw
 from handlers.document_handlers import get_document_handlers as _get_document_handlers_raw
 from handlers.document_comment_handlers import get_document_comment_handlers as _get_document_comment_handlers_raw
+from handlers.attachment_comment_handlers import get_attachment_comment_handlers as _get_attachment_comment_handlers_raw
 from handlers.part_handlers import get_part_handlers as _get_part_handlers_raw
 from handlers.receiving_handlers import (
     ReceivingHandlers,
@@ -63,6 +64,7 @@ _receiving_handlers = None
 _shopping_list_handlers = None
 _document_handlers = None
 _document_comment_handlers = None
+_attachment_comment_handlers = None
 
 
 def _get_p3_handlers():
@@ -156,6 +158,14 @@ def _get_document_comment_handlers():
     if _document_comment_handlers is None:
         _document_comment_handlers = _get_document_comment_handlers_raw(get_supabase_client())
     return _document_comment_handlers
+
+
+def _get_attachment_comment_handlers():
+    """Get lazy-initialized Attachment Comment handlers (cohort-shared 2026-04-24)."""
+    global _attachment_comment_handlers
+    if _attachment_comment_handlers is None:
+        _attachment_comment_handlers = _get_attachment_comment_handlers_raw(get_supabase_client())
+    return _attachment_comment_handlers
 
 
 def _get_hours_of_rest_handlers():
@@ -681,6 +691,50 @@ async def _doc_list_document_comments(params: Dict[str, Any]) -> Dict[str, Any]:
         "yacht_id": params.get("yacht_id"),
         "user_id": params.get("user_id"),
     }
+    payload = {k: v for k, v in params.items() if k not in ("yacht_id", "user_id", "user_context")}
+    return await fn(payload, context)
+
+
+# ============================================================================
+# ATTACHMENT COMMENT WRAPPERS (cohort-shared threaded comments — 2026-04-24)
+# ============================================================================
+
+async def _att_add_attachment_comment(params: Dict[str, Any]) -> Dict[str, Any]:
+    handlers = _get_attachment_comment_handlers()
+    fn = handlers.get("add_attachment_comment")
+    if not fn:
+        raise ValueError("add_attachment_comment handler not registered")
+    context = {"yacht_id": params.get("yacht_id"), "user_id": params.get("user_id")}
+    payload = {k: v for k, v in params.items() if k not in ("yacht_id", "user_id", "user_context")}
+    return await fn(payload, context)
+
+
+async def _att_update_attachment_comment(params: Dict[str, Any]) -> Dict[str, Any]:
+    handlers = _get_attachment_comment_handlers()
+    fn = handlers.get("update_attachment_comment")
+    if not fn:
+        raise ValueError("update_attachment_comment handler not registered")
+    context = {"yacht_id": params.get("yacht_id"), "user_id": params.get("user_id")}
+    payload = {k: v for k, v in params.items() if k not in ("yacht_id", "user_id", "user_context")}
+    return await fn(payload, context)
+
+
+async def _att_delete_attachment_comment(params: Dict[str, Any]) -> Dict[str, Any]:
+    handlers = _get_attachment_comment_handlers()
+    fn = handlers.get("delete_attachment_comment")
+    if not fn:
+        raise ValueError("delete_attachment_comment handler not registered")
+    context = {"yacht_id": params.get("yacht_id"), "user_id": params.get("user_id")}
+    payload = {k: v for k, v in params.items() if k not in ("yacht_id", "user_id", "user_context")}
+    return await fn(payload, context)
+
+
+async def _att_list_attachment_comments(params: Dict[str, Any]) -> Dict[str, Any]:
+    handlers = _get_attachment_comment_handlers()
+    fn = handlers.get("list_attachment_comments")
+    if not fn:
+        raise ValueError("list_attachment_comments handler not registered")
+    context = {"yacht_id": params.get("yacht_id"), "user_id": params.get("user_id")}
     payload = {k: v for k, v in params.items() if k not in ("yacht_id", "user_id", "user_context")}
     return await fn(payload, context)
 
@@ -4312,6 +4366,11 @@ INTERNAL_HANDLERS: Dict[str, Any] = {
     # Document Comment Handlers (Document Lens v2 - Comments MVP)
     # =========================================================================
     "add_document_comment": _doc_add_document_comment,
+    # Attachment comments (cohort-shared threaded comments, 2026-04-24)
+    "add_attachment_comment":    _att_add_attachment_comment,
+    "update_attachment_comment": _att_update_attachment_comment,
+    "delete_attachment_comment": _att_delete_attachment_comment,
+    "list_attachment_comments":  _att_list_attachment_comments,
     "update_document_comment": _doc_update_document_comment,
     "delete_document_comment": _doc_delete_document_comment,
     "list_document_comments": _doc_list_document_comments,

--- a/apps/api/action_router/registry.py
+++ b/apps/api/action_router/registry.py
@@ -2066,6 +2066,90 @@ ACTION_REGISTRY: Dict[str, ActionDefinition] = {
     ),
 
     # ========================================================================
+    # Domain: cohort-shared (polymorphic across work_orders, equipment, faults,
+    #                       handovers, etc. via pms_attachments.entity_type)
+    # Table : pms_attachment_comments
+    # Added : 2026-04-24 — CEO pivot from single-caption to threaded comments.
+    #         Mirrors doc_metadata_comments 1:1 with attachment_id key.
+    # ========================================================================
+
+    "add_attachment_comment": ActionDefinition(
+        action_id="add_attachment_comment",
+        label="Add Comment",
+        endpoint="/v1/actions/execute",
+        handler_type=HandlerType.INTERNAL,
+        method="POST",
+        allowed_roles=["crew", "deckhand", "steward", "chef", "bosun", "engineer", "eto",
+                       "chief_engineer", "chief_officer", "chief_steward", "purser", "captain", "manager"],
+        required_fields=["yacht_id", "attachment_id", "comment"],
+        domain=None,  # polymorphic — attachment.entity_type drives the host lens
+        variant=ActionVariant.MUTATE,
+        search_keywords=["comment", "note", "photo", "attachment", "add", "remark", "caption", "annotation"],
+        field_metadata=[
+            FieldMetadata("yacht_id", FieldClassification.CONTEXT),
+            FieldMetadata("attachment_id", FieldClassification.REQUIRED, description="pms_attachments.id UUID"),
+            FieldMetadata("comment", FieldClassification.REQUIRED, description="Comment text"),
+            FieldMetadata("parent_comment_id", FieldClassification.OPTIONAL, description="Parent comment UUID for threaded reply"),
+        ],
+    ),
+
+    "update_attachment_comment": ActionDefinition(
+        action_id="update_attachment_comment",
+        label="Edit Comment",
+        endpoint="/v1/actions/execute",
+        handler_type=HandlerType.INTERNAL,
+        method="POST",
+        allowed_roles=["crew", "deckhand", "steward", "chef", "bosun", "engineer", "eto",
+                       "chief_engineer", "chief_officer", "chief_steward", "purser", "captain", "manager"],
+        required_fields=["yacht_id", "comment_id", "comment"],
+        domain=None,
+        variant=ActionVariant.MUTATE,
+        search_keywords=["edit", "update", "comment", "revise", "correct", "caption"],
+        field_metadata=[
+            FieldMetadata("yacht_id", FieldClassification.CONTEXT),
+            FieldMetadata("comment_id", FieldClassification.REQUIRED, description="pms_attachment_comments.id UUID"),
+            FieldMetadata("comment", FieldClassification.REQUIRED, description="New comment text"),
+        ],
+    ),
+
+    "delete_attachment_comment": ActionDefinition(
+        action_id="delete_attachment_comment",
+        label="Delete Comment",
+        endpoint="/v1/actions/execute",
+        handler_type=HandlerType.INTERNAL,
+        method="POST",
+        allowed_roles=["crew", "deckhand", "steward", "chef", "bosun", "engineer", "eto",
+                       "chief_engineer", "chief_officer", "chief_steward", "purser", "captain", "manager"],
+        required_fields=["yacht_id", "comment_id"],
+        domain=None,
+        variant=ActionVariant.MUTATE,
+        search_keywords=["delete", "remove", "comment", "erase", "caption"],
+        field_metadata=[
+            FieldMetadata("yacht_id", FieldClassification.CONTEXT),
+            FieldMetadata("comment_id", FieldClassification.REQUIRED, description="pms_attachment_comments.id UUID"),
+        ],
+    ),
+
+    "list_attachment_comments": ActionDefinition(
+        action_id="list_attachment_comments",
+        label="View Comments",
+        endpoint="/v1/actions/execute",
+        handler_type=HandlerType.INTERNAL,
+        method="POST",
+        allowed_roles=["crew", "deckhand", "steward", "chef", "bosun", "engineer", "eto",
+                       "chief_engineer", "chief_officer", "chief_steward", "purser", "captain", "manager"],
+        required_fields=["yacht_id", "attachment_id"],
+        domain=None,
+        variant=ActionVariant.READ,
+        search_keywords=["list", "view", "comments", "attachment", "photo", "show"],
+        field_metadata=[
+            FieldMetadata("yacht_id", FieldClassification.CONTEXT),
+            FieldMetadata("attachment_id", FieldClassification.REQUIRED, description="pms_attachments.id UUID"),
+            FieldMetadata("include_threads", FieldClassification.OPTIONAL, description="Include threaded replies (default: true)"),
+        ],
+    ),
+
+    # ========================================================================
     # PARTS/INVENTORY ACTIONS (Part Lens v2)
     # ========================================================================
     # 10 actions: 2 READ, 6 MUTATE, 2 SIGNED

--- a/apps/api/handlers/attachment_comment_handlers.py
+++ b/apps/api/handlers/attachment_comment_handlers.py
@@ -1,0 +1,449 @@
+"""
+Attachment Comment Handlers
+============================
+
+Handlers for pms_attachment_comments — threaded comments on images / files
+attached via pms_attachments (polymorphic across work_orders, equipment,
+faults, handovers, etc).
+
+ACTIONS:
+    add_attachment_comment    — Append a comment to an attachment (optionally a reply)
+    update_attachment_comment — Edit own comment (HOD+ can edit any)
+    delete_attachment_comment — Soft-delete (owner or HOD+)
+    list_attachment_comments  — Threaded fetch for rendering
+
+Pattern mirrors DocumentCommentHandlers (handlers/document_comment_handlers.py)
+verbatim — same method surface, same RLS-backed ownership rules, same
+thread-tree assembly. Rename map: document → attachment, doc_metadata →
+pms_attachments, doc_metadata_comments → pms_attachment_comments,
+document_id → attachment_id.
+"""
+
+from datetime import datetime, timezone
+from typing import Dict, List, Optional
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+class AttachmentCommentHandlers:
+    """Attachment comment domain handlers."""
+
+    def __init__(self, supabase_client):
+        self.db = supabase_client
+
+    # ── add_attachment_comment ────────────────────────────────────────────
+
+    async def add_attachment_comment(
+        self,
+        attachment_id: str,
+        yacht_id: str,
+        user_id: str,
+        comment: str,
+        parent_comment_id: Optional[str] = None,
+    ) -> Dict:
+        try:
+            if not comment or not comment.strip():
+                return {
+                    "status": "error",
+                    "error_code": "VALIDATION_ERROR",
+                    "message": "Comment cannot be empty",
+                }
+
+            att_result = (
+                self.db.table("pms_attachments")
+                .select("id, deleted_at")
+                .eq("id", attachment_id)
+                .eq("yacht_id", yacht_id)
+                .maybe_single()
+                .execute()
+            )
+
+            if not att_result or not att_result.data:
+                return {
+                    "status": "error",
+                    "error_code": "NOT_FOUND",
+                    "message": f"Attachment not found: {attachment_id}",
+                }
+
+            if att_result.data.get("deleted_at"):
+                return {
+                    "status": "error",
+                    "error_code": "INVALID_STATE",
+                    "message": "Cannot comment on deleted attachment",
+                }
+
+            if parent_comment_id:
+                parent_result = (
+                    self.db.table("pms_attachment_comments")
+                    .select("id")
+                    .eq("id", parent_comment_id)
+                    .eq("attachment_id", attachment_id)
+                    .is_("deleted_at", "null")
+                    .maybe_single()
+                    .execute()
+                )
+                if not parent_result or not parent_result.data:
+                    return {
+                        "status": "error",
+                        "error_code": "NOT_FOUND",
+                        "message": f"Parent comment not found: {parent_comment_id}",
+                    }
+
+            now = datetime.now(timezone.utc).isoformat()
+            comment_data = {
+                "yacht_id": yacht_id,
+                "attachment_id": attachment_id,
+                "comment": comment.strip(),
+                "created_by": user_id,
+                "created_at": now,
+                "parent_comment_id": parent_comment_id,
+            }
+
+            result = (
+                self.db.table("pms_attachment_comments")
+                .insert(comment_data)
+                .execute()
+            )
+
+            if not result.data:
+                return {
+                    "status": "error",
+                    "error_code": "INSERT_FAILED",
+                    "message": "Failed to create comment",
+                }
+
+            comment_id = result.data[0]["id"]
+            author_department = result.data[0].get("author_department")
+
+            logger.info(
+                f"Attachment comment created: {comment_id} on attachment {attachment_id}"
+            )
+
+            return {
+                "status": "success",
+                "comment_id": comment_id,
+                "attachment_id": attachment_id,
+                "author_department": author_department,
+                "created_at": now,
+            }
+
+        except Exception as e:
+            logger.error(f"add_attachment_comment failed: {e}", exc_info=True)
+            return {
+                "status": "error",
+                "error_code": "INTERNAL_ERROR",
+                "message": str(e),
+            }
+
+    # ── update_attachment_comment ─────────────────────────────────────────
+
+    async def update_attachment_comment(
+        self,
+        comment_id: str,
+        yacht_id: str,
+        user_id: str,
+        comment: str,
+    ) -> Dict:
+        try:
+            if not comment or not comment.strip():
+                return {
+                    "status": "error",
+                    "error_code": "VALIDATION_ERROR",
+                    "message": "Comment cannot be empty",
+                }
+
+            existing = (
+                self.db.table("pms_attachment_comments")
+                .select("id, created_by, deleted_at")
+                .eq("id", comment_id)
+                .eq("yacht_id", yacht_id)
+                .maybe_single()
+                .execute()
+            )
+
+            if not existing or not existing.data:
+                return {
+                    "status": "error",
+                    "error_code": "NOT_FOUND",
+                    "message": f"Comment not found: {comment_id}",
+                }
+
+            if existing.data.get("deleted_at"):
+                return {
+                    "status": "error",
+                    "error_code": "INVALID_STATE",
+                    "message": "Cannot edit deleted comment",
+                }
+
+            if existing.data.get("created_by") != user_id:
+                role_result = (
+                    self.db.table("auth_users_roles")
+                    .select("role")
+                    .eq("user_id", user_id)
+                    .eq("yacht_id", yacht_id)
+                    .maybe_single()
+                    .execute()
+                )
+                role = (
+                    role_result.data.get("role")
+                    if role_result and role_result.data
+                    else None
+                )
+                if role not in ("admin", "captain", "chief_engineer", "manager"):
+                    return {
+                        "status": "error",
+                        "error_code": "FORBIDDEN",
+                        "message": "Can only edit your own comments",
+                    }
+
+            now = datetime.now(timezone.utc).isoformat()
+            update_result = (
+                self.db.table("pms_attachment_comments")
+                .update({
+                    "comment": comment.strip(),
+                    "updated_by": user_id,
+                    "updated_at": now,
+                })
+                .eq("id", comment_id)
+                .execute()
+            )
+
+            if not update_result.data:
+                return {
+                    "status": "error",
+                    "error_code": "UPDATE_FAILED",
+                    "message": "Failed to update comment",
+                }
+
+            logger.info(f"Attachment comment updated: {comment_id}")
+
+            return {
+                "status": "success",
+                "comment_id": comment_id,
+                "updated_at": now,
+            }
+
+        except Exception as e:
+            logger.error(f"update_attachment_comment failed: {e}", exc_info=True)
+            return {
+                "status": "error",
+                "error_code": "INTERNAL_ERROR",
+                "message": str(e),
+            }
+
+    # ── delete_attachment_comment ─────────────────────────────────────────
+
+    async def delete_attachment_comment(
+        self,
+        comment_id: str,
+        yacht_id: str,
+        user_id: str,
+    ) -> Dict:
+        try:
+            existing = (
+                self.db.table("pms_attachment_comments")
+                .select("id, created_by, deleted_at")
+                .eq("id", comment_id)
+                .eq("yacht_id", yacht_id)
+                .maybe_single()
+                .execute()
+            )
+
+            if not existing or not existing.data:
+                return {
+                    "status": "error",
+                    "error_code": "NOT_FOUND",
+                    "message": f"Comment not found: {comment_id}",
+                }
+
+            if existing.data.get("deleted_at"):
+                return {
+                    "status": "error",
+                    "error_code": "INVALID_STATE",
+                    "message": "Comment already deleted",
+                }
+
+            if existing.data.get("created_by") != user_id:
+                role_result = (
+                    self.db.table("auth_users_roles")
+                    .select("role")
+                    .eq("user_id", user_id)
+                    .eq("yacht_id", yacht_id)
+                    .maybe_single()
+                    .execute()
+                )
+                role = (
+                    role_result.data.get("role")
+                    if role_result and role_result.data
+                    else None
+                )
+                if role not in ("admin", "captain", "chief_engineer", "manager"):
+                    return {
+                        "status": "error",
+                        "error_code": "FORBIDDEN",
+                        "message": "Can only delete your own comments",
+                    }
+
+            now = datetime.now(timezone.utc).isoformat()
+            delete_result = (
+                self.db.table("pms_attachment_comments")
+                .update({
+                    "deleted_by": user_id,
+                    "deleted_at": now,
+                })
+                .eq("id", comment_id)
+                .execute()
+            )
+
+            if not delete_result.data:
+                return {
+                    "status": "error",
+                    "error_code": "DELETE_FAILED",
+                    "message": "Failed to delete comment",
+                }
+
+            logger.info(f"Attachment comment deleted: {comment_id}")
+
+            return {
+                "status": "success",
+                "comment_id": comment_id,
+                "deleted_at": now,
+            }
+
+        except Exception as e:
+            logger.error(f"delete_attachment_comment failed: {e}", exc_info=True)
+            return {
+                "status": "error",
+                "error_code": "INTERNAL_ERROR",
+                "message": str(e),
+            }
+
+    # ── list_attachment_comments ──────────────────────────────────────────
+
+    async def list_attachment_comments(
+        self,
+        attachment_id: str,
+        yacht_id: str,
+        include_threads: bool = True,
+    ) -> Dict:
+        try:
+            att_result = (
+                self.db.table("pms_attachments")
+                .select("id")
+                .eq("id", attachment_id)
+                .eq("yacht_id", yacht_id)
+                .maybe_single()
+                .execute()
+            )
+
+            if not att_result or not att_result.data:
+                return {
+                    "status": "error",
+                    "error_code": "NOT_FOUND",
+                    "message": f"Attachment not found: {attachment_id}",
+                }
+
+            result = (
+                self.db.table("pms_attachment_comments")
+                .select(
+                    "id, comment, created_by, created_at, updated_at, "
+                    "parent_comment_id, author_department"
+                )
+                .eq("attachment_id", attachment_id)
+                .eq("yacht_id", yacht_id)
+                .is_("deleted_at", "null")
+                .order("created_at", desc=False)
+                .execute()
+            )
+
+            comments = result.data or []
+
+            if include_threads and comments:
+                comments = self._build_comment_tree(comments)
+
+            return {
+                "status": "success",
+                "attachment_id": attachment_id,
+                "comments": comments,
+                "total_count": len(result.data or []),
+            }
+
+        except Exception as e:
+            logger.error(f"list_attachment_comments failed: {e}", exc_info=True)
+            return {
+                "status": "error",
+                "error_code": "INTERNAL_ERROR",
+                "message": str(e),
+            }
+
+    def _build_comment_tree(self, comments: List[Dict]) -> List[Dict]:
+        """Build threaded comment tree from flat list."""
+        comment_map = {c["id"]: {**c, "replies": []} for c in comments}
+        root_comments = []
+        for c in comments:
+            parent_id = c.get("parent_comment_id")
+            if parent_id and parent_id in comment_map:
+                comment_map[parent_id]["replies"].append(comment_map[c["id"]])
+            else:
+                root_comments.append(comment_map[c["id"]])
+        return root_comments
+
+
+# =============================================================================
+# ACTION ROUTER ADAPTERS
+# =============================================================================
+
+
+def _add_attachment_comment_adapter(handlers: AttachmentCommentHandlers):
+    async def handler(params: Dict, context: Dict) -> Dict:
+        return await handlers.add_attachment_comment(
+            attachment_id=params["attachment_id"],
+            yacht_id=context["yacht_id"],
+            user_id=context["user_id"],
+            comment=params["comment"],
+            parent_comment_id=params.get("parent_comment_id"),
+        )
+    return handler
+
+
+def _update_attachment_comment_adapter(handlers: AttachmentCommentHandlers):
+    async def handler(params: Dict, context: Dict) -> Dict:
+        return await handlers.update_attachment_comment(
+            comment_id=params["comment_id"],
+            yacht_id=context["yacht_id"],
+            user_id=context["user_id"],
+            comment=params["comment"],
+        )
+    return handler
+
+
+def _delete_attachment_comment_adapter(handlers: AttachmentCommentHandlers):
+    async def handler(params: Dict, context: Dict) -> Dict:
+        return await handlers.delete_attachment_comment(
+            comment_id=params["comment_id"],
+            yacht_id=context["yacht_id"],
+            user_id=context["user_id"],
+        )
+    return handler
+
+
+def _list_attachment_comments_adapter(handlers: AttachmentCommentHandlers):
+    async def handler(params: Dict, context: Dict) -> Dict:
+        return await handlers.list_attachment_comments(
+            attachment_id=params["attachment_id"],
+            yacht_id=context["yacht_id"],
+            include_threads=params.get("include_threads", True),
+        )
+    return handler
+
+
+def get_attachment_comment_handlers(supabase_client) -> Dict:
+    """Action-router registration map for attachment-comment actions."""
+    handlers = AttachmentCommentHandlers(supabase_client)
+    return {
+        "add_attachment_comment":    _add_attachment_comment_adapter(handlers),
+        "update_attachment_comment": _update_attachment_comment_adapter(handlers),
+        "delete_attachment_comment": _delete_attachment_comment_adapter(handlers),
+        "list_attachment_comments":  _list_attachment_comments_adapter(handlers),
+    }

--- a/apps/api/tests/test_attachment_comment_handlers.py
+++ b/apps/api/tests/test_attachment_comment_handlers.py
@@ -1,0 +1,408 @@
+# apps/api/tests/test_attachment_comment_handlers.py
+"""
+Unit tests for AttachmentCommentHandlers (cohort-shared threaded comments
+on pms_attachments, added 2026-04-24).
+
+Mirrors DocumentCommentHandlers test surface where applicable. Uses a fake
+fluent supabase stub — no DB, no HTTP.
+"""
+
+import sys
+import os
+from unittest.mock import MagicMock
+
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+
+YACHT = "yacht-uuid-1"
+USER = "user-uuid-1"
+OTHER_USER = "user-uuid-2"
+ATT = "att-uuid-1"
+COMMENT = "comment-uuid-1"
+
+
+class _Q:
+    def __init__(self, parent, tbl):
+        self.parent = parent
+        self.tbl = tbl
+        self._op = None
+        self._payload = None
+        self._filters = []
+        self._maybe_single = False
+
+    def select(self, _cols): self._op = "select"; return self
+    def update(self, p):     self._op = "update"; self._payload = p; return self
+    def insert(self, p):     self._op = "insert"; self._payload = p; return self
+    def eq(self, k, v):      self._filters.append(("eq", k, v)); return self
+    def is_(self, k, v):     self._filters.append(("is_", k, v)); return self
+    def order(self, *_a, **_kw): return self
+    def limit(self, _):      return self
+
+    def maybe_single(self):
+        self._maybe_single = True
+        return self
+
+    def execute(self):
+        self.parent.calls.append({
+            "table": self.tbl, "op": self._op,
+            "payload": self._payload, "filters": tuple(self._filters),
+            "maybe_single": self._maybe_single,
+        })
+        # Canned responses are keyed (table, op, maybe_single).
+        key = (self.tbl, self._op, self._maybe_single)
+        canned = self.parent.canned.get(key)
+        if canned is None and self._maybe_single:
+            # "no row" for maybe_single → data=None
+            return MagicMock(data=None)
+        if canned is None:
+            return MagicMock(data=[])
+        if self._maybe_single:
+            return MagicMock(data=canned.get("data"))
+        return MagicMock(data=canned.get("data", []))
+
+
+class _DB:
+    def __init__(self):
+        self.calls = []
+        self.canned = {}
+    def table(self, n): return _Q(self, n)
+
+
+def _make_handler(db):
+    from handlers.attachment_comment_handlers import AttachmentCommentHandlers
+    return AttachmentCommentHandlers(supabase_client=db)
+
+
+# ── add_attachment_comment ─────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_add_comment_happy_path():
+    db = _DB()
+    db.canned = {
+        ("pms_attachments", "select", True): {"data": {"id": ATT, "deleted_at": None}},
+        ("pms_attachment_comments", "insert", False): {
+            "data": [{"id": "new-1", "author_department": "engineering"}]
+        },
+    }
+    h = _make_handler(db)
+    out = await h.add_attachment_comment(
+        attachment_id=ATT, yacht_id=YACHT, user_id=USER,
+        comment="Panel open — wires crossed",
+    )
+    assert out["status"] == "success"
+    assert out["attachment_id"] == ATT
+    assert out["author_department"] == "engineering"
+
+    inserts = [c for c in db.calls if c["table"] == "pms_attachment_comments" and c["op"] == "insert"]
+    assert len(inserts) == 1
+    assert inserts[0]["payload"]["comment"] == "Panel open — wires crossed"
+    assert inserts[0]["payload"]["created_by"] == USER
+
+
+@pytest.mark.asyncio
+async def test_add_comment_rejects_empty_text():
+    db = _DB()
+    h = _make_handler(db)
+    for blank in ("", "   ", None):
+        out = await h.add_attachment_comment(
+            attachment_id=ATT, yacht_id=YACHT, user_id=USER,
+            comment=blank,  # type: ignore[arg-type]
+        )
+        assert out["status"] == "error"
+        assert out["error_code"] == "VALIDATION_ERROR"
+    # Zero DB writes.
+    assert [c for c in db.calls if c["op"] == "insert"] == []
+
+
+@pytest.mark.asyncio
+async def test_add_comment_rejects_missing_attachment():
+    db = _DB()
+    db.canned = {
+        ("pms_attachments", "select", True): {"data": None},
+    }
+    h = _make_handler(db)
+    out = await h.add_attachment_comment(
+        attachment_id=ATT, yacht_id=YACHT, user_id=USER, comment="hello",
+    )
+    assert out["status"] == "error"
+    assert out["error_code"] == "NOT_FOUND"
+
+
+@pytest.mark.asyncio
+async def test_add_comment_rejects_deleted_attachment():
+    db = _DB()
+    db.canned = {
+        ("pms_attachments", "select", True): {
+            "data": {"id": ATT, "deleted_at": "2026-04-24T00:00:00Z"}
+        },
+    }
+    h = _make_handler(db)
+    out = await h.add_attachment_comment(
+        attachment_id=ATT, yacht_id=YACHT, user_id=USER, comment="hello",
+    )
+    assert out["status"] == "error"
+    assert out["error_code"] == "INVALID_STATE"
+
+
+@pytest.mark.asyncio
+async def test_add_reply_validates_parent_thread():
+    db = _DB()
+    db.canned = {
+        ("pms_attachments", "select", True): {"data": {"id": ATT, "deleted_at": None}},
+        ("pms_attachment_comments", "select", True): {"data": {"id": "parent-1"}},
+        ("pms_attachment_comments", "insert", False): {
+            "data": [{"id": "reply-1", "author_department": "engineering"}]
+        },
+    }
+    h = _make_handler(db)
+    out = await h.add_attachment_comment(
+        attachment_id=ATT, yacht_id=YACHT, user_id=USER,
+        comment="Confirm that reading",
+        parent_comment_id="parent-1",
+    )
+    assert out["status"] == "success"
+    # The INSERT payload carries the parent_comment_id
+    inserts = [c for c in db.calls if c["op"] == "insert"]
+    assert inserts[0]["payload"]["parent_comment_id"] == "parent-1"
+
+
+@pytest.mark.asyncio
+async def test_add_reply_rejects_unknown_parent():
+    db = _DB()
+    db.canned = {
+        ("pms_attachments", "select", True): {"data": {"id": ATT, "deleted_at": None}},
+        ("pms_attachment_comments", "select", True): {"data": None},  # parent lookup returns nothing
+    }
+    h = _make_handler(db)
+    out = await h.add_attachment_comment(
+        attachment_id=ATT, yacht_id=YACHT, user_id=USER,
+        comment="Reply to ghost", parent_comment_id="missing",
+    )
+    assert out["status"] == "error"
+    assert out["error_code"] == "NOT_FOUND"
+    assert "Parent comment" in out["message"]
+
+
+# ── update_attachment_comment ──────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_update_owner_happy_path():
+    db = _DB()
+    db.canned = {
+        ("pms_attachment_comments", "select", True): {
+            "data": {"id": COMMENT, "created_by": USER, "deleted_at": None}
+        },
+        ("pms_attachment_comments", "update", False): {
+            "data": [{"id": COMMENT}]
+        },
+    }
+    h = _make_handler(db)
+    out = await h.update_attachment_comment(
+        comment_id=COMMENT, yacht_id=YACHT, user_id=USER,
+        comment="Revised caption",
+    )
+    assert out["status"] == "success"
+    updates = [c for c in db.calls if c["table"] == "pms_attachment_comments" and c["op"] == "update"]
+    assert updates[0]["payload"]["comment"] == "Revised caption"
+    assert updates[0]["payload"]["updated_by"] == USER
+
+
+@pytest.mark.asyncio
+async def test_update_non_owner_crew_forbidden():
+    db = _DB()
+    db.canned = {
+        ("pms_attachment_comments", "select", True): {
+            "data": {"id": COMMENT, "created_by": OTHER_USER, "deleted_at": None}
+        },
+        ("auth_users_roles", "select", True): {"data": {"role": "crew"}},
+    }
+    h = _make_handler(db)
+    out = await h.update_attachment_comment(
+        comment_id=COMMENT, yacht_id=YACHT, user_id=USER, comment="Nope",
+    )
+    assert out["status"] == "error"
+    assert out["error_code"] == "FORBIDDEN"
+
+
+@pytest.mark.asyncio
+async def test_update_non_owner_captain_allowed():
+    db = _DB()
+    db.canned = {
+        ("pms_attachment_comments", "select", True): {
+            "data": {"id": COMMENT, "created_by": OTHER_USER, "deleted_at": None}
+        },
+        ("auth_users_roles", "select", True): {"data": {"role": "captain"}},
+        ("pms_attachment_comments", "update", False): {"data": [{"id": COMMENT}]},
+    }
+    h = _make_handler(db)
+    out = await h.update_attachment_comment(
+        comment_id=COMMENT, yacht_id=YACHT, user_id=USER, comment="Captain edit",
+    )
+    assert out["status"] == "success"
+
+
+@pytest.mark.asyncio
+async def test_update_missing_comment_returns_not_found():
+    db = _DB()
+    db.canned = {
+        ("pms_attachment_comments", "select", True): {"data": None},
+    }
+    h = _make_handler(db)
+    out = await h.update_attachment_comment(
+        comment_id=COMMENT, yacht_id=YACHT, user_id=USER, comment="x",
+    )
+    assert out["status"] == "error"
+    assert out["error_code"] == "NOT_FOUND"
+
+
+@pytest.mark.asyncio
+async def test_update_already_deleted_rejected():
+    db = _DB()
+    db.canned = {
+        ("pms_attachment_comments", "select", True): {
+            "data": {"id": COMMENT, "created_by": USER, "deleted_at": "2026-04-24T00:00:00Z"}
+        },
+    }
+    h = _make_handler(db)
+    out = await h.update_attachment_comment(
+        comment_id=COMMENT, yacht_id=YACHT, user_id=USER, comment="x",
+    )
+    assert out["status"] == "error"
+    assert out["error_code"] == "INVALID_STATE"
+
+
+@pytest.mark.asyncio
+async def test_update_empty_text_rejected():
+    db = _DB()
+    h = _make_handler(db)
+    out = await h.update_attachment_comment(
+        comment_id=COMMENT, yacht_id=YACHT, user_id=USER, comment="   ",
+    )
+    assert out["status"] == "error"
+    assert out["error_code"] == "VALIDATION_ERROR"
+
+
+# ── delete_attachment_comment ──────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_delete_owner_happy_path():
+    db = _DB()
+    db.canned = {
+        ("pms_attachment_comments", "select", True): {
+            "data": {"id": COMMENT, "created_by": USER, "deleted_at": None}
+        },
+        ("pms_attachment_comments", "update", False): {"data": [{"id": COMMENT}]},
+    }
+    h = _make_handler(db)
+    out = await h.delete_attachment_comment(
+        comment_id=COMMENT, yacht_id=YACHT, user_id=USER,
+    )
+    assert out["status"] == "success"
+    updates = [c for c in db.calls if c["op"] == "update"]
+    assert updates[0]["payload"]["deleted_by"] == USER
+    assert "deleted_at" in updates[0]["payload"]
+
+
+@pytest.mark.asyncio
+async def test_delete_non_owner_non_hod_forbidden():
+    db = _DB()
+    db.canned = {
+        ("pms_attachment_comments", "select", True): {
+            "data": {"id": COMMENT, "created_by": OTHER_USER, "deleted_at": None}
+        },
+        ("auth_users_roles", "select", True): {"data": {"role": "crew"}},
+    }
+    h = _make_handler(db)
+    out = await h.delete_attachment_comment(
+        comment_id=COMMENT, yacht_id=YACHT, user_id=USER,
+    )
+    assert out["status"] == "error"
+    assert out["error_code"] == "FORBIDDEN"
+
+
+@pytest.mark.asyncio
+async def test_delete_already_deleted_rejected():
+    db = _DB()
+    db.canned = {
+        ("pms_attachment_comments", "select", True): {
+            "data": {"id": COMMENT, "created_by": USER, "deleted_at": "2026-04-24T00:00:00Z"}
+        },
+    }
+    h = _make_handler(db)
+    out = await h.delete_attachment_comment(
+        comment_id=COMMENT, yacht_id=YACHT, user_id=USER,
+    )
+    assert out["status"] == "error"
+    assert out["error_code"] == "INVALID_STATE"
+
+
+# ── list_attachment_comments + thread assembly ─────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_list_returns_flat_list_when_include_threads_false():
+    db = _DB()
+    flat = [
+        {"id": "1", "comment": "A", "parent_comment_id": None, "created_by": USER,  "created_at": "2026-04-24T01:00:00Z"},
+        {"id": "2", "comment": "B", "parent_comment_id": "1",  "created_by": OTHER_USER, "created_at": "2026-04-24T02:00:00Z"},
+    ]
+    db.canned = {
+        ("pms_attachments", "select", True): {"data": {"id": ATT}},
+        ("pms_attachment_comments", "select", False): {"data": flat},
+    }
+    h = _make_handler(db)
+    out = await h.list_attachment_comments(
+        attachment_id=ATT, yacht_id=YACHT, include_threads=False,
+    )
+    assert out["status"] == "success"
+    assert out["total_count"] == 2
+    assert out["comments"] == flat  # unchanged
+
+
+@pytest.mark.asyncio
+async def test_list_builds_thread_tree_when_include_threads_true():
+    db = _DB()
+    flat = [
+        {"id": "root", "comment": "Root", "parent_comment_id": None, "created_by": USER,  "created_at": "t1"},
+        {"id": "r1",   "comment": "Reply 1", "parent_comment_id": "root", "created_by": OTHER_USER, "created_at": "t2"},
+        {"id": "r2",   "comment": "Reply 2", "parent_comment_id": "root", "created_by": OTHER_USER, "created_at": "t3"},
+        {"id": "orph", "comment": "Orphan",  "parent_comment_id": "missing-parent", "created_by": USER, "created_at": "t4"},
+    ]
+    db.canned = {
+        ("pms_attachments", "select", True): {"data": {"id": ATT}},
+        ("pms_attachment_comments", "select", False): {"data": flat},
+    }
+    h = _make_handler(db)
+    out = await h.list_attachment_comments(
+        attachment_id=ATT, yacht_id=YACHT, include_threads=True,
+    )
+    assert out["status"] == "success"
+    # `total_count` reflects the flat row count, not tree size.
+    assert out["total_count"] == 4
+    roots = out["comments"]
+    # "root" has two replies; "orph" surfaces as a root because its parent was missing.
+    root_ids = sorted(r["id"] for r in roots)
+    assert root_ids == ["orph", "root"]
+    root = next(r for r in roots if r["id"] == "root")
+    assert sorted(rep["id"] for rep in root["replies"]) == ["r1", "r2"]
+    orph = next(r for r in roots if r["id"] == "orph")
+    assert orph["replies"] == []
+
+
+@pytest.mark.asyncio
+async def test_list_returns_not_found_for_unknown_attachment():
+    db = _DB()
+    db.canned = {
+        ("pms_attachments", "select", True): {"data": None},
+    }
+    h = _make_handler(db)
+    out = await h.list_attachment_comments(
+        attachment_id=ATT, yacht_id=YACHT,
+    )
+    assert out["status"] == "error"
+    assert out["error_code"] == "NOT_FOUND"

--- a/docs/ongoing_work/work_orders/PLAN.md
+++ b/docs/ongoing_work/work_orders/PLAN.md
@@ -275,6 +275,67 @@ MVP call: enhance the JSON path (where the live data and handlers are). Table mi
 
 ---
 
+## PR-ATT-COMMENTS — threaded attachment comments (shipped 2026-04-24)
+
+### Why
+CEO pivot 2026-04-24: move from single-caption (`pms_attachments.description`) to threaded comments. Image/photo reviewers commonly need multi-message discussion on damage progression, repair validation, and hand-off sign-off — single `description` was MVP shorthand that doesn't reflect the real flow. Cohort-shared because the table is polymorphic — every lens that uploads to `pms_attachments` gets the same thread primitive.
+
+### DB (applied directly via psql, file-less per `feedback_migration_convention.md`)
+Table `public.pms_attachment_comments` mirrors `doc_metadata_comments` 1:1 with `attachment_id` in place of `document_id`:
+```sql
+CREATE TABLE pms_attachment_comments (
+  id uuid PK,
+  yacht_id uuid NOT NULL REFERENCES yacht_registry(id) ON DELETE CASCADE,
+  attachment_id uuid NOT NULL REFERENCES pms_attachments(id) ON DELETE CASCADE,
+  comment text NOT NULL CHECK (length(trim(comment)) > 0),
+  created_by uuid NOT NULL,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_by uuid, updated_at timestamptz,
+  deleted_by uuid, deleted_at timestamptz,
+  author_department varchar(100) CHECK (... in list),
+  parent_comment_id uuid REFERENCES pms_attachment_comments(id) ON DELETE CASCADE,
+  metadata jsonb DEFAULT '{}'::jsonb
+);
+-- 5 indexes (active, attachment, yacht, parent, created_at).
+-- 4 RLS policies (select/insert/update + service-role bypass) — same shape as doc comments.
+-- Trigger trg_populate_att_comment_department_before_insert reuses
+-- trg_populate_doc_comment_department() — same NEW.created_by/yacht_id → department map.
+```
+Backfill: every existing `pms_attachments.description` that is non-null and non-blank becomes row-1 of the thread, authored by `uploaded_by` at `uploaded_at`, tagged `metadata.source='backfill_20260424'`. 6 rows migrated in prod.
+
+### Backend
+- **`apps/api/handlers/attachment_comment_handlers.py` (new)** — `AttachmentCommentHandlers` with 4 methods (add/update/edit/delete + list_with_thread_tree). Direct mirror of `document_comment_handlers.py` with column renames. Explicit ownership + HOD-override for edit/delete (`admin`/`captain`/`chief_engineer`/`manager`). Soft-delete only — full audit trail.
+- **`apps/api/action_router/dispatchers/internal_dispatcher.py`** — lazy-init getter, 4 wrappers (`_att_add`/`_att_update`/`_att_delete`/`_att_list_attachment_comments`), HANDLER_MAP entries.
+- **`apps/api/action_router/registry.py`** — 4 `ActionDefinition` entries (domain=None because this is cross-lens / polymorphic), full `field_metadata`, HOD-broad `allowed_roles` (every role including `crew` can comment; the DB RLS is the last line of defense).
+- **`apps/api/tests/test_attachment_comment_handlers.py` (new)** — 18 pytest-asyncio specs covering happy paths, validation errors (empty text, deleted attachment, missing parent), RBAC (owner vs non-owner + HOD override), thread-tree assembly (orphan handling), include_threads=false flat-list return.
+
+### Verification
+- `pytest test_attachment_comment_handlers.py + test_entity_prefill.py + test_close_work_order_bridge.py + test_checklist_item_sop_handlers.py` → 69/69 green
+- `python3 ast.parse` on touched .py files → clean
+- `psql` verify post-migration: 1 table, 6 indexes, 4 policies, 6 backfilled comments ✓
+
+### Frontend status
+**`LensImageViewer` UNCHANGED in this PR.** Current viewer reads `LensImage.description` as the single-caption overlay — which still renders correctly because the backfill preserved all descriptions. Threaded-comment UI adoption is a per-lens decision:
+- **WORKORDER05 (PR-WO-4b)** — will extend the viewer to accept `comments: LensImageComment[]` as an optional prop and render the thread below the image when present.
+- **EQUIPMENT05 (PR-EQ-4)** — same extension; pulls from `list_attachment_comments` via the action router.
+- **FAULT05 / future lenses** — consume identically.
+This per-lens migration path means: no breaking change to the `LensImageViewer` API today; threaded UI ships when each consumer is ready to wire it.
+
+### Actions surfaced
+| action_id | Purpose | Roles |
+|---|---|---|
+| `add_attachment_comment` | Append a comment (optionally a reply via `parent_comment_id`) | crew+ |
+| `update_attachment_comment` | Edit text (owner or HOD) | crew+ |
+| `delete_attachment_comment` | Soft-delete (owner or HOD) | crew+ |
+| `list_attachment_comments` | Fetch flat or threaded tree | crew+ |
+
+### Deferred
+- Viewer-side threaded-UI (per-lens adoption PRs).
+- Bulk-import shape for vessels arriving with legacy captions beyond a single field (out of scope — single `description` backfill covers everything we see today).
+- Drop `pms_attachments.description` column once all lenses have migrated — wait 2-3 lens PRs before removing for safety.
+
+---
+
 ## PR-WO-5 — remaining scope
 
-Calendar tab (List / Calendar toggle). ~6-10h focused work. Begins after PR-WO-4 is merged to main.
+Calendar tab (List / Calendar toggle). ~6-10h focused work. Begins after the cohort adopts threaded comments into the viewer.


### PR DESCRIPTION
## Summary
CEO pivot 2026-04-24: move image/attachment captions from a single `pms_attachments.description` field to a full threaded-comment table. Cohort-shared because `pms_attachments` is polymorphic — every lens (work_orders, equipment, faults, handovers, purchase_orders, receiving, warranty, parts, certificates, documents, notes, checklist_item) gets the same thread primitive.

## Migration (applied directly to tenant via psql 2026-04-24)
- **Table** `public.pms_attachment_comments` mirrors `doc_metadata_comments` 1:1 with `attachment_id` in place of `document_id`. Same column names, same CHECK constraints, same indexes, same RLS shape, same department-populating trigger (reuses existing `trg_populate_doc_comment_department()` — identical column semantics).
- **Backfill**: every existing `pms_attachments.description` (non-null, non-blank, not soft-deleted) → row-1 of its own thread, authored by `uploaded_by` at `uploaded_at`, tagged `metadata.source='backfill_20260424'`. Verified **6 rows migrated**.
- **File-less** per `feedback_migration_convention.md` — SQL applied inline and recorded in `docs/ongoing_work/work_orders/PLAN.md` verbatim.

## Backend
- `apps/api/handlers/attachment_comment_handlers.py` **(new)** — 4-method handler mirroring `document_comment_handlers.py`; ownership + HOD override; soft-delete; thread-tree assembly.
- `apps/api/action_router/dispatchers/internal_dispatcher.py` — import + lazy init + 4 wrappers + HANDLER_MAP entries.
- `apps/api/action_router/registry.py` — 4 `ActionDefinition` entries (`add_attachment_comment`, `update_attachment_comment`, `delete_attachment_comment`, `list_attachment_comments`). `domain=None` — polymorphic.
- `apps/api/tests/test_attachment_comment_handlers.py` **(new)** — **18 pytest-asyncio specs**.

## Frontend
**`LensImageViewer` unchanged** in this PR. Single-caption overlay continues to work because the backfill preserved every description. Threaded-UI adoption is a per-lens decision — WORKORDER05 (PR-WO-4b) and EQUIPMENT05 (PR-EQ-4) will extend the viewer with a `comments?: LensImageComment[]` prop when ready.

## Test plan
- [x] `pytest test_attachment_comment_handlers + test_entity_prefill + test_close_work_order_bridge + test_checklist_item_sop_handlers` → 69/69
- [x] `python3 ast.parse` on touched .py → clean
- [x] `psql` post-migration verification: 1 table + 6 indexes + 4 policies + 6 backfilled rows ✓
- [ ] Post-merge: cohort lenses begin adopting threaded UI at their own pace

## Deferred
- Viewer-side threaded UI — per-lens PRs.
- Drop `pms_attachments.description` column — wait 2-3 lens adoptions before removal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)