### PR TITLE
fix(routing): entityRoutes.handover_item — remove broken mapping

### DIFF
--- a/apps/web/src/lib/__tests__/entityRoutes.test.ts
+++ b/apps/web/src/lib/__tests__/entityRoutes.test.ts
@@ -1,0 +1,49 @@
+// apps/web/src/lib/__tests__/entityRoutes.test.ts
+
+import { describe, it, expect } from 'vitest';
+import { getEntityRoute, type EntityRouteType } from '../entityRoutes';
+
+describe('getEntityRoute', () => {
+  it.each<[EntityRouteType, string]>([
+    ['work_order', '/work-orders'],
+    ['fault', '/faults'],
+    ['equipment', '/equipment'],
+    ['part', '/inventory'],
+    ['email', '/email'],
+    ['shopping_list', '/shopping-list'],
+    ['receiving', '/receiving'],
+    ['document', '/documents'],
+    ['certificate', '/certificates'],
+    ['warranty', '/warranties'],
+    ['purchase_order', '/purchasing'],
+    ['hours_of_rest', '/hours-of-rest'],
+    ['hours_of_rest_signoff', '/hours-of-rest/signoffs'],
+    ['manual', '/documents'],
+    ['shopping_item', '/shopping-list'],
+    ['inventory', '/inventory'],
+    ['handover_export', '/handover-export'],
+  ])('resolves %s → %s (no id)', (type, expected) => {
+    expect(getEntityRoute(type)).toBe(expected);
+  });
+
+  it('appends entityId when supplied', () => {
+    expect(getEntityRoute('work_order', 'wo-uuid-1')).toBe('/work-orders/wo-uuid-1');
+    expect(getEntityRoute('fault', 'f-uuid-1')).toBe('/faults/f-uuid-1');
+    expect(getEntityRoute('hours_of_rest_signoff', 'sig-uuid-1'))
+      .toBe('/hours-of-rest/signoffs/sig-uuid-1');
+  });
+
+  it('handover_item falls through to "/" — latent-bug guard (2026-04-24)', () => {
+    // Previously mapped to /handover-export/{id}, which 404'd because a
+    // handover_item.id is not a handover_export.id. Callers needing the real
+    // URL should read handover_items.entity_url directly (populated from this
+    // helper via the item's source entity_type/entity_id at export time).
+    expect(getEntityRoute('handover_item')).toBe('/');
+    expect(getEntityRoute('handover_item', 'any-uuid')).toBe('/');
+  });
+
+  it('unknown string type falls through to "/"', () => {
+    // Runtime-cast because TS type union excludes bogus values.
+    expect(getEntityRoute('not_a_real_type' as EntityRouteType)).toBe('/');
+  });
+});

--- a/apps/web/src/lib/entityRoutes.ts
+++ b/apps/web/src/lib/entityRoutes.ts
@@ -3,13 +3,50 @@
  *
  * Fragmented routes are the ONLY architecture (single-surface retired 2026-03-18).
  * Each entity type maps to its own URL route.
+ *
+ * Latent-bug correction 2026-04-24 (HANDOVER08 + WORKORDER05):
+ *   `'handover_item'` was previously mapped to `/handover-export/{id}` —
+ *   which 404'd because `handover_items.id` is not a `handover_exports.id`,
+ *   yet the route expected the latter. Callers need either:
+ *     (a) the PARENT export URL  → `/handover-export/{export_id}`
+ *         (needs a join, not expressible as a static routeMap entry), or
+ *     (b) the SOURCE entity URL  → `/<entity_type>/<entity_id>` via the
+ *         stored `handover_items.entity_url` column (canonical — already
+ *         populated at export time using this same helper).
+ *   Removed from the map so accidental future use falls through to '/',
+ *   which surfaces loudly in dev instead of silently 404ing.
+ *   If you have a `handover_item` row and want its URL, read
+ *   `handover_items.entity_url` directly; don't call this helper for it.
  */
 
+export type EntityRouteType =
+  | 'work_order'
+  | 'fault'
+  | 'equipment'
+  | 'part'
+  | 'email'
+  | 'shopping_list'
+  | 'receiving'
+  | 'document'
+  | 'certificate'
+  | 'warranty'
+  | 'purchase_order'
+  | 'hours_of_rest'
+  | 'hours_of_rest_signoff'
+  | 'manual'
+  | 'shopping_item'
+  | 'inventory'
+  | 'handover_item'   // intentionally has NO routeMap entry — see header
+  | 'handover_export';
+
 /**
- * Get the route for an entity type
+ * Get the route for an entity type.
+ *
+ * Unknown types (or the explicitly-unsupported `'handover_item'`) return '/'
+ * so the caller's UI surfaces a visible bug rather than silently 404ing.
  */
 export function getEntityRoute(
-  entityType: 'work_order' | 'fault' | 'equipment' | 'part' | 'email' | 'shopping_list' | 'receiving' | 'document' | 'certificate' | 'warranty' | 'purchase_order' | 'hours_of_rest' | 'hours_of_rest_signoff' | 'manual' | 'shopping_item' | 'inventory' | 'handover_item' | 'handover_export',
+  entityType: EntityRouteType,
   entityId?: string
 ): string {
   const routeMap: Record<string, string> = {
@@ -29,7 +66,7 @@ export function getEntityRoute(
     manual: '/documents',
     shopping_item: '/shopping-list',
     inventory: '/inventory',
-    handover_item: '/handover-export',
+    // handover_item intentionally absent — see file header comment.
     handover_export: '/handover-export',
   };
 


### PR DESCRIPTION
## Summary
Latent-bug fix flagged by HANDOVER08 during the PR #696 wire-walk review. `getEntityRoute('handover_item', id)` was mapping to `/handover-export/{id}` — but `handover_items.id` is not a `handover_exports.id`, so the resulting URL always 404'd. Dead-but-silently-broken: no live caller (grep shows only type-union and switch-case usages, no route resolution).

## Correction
- `apps/web/src/lib/entityRoutes.ts` — removed the broken map entry; added header comment explaining what callers should do instead (read `handover_items.entity_url` directly, which is populated at export time with the item's SOURCE entity route).
- `handover_item` stays in the type union so existing callers typecheck; at runtime they now fall through to `'/'` — visibly broken in dev instead of silently 404ing.
- Extracted the union to an exported `EntityRouteType` for test parametrisation.
- `apps/web/src/lib/__tests__/entityRoutes.test.ts` **(new)** — 20 vitest cases covering every valid type, id-appending, the `handover_item` fallback guard, and unknown-string fallback.

## Test plan
- [x] `vitest run entityRoutes.test.ts` → 20/20 green
- [x] `npx tsc --noEmit` on apps/web → clean
- [x] Grep confirms no live callers to `getEntityRoute('handover_item', ...)` anywhere in `apps/web/src/`
- [ ] Post-merge: HANDOVER08 ships the B5 related-rail PR reading `handover_items.entity_url` (already their plan; this fix just makes the helper correct)

## Reviewers
- HANDOVER08 — original flag
- DOCUMENTS04 / cohort — shared-route ownership

🤖 Generated with [Claude Code](https://claude.com/claude-code)