### PR TITLE
feat(work-orders): calendar tab — monthly grid with clickable WO chips

### DIFF
--- a/apps/api/routes/vessel_surface_routes.py
+++ b/apps/api/routes/vessel_surface_routes.py
@@ -686,6 +686,9 @@ async def get_domain_records(
     vendor_reference: Optional[str] = Query(None, description="Vendor reference ilike (receiving)"),
     po_number: Optional[str] = Query(None, description="PO number ilike (receiving)"),
     currency: Optional[str] = Query(None, description="Currency exact match (receiving)"),
+    # Work-order-specific filters (2026-04-24, WORKORDER05 PR-WO-5 calendar tab)
+    due_from: Optional[str] = Query(None, description="Due date from (YYYY-MM-DD, work_orders)"),
+    due_to: Optional[str] = Query(None, description="Due date to (YYYY-MM-DD, work_orders)"),
     sort: Optional[str] = Query(None, description="Sort field"),
     limit: int = Query(50, ge=1, le=2000),
     offset: int = Query(0, ge=0),
@@ -750,6 +753,17 @@ async def get_domain_records(
         # Apply assigned filter
         if assigned and domain in ("work_orders",):
             query = query.eq("assigned_to", assigned)
+
+        # Work-order-specific due_date range (calendar tab, PR-WO-5).
+        # Calendar fetches the month window. NULL due_date rows are excluded
+        # by the range predicate — intentional (WOs without due dates have no
+        # position on the calendar).
+        if domain == "work_orders":
+            if due_from:
+                query = query.gte("due_date", due_from)
+            if due_to:
+                # Inclusive end-of-day so due_date<=YYYY-MM-DD catches same-day rows.
+                query = query.lte("due_date", f"{due_to}T23:59:59.999Z")
 
         # Apply cert sub-domain filter (vessel vs crew) — v_certificates_enriched has a `domain` column
         if cert_domain and domain == "certificates" and cert_domain in ("vessel", "crew"):

--- a/apps/web/src/app/work-orders/page.tsx
+++ b/apps/web/src/app/work-orders/page.tsx
@@ -11,15 +11,92 @@ import { workOrderToListResult } from '@/features/work-orders/adapter';
 import { WORK_ORDER_COLUMNS } from '@/features/work-orders/columns';
 import { WORK_ORDER_FILTERS } from '@/features/entity-list/types/filter-config';
 import type { WorkOrder } from '@/features/work-orders/types';
+import { WorkOrderCalendar } from '@/features/work-orders/WorkOrderCalendar';
+import {
+  useMonthWorkOrders,
+  firstOfMonth,
+  lastOfMonth,
+  toISODate,
+} from '@/features/work-orders/useMonthWorkOrders';
 
 function LensContent() {
   return <div className={lensStyles.root}><WorkOrderContent /></div>;
 }
 
+// ── View toggle (List / Calendar) ─────────────────────────────────────────
+// CEO UX sheet /Users/celeste7/Desktop/lens_card_upgrades.md:455 —
+// "we will need 'list' (to host existing list filtered), and 'calendar'
+//  (the new version we are going to build)". URL is the source of truth:
+// `?view=calendar` flips the tab. Omit for default list.
+
+type LensView = 'list' | 'calendar';
+
+function isLensView(value: string | null): value is LensView {
+  return value === 'list' || value === 'calendar';
+}
+
+function ViewToggle({
+  active,
+  onChange,
+}: {
+  active: LensView;
+  onChange: (next: LensView) => void;
+}) {
+  return (
+    <div
+      role="tablist"
+      aria-label="Work-orders view"
+      style={{
+        display: 'inline-flex',
+        padding: 2,
+        background: 'var(--neutral-bg)',
+        border: '1px solid var(--border-sub)',
+        borderRadius: 6,
+      }}
+    >
+      {(['list', 'calendar'] as LensView[]).map((v) => {
+        const isActive = v === active;
+        return (
+          <button
+            key={v}
+            role="tab"
+            aria-selected={isActive}
+            type="button"
+            onClick={() => onChange(v)}
+            style={{
+              appearance: 'none',
+              WebkitAppearance: 'none',
+              padding: '6px 14px',
+              borderRadius: 4,
+              border: 'none',
+              background: isActive ? 'var(--surface)' : 'transparent',
+              color: isActive ? 'var(--txt)' : 'var(--txt2)',
+              fontSize: 12,
+              fontWeight: isActive ? 600 : 500,
+              cursor: 'pointer',
+              textTransform: 'capitalize',
+              boxShadow: isActive
+                ? '0 1px 2px rgba(0,0,0,0.08)'
+                : 'none',
+              transition: 'background 120ms ease, color 120ms ease',
+            }}
+          >
+            {v}
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+// ── Page content ───────────────────────────────────────────────────────────
+
 function WorkOrdersPageContent() {
   const router = useRouter();
   const searchParams = useSearchParams();
   const selectedId = searchParams.get('id');
+  const viewParam = searchParams.get('view');
+  const view: LensView = isLensView(viewParam) ? viewParam : 'list';
 
   const handleSelect = React.useCallback(
     (id: string, yachtId?: string) => {
@@ -38,21 +115,77 @@ function WorkOrdersPageContent() {
     router.push(`/work-orders${qs ? `?${qs}` : ''}`, { scroll: false });
   }, [router, searchParams]);
 
+  const handleViewChange = React.useCallback(
+    (next: LensView) => {
+      const params = new URLSearchParams(searchParams.toString());
+      if (next === 'list') params.delete('view');
+      else params.set('view', next);
+      const qs = params.toString();
+      router.push(`/work-orders${qs ? `?${qs}` : ''}`, { scroll: false });
+    },
+    [router, searchParams],
+  );
+
+  // Calendar-tab state: the month currently displayed. Local to the page
+  // (not URL-tracked for MVP — next/prev month is ephemeral navigation).
+  const [calendarMonth, setCalendarMonth] = React.useState<Date>(() =>
+    firstOfMonth(new Date()),
+  );
+
+  const monthWos = useMonthWorkOrders({
+    fromISO: toISODate(firstOfMonth(calendarMonth)),
+    toISO: toISODate(lastOfMonth(calendarMonth)),
+    enabled: view === 'calendar',
+  });
+
   return (
-    <div className="h-full bg-surface-base">
-      <FilteredEntityList<WorkOrder>
-        domain="work-orders"
-        queryKey={['work-orders']}
-        table="v_work_orders_enriched"
-        columns="id, title, description, status, priority, severity, type, work_order_type, frequency, wo_number, equipment_id, equipment_name, assigned_to, assigned_to_name, due_date, completed_at, created_at, updated_at"
-        adapter={workOrderToListResult}
-        filterConfig={WORK_ORDER_FILTERS}
-        selectedId={selectedId}
-        onSelect={handleSelect}
-        emptyMessage="No work orders found"
-        sortBy="created_at"
-        tableColumns={WORK_ORDER_COLUMNS}
-      />
+    <div
+      className="h-full bg-surface-base"
+      style={{ display: 'flex', flexDirection: 'column' }}
+    >
+      {/* Tab strip — sticky above the view body */}
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'flex-start',
+          gap: 10,
+          padding: '10px 20px',
+          borderBottom: '1px solid var(--border-faint)',
+          flexShrink: 0,
+          background: 'var(--surface-base)',
+        }}
+      >
+        <ViewToggle active={view} onChange={handleViewChange} />
+      </div>
+
+      {/* View body */}
+      <div style={{ flex: 1, minHeight: 0 }}>
+        {view === 'list' ? (
+          <FilteredEntityList<WorkOrder>
+            domain="work-orders"
+            queryKey={['work-orders']}
+            table="v_work_orders_enriched"
+            columns="id, title, description, status, priority, severity, type, work_order_type, frequency, wo_number, equipment_id, equipment_name, assigned_to, assigned_to_name, due_date, completed_at, created_at, updated_at"
+            adapter={workOrderToListResult}
+            filterConfig={WORK_ORDER_FILTERS}
+            selectedId={selectedId}
+            onSelect={handleSelect}
+            emptyMessage="No work orders found"
+            sortBy="created_at"
+            tableColumns={WORK_ORDER_COLUMNS}
+          />
+        ) : (
+          <WorkOrderCalendar
+            records={monthWos.records}
+            currentMonth={calendarMonth}
+            onMonthChange={setCalendarMonth}
+            onSelect={handleSelect}
+            isLoading={monthWos.isLoading}
+            error={monthWos.error}
+          />
+        )}
+      </div>
 
       <EntityDetailOverlay isOpen={!!selectedId} onClose={handleCloseDetail}>
         {selectedId && (

--- a/apps/web/src/features/work-orders/WorkOrderCalendar.tsx
+++ b/apps/web/src/features/work-orders/WorkOrderCalendar.tsx
@@ -1,0 +1,566 @@
+'use client';
+
+/**
+ * WorkOrderCalendar — month-grid calendar view for /work-orders.
+ *
+ * UX spec: /Users/celeste7/Desktop/lens_card_upgrades.md:455-476.
+ *   - Monthly grid, Seahub-style, driven by `due_date`.
+ *   - Each WO renders as a coloured chip inside its due-date cell.
+ *   - Click a chip → open the existing WO overlay (same `onSelect` the list
+ *     view uses — zero UX drift).
+ *   - Completed and cancelled WOs stay visible: green shading for completed,
+ *     grey+strikethrough for cancelled / deleted. CEO spec line 476:
+ *     "IF work order is deleted, in fault, completed etc. STILL SHOW THIS ON
+ *      CALENDAR, dont hide it."
+ *   - Colour precedence for active WOs: severity > priority. Falls back to
+ *     neutral for unknown enums.
+ *   - Overflow handling: max 3 chips visible per cell; "+N more" opens an
+ *     in-cell expanded list. Simple, mobile-friendly, no multi-day-span bars
+ *     (CEO explicit MVP scope — no Apple-Calendar-level overlap solver).
+ *
+ * 100% tokenised. No third-party calendar lib.
+ */
+
+import * as React from 'react';
+import {
+  toISODate,
+  firstOfMonth,
+  lastOfMonth,
+  recordDueDateKey,
+  type WorkOrderCalendarRecord,
+} from './useMonthWorkOrders';
+
+// ── Types ──────────────────────────────────────────────────────────────────
+
+export interface WorkOrderCalendarProps {
+  records: WorkOrderCalendarRecord[];
+  /** The month currently being displayed. */
+  currentMonth: Date;
+  /** Change month (prev / next / today). */
+  onMonthChange: (next: Date) => void;
+  /** Click a WO chip → open its overlay. Same handler the list view uses. */
+  onSelect: (id: string, yachtId?: string) => void;
+  isLoading?: boolean;
+  error?: Error | null;
+}
+
+// ── Colour precedence (tokens only) ────────────────────────────────────────
+
+type ChipPalette = { fg: string; bg: string; bd: string };
+
+const CHIP_COMPLETED: ChipPalette = {
+  fg: 'var(--green)',
+  bg: 'var(--green-bg)',
+  bd: 'var(--green-border)',
+};
+const CHIP_TERMINAL: ChipPalette = {
+  fg: 'var(--text-tertiary)',
+  bg: 'var(--surface)',
+  bd: 'var(--border-faint)',
+};
+
+const SEVERITY_PALETTE: Record<string, ChipPalette> = {
+  critical: { fg: 'var(--red)',   bg: 'var(--red-bg)',   bd: 'var(--red-border)' },
+  high:     { fg: 'var(--red)',   bg: 'var(--red-bg)',   bd: 'var(--red-border)' },
+  warning:  { fg: 'var(--amber)', bg: 'var(--amber-bg)', bd: 'var(--amber-border)' },
+  medium:   { fg: 'var(--amber)', bg: 'var(--amber-bg)', bd: 'var(--amber-border)' },
+  low:      { fg: 'var(--text-tertiary)', bg: 'var(--surface)', bd: 'var(--border-faint)' },
+};
+
+const PRIORITY_PALETTE: Record<string, ChipPalette> = {
+  emergency: { fg: 'var(--red)',   bg: 'var(--red-bg)',   bd: 'var(--red-border)' },
+  critical:  { fg: 'var(--red)',   bg: 'var(--red-bg)',   bd: 'var(--red-border)' },
+  important: { fg: 'var(--amber)', bg: 'var(--amber-bg)', bd: 'var(--amber-border)' },
+  routine:   { fg: 'var(--mark)',  bg: 'var(--teal-bg)',  bd: 'var(--mark-hover)' },
+};
+
+const CHIP_NEUTRAL: ChipPalette = {
+  fg: 'var(--mark)',
+  bg: 'var(--teal-bg)',
+  bd: 'var(--mark-hover)',
+};
+
+/**
+ * Determine the colour palette for a chip. CEO spec (line 476): precedence is
+ * severity > priority for active WOs; terminal states override everything.
+ */
+export function paletteForRecord(r: WorkOrderCalendarRecord): ChipPalette {
+  const status = (r.status ?? '').toLowerCase();
+  if (status === 'completed' || status === 'closed' || r.completed_at) {
+    return CHIP_COMPLETED;
+  }
+  if (status === 'cancelled' || status === 'archived') {
+    return CHIP_TERMINAL;
+  }
+  const sev = (r.severity ?? '').toLowerCase();
+  if (sev && SEVERITY_PALETTE[sev]) return SEVERITY_PALETTE[sev];
+  const pri = (r.priority ?? '').toLowerCase();
+  if (pri && PRIORITY_PALETTE[pri]) return PRIORITY_PALETTE[pri];
+  return CHIP_NEUTRAL;
+}
+
+export function isTerminal(r: WorkOrderCalendarRecord): boolean {
+  const s = (r.status ?? '').toLowerCase();
+  return (
+    s === 'completed' ||
+    s === 'closed' ||
+    s === 'cancelled' ||
+    s === 'archived' ||
+    Boolean(r.completed_at)
+  );
+}
+
+// ── Grid helpers ───────────────────────────────────────────────────────────
+
+const WEEKDAY_LABELS_MON_FIRST = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'];
+
+/**
+ * Return 42 date objects covering the month display — six rows of seven days,
+ * including trailing days from the previous month and leading days of the
+ * next so the grid is always rectangular. Week starts Monday (maritime norm).
+ */
+export function buildMonthGrid(monthAnchor: Date): Date[] {
+  const first = firstOfMonth(monthAnchor);
+  // Day-of-week with Monday=0..Sunday=6.
+  const dowMonZero = (first.getDay() + 6) % 7;
+  const gridStart = new Date(
+    first.getFullYear(),
+    first.getMonth(),
+    1 - dowMonZero,
+  );
+  const cells: Date[] = [];
+  for (let i = 0; i < 42; i++) {
+    cells.push(
+      new Date(
+        gridStart.getFullYear(),
+        gridStart.getMonth(),
+        gridStart.getDate() + i,
+      ),
+    );
+  }
+  return cells;
+}
+
+/** Bucket records by their due_date (YYYY-MM-DD). NULL due dates drop silently. */
+export function bucketByDueDate(
+  records: WorkOrderCalendarRecord[],
+): Map<string, WorkOrderCalendarRecord[]> {
+  const out = new Map<string, WorkOrderCalendarRecord[]>();
+  for (const r of records) {
+    const key = recordDueDateKey(r);
+    if (!key) continue;
+    const list = out.get(key);
+    if (list) list.push(r);
+    else out.set(key, [r]);
+  }
+  return out;
+}
+
+// ── Component ──────────────────────────────────────────────────────────────
+
+export function WorkOrderCalendar({
+  records,
+  currentMonth,
+  onMonthChange,
+  onSelect,
+  isLoading,
+  error,
+}: WorkOrderCalendarProps) {
+  const [expandedCell, setExpandedCell] = React.useState<string | null>(null);
+
+  const monthLabel = React.useMemo(
+    () =>
+      currentMonth.toLocaleDateString('en-GB', {
+        month: 'long',
+        year: 'numeric',
+      }),
+    [currentMonth],
+  );
+
+  const todayKey = React.useMemo(() => toISODate(new Date()), []);
+  const grid = React.useMemo(() => buildMonthGrid(currentMonth), [currentMonth]);
+  const buckets = React.useMemo(() => bucketByDueDate(records), [records]);
+
+  const handlePrev = () =>
+    onMonthChange(new Date(currentMonth.getFullYear(), currentMonth.getMonth() - 1, 1));
+  const handleNext = () =>
+    onMonthChange(new Date(currentMonth.getFullYear(), currentMonth.getMonth() + 1, 1));
+  const handleToday = () => onMonthChange(firstOfMonth(new Date()));
+
+  return (
+    <div
+      data-testid="wo-calendar"
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        height: '100%',
+        background: 'var(--surface-base)',
+      }}
+    >
+      {/* Toolbar */}
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+          padding: '14px 20px',
+          borderBottom: '1px solid var(--border-faint)',
+          flexShrink: 0,
+        }}
+      >
+        <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+          <IconButton aria-label="Previous month" onClick={handlePrev}>
+            ‹
+          </IconButton>
+          <IconButton aria-label="Next month" onClick={handleNext}>
+            ›
+          </IconButton>
+          <button
+            type="button"
+            onClick={handleToday}
+            style={{
+              appearance: 'none',
+              WebkitAppearance: 'none',
+              marginLeft: 8,
+              padding: '6px 12px',
+              background: 'var(--neutral-bg)',
+              border: '1px solid var(--border-sub)',
+              borderRadius: 6,
+              cursor: 'pointer',
+              fontSize: 12,
+              fontWeight: 500,
+              color: 'var(--txt2)',
+            }}
+          >
+            Today
+          </button>
+          <span
+            style={{
+              marginLeft: 16,
+              fontSize: 14,
+              fontWeight: 600,
+              color: 'var(--txt)',
+            }}
+          >
+            {monthLabel}
+          </span>
+        </div>
+        <span style={{ fontSize: 12, color: 'var(--txt3)' }}>
+          {isLoading
+            ? 'Loading…'
+            : `${records.length} work order${records.length === 1 ? '' : 's'} in this month`}
+        </span>
+      </div>
+
+      {error && (
+        <div
+          style={{
+            padding: '16px 20px',
+            fontSize: 12,
+            color: 'var(--red)',
+            background: 'var(--red-bg)',
+            borderBottom: '1px solid var(--red-border)',
+          }}
+        >
+          Failed to load calendar: {error.message}
+        </div>
+      )}
+
+      {/* Weekday header */}
+      <div
+        style={{
+          display: 'grid',
+          gridTemplateColumns: 'repeat(7, minmax(0, 1fr))',
+          borderBottom: '1px solid var(--border-faint)',
+          flexShrink: 0,
+        }}
+      >
+        {WEEKDAY_LABELS_MON_FIRST.map((label) => (
+          <div
+            key={label}
+            style={{
+              padding: '8px 10px',
+              fontSize: 10,
+              fontWeight: 600,
+              letterSpacing: '0.06em',
+              textTransform: 'uppercase',
+              color: 'var(--txt2)',
+              borderRight: '1px solid var(--border-faint)',
+            }}
+          >
+            {label}
+          </div>
+        ))}
+      </div>
+
+      {/* Month grid */}
+      <div
+        style={{
+          flex: 1,
+          display: 'grid',
+          gridTemplateColumns: 'repeat(7, minmax(0, 1fr))',
+          gridTemplateRows: 'repeat(6, minmax(110px, 1fr))',
+          overflow: 'auto',
+        }}
+      >
+        {grid.map((day) => {
+          const key = toISODate(day);
+          const inMonth = day.getMonth() === currentMonth.getMonth();
+          const isToday = key === todayKey;
+          const dayRecords = buckets.get(key) ?? [];
+          const expanded = expandedCell === key;
+          return (
+            <DayCell
+              key={key}
+              day={day}
+              isoKey={key}
+              inMonth={inMonth}
+              isToday={isToday}
+              records={dayRecords}
+              expanded={expanded}
+              onToggleExpanded={() =>
+                setExpandedCell(expanded ? null : key)
+              }
+              onSelectRecord={onSelect}
+            />
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+// ── Day cell ───────────────────────────────────────────────────────────────
+
+const VISIBLE_CHIP_LIMIT = 3;
+
+function DayCell({
+  day,
+  isoKey,
+  inMonth,
+  isToday,
+  records,
+  expanded,
+  onToggleExpanded,
+  onSelectRecord,
+}: {
+  day: Date;
+  isoKey: string;
+  inMonth: boolean;
+  isToday: boolean;
+  records: WorkOrderCalendarRecord[];
+  expanded: boolean;
+  onToggleExpanded: () => void;
+  onSelectRecord: (id: string, yachtId?: string) => void;
+}) {
+  const visible = expanded
+    ? records
+    : records.slice(0, VISIBLE_CHIP_LIMIT);
+  const hidden = records.length - visible.length;
+
+  return (
+    <div
+      data-testid={`wo-calendar-cell-${isoKey}`}
+      data-in-month={inMonth}
+      data-is-today={isToday}
+      style={{
+        borderRight: '1px solid var(--border-faint)',
+        borderBottom: '1px solid var(--border-faint)',
+        padding: 6,
+        background: inMonth ? 'var(--surface-base)' : 'var(--neutral-bg)',
+        display: 'flex',
+        flexDirection: 'column',
+        gap: 4,
+        minHeight: 110,
+        position: 'relative',
+      }}
+    >
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+          marginBottom: 2,
+        }}
+      >
+        <span
+          style={{
+            fontSize: 11,
+            fontFamily: 'var(--font-mono)',
+            fontWeight: isToday ? 700 : 500,
+            color: inMonth
+              ? isToday
+                ? 'var(--mark)'
+                : 'var(--txt)'
+              : 'var(--txt3)',
+          }}
+        >
+          {day.getDate()}
+        </span>
+        {isToday && (
+          <span
+            style={{
+              fontSize: 9,
+              fontWeight: 700,
+              letterSpacing: '0.06em',
+              textTransform: 'uppercase',
+              color: 'var(--mark)',
+            }}
+          >
+            Today
+          </span>
+        )}
+      </div>
+
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 3 }}>
+        {visible.map((r) => (
+          <WorkOrderChip key={r.id} record={r} onClick={onSelectRecord} />
+        ))}
+        {hidden > 0 && !expanded && (
+          <button
+            type="button"
+            onClick={onToggleExpanded}
+            style={{
+              appearance: 'none',
+              WebkitAppearance: 'none',
+              background: 'transparent',
+              border: '1px dashed var(--border-sub)',
+              borderRadius: 3,
+              padding: '2px 6px',
+              cursor: 'pointer',
+              fontSize: 10,
+              fontWeight: 600,
+              color: 'var(--txt2)',
+              alignSelf: 'flex-start',
+            }}
+          >
+            +{hidden} more
+          </button>
+        )}
+        {expanded && records.length > VISIBLE_CHIP_LIMIT && (
+          <button
+            type="button"
+            onClick={onToggleExpanded}
+            style={{
+              appearance: 'none',
+              WebkitAppearance: 'none',
+              background: 'transparent',
+              border: '1px dashed var(--border-sub)',
+              borderRadius: 3,
+              padding: '2px 6px',
+              cursor: 'pointer',
+              fontSize: 10,
+              fontWeight: 600,
+              color: 'var(--txt2)',
+              alignSelf: 'flex-start',
+            }}
+          >
+            Collapse
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}
+
+// ── Chip ───────────────────────────────────────────────────────────────────
+
+function WorkOrderChip({
+  record,
+  onClick,
+}: {
+  record: WorkOrderCalendarRecord;
+  onClick: (id: string, yachtId?: string) => void;
+}) {
+  const palette = paletteForRecord(record);
+  const terminal = isTerminal(record);
+  const ref = record.ref ? `WO·${record.ref}` : '';
+  return (
+    <button
+      type="button"
+      onClick={() => onClick(record.id, record.yacht_id)}
+      aria-label={`Open ${record.title ?? 'work order'}`}
+      title={record.title ?? 'Work order'}
+      style={{
+        appearance: 'none',
+        WebkitAppearance: 'none',
+        textAlign: 'left',
+        display: 'flex',
+        alignItems: 'center',
+        gap: 5,
+        padding: '3px 6px',
+        borderRadius: 3,
+        background: palette.bg,
+        border: `1px solid ${palette.bd}`,
+        color: palette.fg,
+        cursor: 'pointer',
+        fontSize: 11,
+        lineHeight: 1.25,
+        textDecoration: terminal ? 'line-through' : undefined,
+        opacity: terminal ? 0.78 : 1,
+        minWidth: 0,
+      }}
+    >
+      {ref && (
+        <span
+          style={{
+            fontFamily: 'var(--font-mono)',
+            fontWeight: 700,
+            fontSize: 10,
+            flexShrink: 0,
+          }}
+        >
+          {ref}
+        </span>
+      )}
+      <span
+        style={{
+          overflow: 'hidden',
+          textOverflow: 'ellipsis',
+          whiteSpace: 'nowrap',
+          minWidth: 0,
+        }}
+      >
+        {record.title ?? 'Work order'}
+      </span>
+    </button>
+  );
+}
+
+// ── Icon button ────────────────────────────────────────────────────────────
+
+function IconButton({
+  children,
+  onClick,
+  'aria-label': ariaLabel,
+}: {
+  children: React.ReactNode;
+  onClick: () => void;
+  'aria-label': string;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      aria-label={ariaLabel}
+      style={{
+        appearance: 'none',
+        WebkitAppearance: 'none',
+        width: 32,
+        height: 32,
+        display: 'inline-flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        background: 'var(--neutral-bg)',
+        border: '1px solid var(--border-sub)',
+        borderRadius: 6,
+        cursor: 'pointer',
+        fontSize: 16,
+        fontWeight: 700,
+        color: 'var(--txt)',
+      }}
+    >
+      {children}
+    </button>
+  );
+}

--- a/apps/web/src/features/work-orders/__tests__/WorkOrderCalendar.test.tsx
+++ b/apps/web/src/features/work-orders/__tests__/WorkOrderCalendar.test.tsx
@@ -1,0 +1,316 @@
+// apps/web/src/features/work-orders/__tests__/WorkOrderCalendar.test.tsx
+//
+// WorkOrderCalendar — grid construction + palette precedence + click through.
+// Covers the pure helpers first (zero-render), then a minimal render smoke
+// test. Component is deliberately presentation-only — real data comes via
+// useMonthWorkOrders, which has its own integration surface.
+
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, screen, fireEvent, cleanup } from '@testing-library/react';
+import * as React from 'react';
+import {
+  WorkOrderCalendar,
+  paletteForRecord,
+  isTerminal,
+  buildMonthGrid,
+  bucketByDueDate,
+} from '../WorkOrderCalendar';
+import { toISODate, type WorkOrderCalendarRecord } from '../useMonthWorkOrders';
+
+afterEach(() => {
+  cleanup();
+});
+
+function rec(over: Partial<WorkOrderCalendarRecord> = {}): WorkOrderCalendarRecord {
+  return {
+    id: over.id ?? 'wo-1',
+    ref: over.ref ?? '0074',
+    title: over.title ?? 'Service main engine',
+    status: over.status,
+    priority: over.priority,
+    severity: over.severity,
+    due_date: over.due_date ?? null,
+    completed_at: over.completed_at ?? null,
+    ...over,
+  };
+}
+
+// ── palette precedence ─────────────────────────────────────────────────────
+
+describe('paletteForRecord', () => {
+  it('completed status → green palette', () => {
+    const p = paletteForRecord(rec({ status: 'completed', priority: 'emergency' }));
+    expect(p.bg).toBe('var(--green-bg)');
+    // Priority is ignored once terminal.
+  });
+
+  it('completed_at set (no status) → green palette', () => {
+    const p = paletteForRecord(rec({ completed_at: '2026-04-20T10:00:00Z' }));
+    expect(p.bg).toBe('var(--green-bg)');
+  });
+
+  it('cancelled / archived → neutral-grey terminal palette', () => {
+    expect(paletteForRecord(rec({ status: 'cancelled' })).bg).toBe('var(--surface)');
+    expect(paletteForRecord(rec({ status: 'archived' })).bg).toBe('var(--surface)');
+  });
+
+  it('severity wins over priority on active WOs', () => {
+    // critical severity + routine priority → red (severity)
+    const p = paletteForRecord(rec({ severity: 'critical', priority: 'routine' }));
+    expect(p.bg).toBe('var(--red-bg)');
+  });
+
+  it('falls back to priority when severity missing', () => {
+    const p = paletteForRecord(rec({ priority: 'emergency' }));
+    expect(p.bg).toBe('var(--red-bg)');
+  });
+
+  it('unknown enums fall back to neutral teal palette', () => {
+    const p = paletteForRecord(rec({ priority: 'zzz_unknown' }));
+    expect(p.bg).toBe('var(--teal-bg)');
+  });
+
+  it('low severity maps to neutral palette (not red)', () => {
+    const p = paletteForRecord(rec({ severity: 'low' }));
+    expect(p.bg).toBe('var(--surface)');
+  });
+});
+
+describe('isTerminal', () => {
+  it.each([
+    [{ status: 'completed' }, true],
+    [{ status: 'closed' }, true],
+    [{ status: 'cancelled' }, true],
+    [{ status: 'archived' }, true],
+    [{ completed_at: '2026-04-20' }, true],
+    [{ status: 'open' }, false],
+    [{ status: 'in_progress' }, false],
+    [{}, false],
+  ] as const)('%o → %s', (over, expected) => {
+    expect(isTerminal(rec(over))).toBe(expected);
+  });
+});
+
+// ── buildMonthGrid ─────────────────────────────────────────────────────────
+
+describe('buildMonthGrid', () => {
+  it('always returns 42 cells', () => {
+    // Pick a month where day-1 falls on various weekdays.
+    for (const m of [0, 1, 4, 8, 11]) {
+      expect(buildMonthGrid(new Date(2026, m, 1))).toHaveLength(42);
+    }
+  });
+
+  it('first cell is Monday — April 2026 (Apr-1 = Wed) shows Mon Mar-30', () => {
+    const grid = buildMonthGrid(new Date(2026, 3, 1));
+    expect(toISODate(grid[0])).toBe('2026-03-30');
+    // Day 2 = Tue 31 Mar; Day 3 = Wed 1 Apr (first-of-month)
+    expect(toISODate(grid[1])).toBe('2026-03-31');
+    expect(toISODate(grid[2])).toBe('2026-04-01');
+  });
+
+  it('Feb 2026 (leap-adjacent check — 2026 is not a leap year)', () => {
+    // Feb 2026: 1 Feb is a Sunday.
+    const grid = buildMonthGrid(new Date(2026, 1, 1));
+    // First cell is Monday 26 Jan.
+    expect(toISODate(grid[0])).toBe('2026-01-26');
+    // 1 Feb appears at index 6 (Sunday slot when week starts Monday).
+    expect(toISODate(grid[6])).toBe('2026-02-01');
+  });
+});
+
+// ── bucketByDueDate ────────────────────────────────────────────────────────
+
+describe('bucketByDueDate', () => {
+  it('groups records by YYYY-MM-DD, drops null due_date', () => {
+    const records = [
+      rec({ id: 'a', due_date: '2026-04-20' }),
+      rec({ id: 'b', due_date: '2026-04-20T14:30:00Z' }),
+      rec({ id: 'c', due_date: '2026-04-21' }),
+      rec({ id: 'd', due_date: null }),
+    ];
+    const buckets = bucketByDueDate(records);
+    expect(buckets.get('2026-04-20')?.map((r) => r.id)).toEqual(['a', 'b']);
+    expect(buckets.get('2026-04-21')?.map((r) => r.id)).toEqual(['c']);
+    expect(buckets.get('null')).toBeUndefined();
+    expect(buckets.size).toBe(2);
+  });
+
+  it('preserves input order within a bucket', () => {
+    const records = [
+      rec({ id: 'first', due_date: '2026-05-01' }),
+      rec({ id: 'second', due_date: '2026-05-01T09:00:00Z' }),
+      rec({ id: 'third', due_date: '2026-05-01T15:00:00Z' }),
+    ];
+    expect(bucketByDueDate(records).get('2026-05-01')?.map((r) => r.id))
+      .toEqual(['first', 'second', 'third']);
+  });
+});
+
+// ── render smoke ────────────────────────────────────────────────────────────
+
+describe('<WorkOrderCalendar>', () => {
+  const REF_MONTH = new Date(2026, 3, 1); // April 2026
+
+  it('renders 42 cells + weekday header + month label', () => {
+    render(
+      <WorkOrderCalendar
+        records={[]}
+        currentMonth={REF_MONTH}
+        onMonthChange={() => {}}
+        onSelect={() => {}}
+      />,
+    );
+    // Month label
+    expect(screen.getByText(/April 2026/)).toBeDefined();
+    // Weekday headers (7)
+    for (const label of ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun']) {
+      expect(screen.getByText(label)).toBeDefined();
+    }
+    // Cells (42)
+    const cells = document.querySelectorAll('[data-testid^="wo-calendar-cell-"]');
+    expect(cells.length).toBe(42);
+  });
+
+  it('renders WO chips in their due-date cell, truncated to 3 with + more', () => {
+    const recs = Array.from({ length: 5 }).map((_, i) =>
+      rec({
+        id: `wo-${i}`,
+        ref: String(74 + i),
+        title: `WO ${i}`,
+        due_date: '2026-04-15',
+        priority: 'routine',
+      }),
+    );
+    render(
+      <WorkOrderCalendar
+        records={recs}
+        currentMonth={REF_MONTH}
+        onMonthChange={() => {}}
+        onSelect={() => {}}
+      />,
+    );
+    const cell = screen.getByTestId('wo-calendar-cell-2026-04-15');
+    // Only 3 chips should render initially
+    const visibleChips = cell.querySelectorAll('button[aria-label^="Open"]');
+    expect(visibleChips.length).toBe(3);
+    // + N more button present
+    expect(cell.textContent).toContain('+2 more');
+
+    // Expand
+    fireEvent.click(cell.querySelector('button[aria-label="Open WO 2"]') ? cell.querySelector('button') as Element : cell.querySelector('button') as Element);
+  });
+
+  it('expanding + collapsing toggles full-day chip list', () => {
+    const recs = Array.from({ length: 5 }).map((_, i) =>
+      rec({ id: `wo-${i}`, title: `WO ${i}`, due_date: '2026-04-10' }),
+    );
+    render(
+      <WorkOrderCalendar
+        records={recs}
+        currentMonth={REF_MONTH}
+        onMonthChange={() => {}}
+        onSelect={() => {}}
+      />,
+    );
+    const cell = screen.getByTestId('wo-calendar-cell-2026-04-10');
+    // Click the +N more button (use text to find it)
+    const moreBtn = Array.from(cell.querySelectorAll('button')).find(
+      (b) => b.textContent?.includes('+2 more'),
+    );
+    expect(moreBtn).toBeDefined();
+    fireEvent.click(moreBtn!);
+    expect(cell.querySelectorAll('button[aria-label^="Open"]').length).toBe(5);
+    // Collapse button present
+    expect(cell.textContent).toContain('Collapse');
+  });
+
+  it('clicking a chip fires onSelect with the record id + yacht_id', () => {
+    const onSelect = vi.fn();
+    render(
+      <WorkOrderCalendar
+        records={[rec({ id: 'wo-x', due_date: '2026-04-12', yacht_id: 'y-1' } as WorkOrderCalendarRecord)]}
+        currentMonth={REF_MONTH}
+        onMonthChange={() => {}}
+        onSelect={onSelect}
+      />,
+    );
+    const cell = screen.getByTestId('wo-calendar-cell-2026-04-12');
+    const chip = cell.querySelector('button[aria-label^="Open"]') as HTMLButtonElement;
+    fireEvent.click(chip);
+    expect(onSelect).toHaveBeenCalledWith('wo-x', 'y-1');
+  });
+
+  it('Today button + Prev/Next fire onMonthChange', () => {
+    const onMonthChange = vi.fn();
+    render(
+      <WorkOrderCalendar
+        records={[]}
+        currentMonth={REF_MONTH}
+        onMonthChange={onMonthChange}
+        onSelect={() => {}}
+      />,
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'Previous month' }));
+    expect(onMonthChange).toHaveBeenLastCalledWith(new Date(2026, 2, 1));
+    fireEvent.click(screen.getByRole('button', { name: 'Next month' }));
+    expect(onMonthChange).toHaveBeenLastCalledWith(new Date(2026, 4, 1));
+    fireEvent.click(screen.getByRole('button', { name: 'Today' }));
+    expect(onMonthChange).toHaveBeenCalled();
+  });
+
+  it('shows loading + error messages when passed', () => {
+    const { rerender } = render(
+      <WorkOrderCalendar
+        records={[]}
+        currentMonth={REF_MONTH}
+        onMonthChange={() => {}}
+        onSelect={() => {}}
+        isLoading
+      />,
+    );
+    expect(screen.getByText(/Loading/)).toBeDefined();
+
+    rerender(
+      <WorkOrderCalendar
+        records={[]}
+        currentMonth={REF_MONTH}
+        onMonthChange={() => {}}
+        onSelect={() => {}}
+        error={new Error('network poof')}
+      />,
+    );
+    expect(screen.getByText(/Failed to load calendar: network poof/)).toBeDefined();
+  });
+
+  it('chip with terminal status renders with strikethrough + green/grey palette', () => {
+    render(
+      <WorkOrderCalendar
+        records={[
+          rec({
+            id: 'done',
+            title: 'Filter replaced',
+            due_date: '2026-04-18',
+            status: 'completed',
+          }),
+          rec({
+            id: 'killed',
+            title: 'Cancelled task',
+            due_date: '2026-04-18',
+            status: 'cancelled',
+          }),
+        ]}
+        currentMonth={REF_MONTH}
+        onMonthChange={() => {}}
+        onSelect={() => {}}
+      />,
+    );
+    const cell = screen.getByTestId('wo-calendar-cell-2026-04-18');
+    const chips = Array.from(cell.querySelectorAll('button[aria-label^="Open"]')) as HTMLButtonElement[];
+    expect(chips).toHaveLength(2);
+    // Both should have line-through — not fragile on exact palette, just the decoration.
+    for (const c of chips) {
+      expect(c.style.textDecoration).toBe('line-through');
+    }
+  });
+});

--- a/apps/web/src/features/work-orders/__tests__/useMonthWorkOrders.test.ts
+++ b/apps/web/src/features/work-orders/__tests__/useMonthWorkOrders.test.ts
@@ -1,0 +1,62 @@
+// apps/web/src/features/work-orders/__tests__/useMonthWorkOrders.test.ts
+//
+// Pure helper coverage for useMonthWorkOrders. The hook itself is
+// integration-tested implicitly via WorkOrderCalendar consumer; these tests
+// lock the date-bucketing primitives that both rely on.
+
+import { describe, it, expect } from 'vitest';
+import {
+  toISODate,
+  firstOfMonth,
+  lastOfMonth,
+  recordDueDateKey,
+  type WorkOrderCalendarRecord,
+} from '../useMonthWorkOrders';
+
+describe('toISODate', () => {
+  it('formats local date as YYYY-MM-DD with zero padding', () => {
+    // Construct using local-time components so the test is TZ-stable.
+    expect(toISODate(new Date(2026, 0, 1))).toBe('2026-01-01');
+    expect(toISODate(new Date(2026, 8, 9))).toBe('2026-09-09');
+    expect(toISODate(new Date(2026, 11, 31))).toBe('2026-12-31');
+  });
+});
+
+describe('firstOfMonth / lastOfMonth', () => {
+  it('firstOfMonth returns the 1st at midnight local', () => {
+    const d = firstOfMonth(new Date(2026, 3, 17));
+    expect(d.getDate()).toBe(1);
+    expect(d.getMonth()).toBe(3);
+    expect(d.getFullYear()).toBe(2026);
+  });
+
+  it('lastOfMonth returns the calendar-last day', () => {
+    expect(lastOfMonth(new Date(2026, 1, 15)).getDate()).toBe(28); // Feb 2026 (non-leap)
+    expect(lastOfMonth(new Date(2028, 1, 15)).getDate()).toBe(29); // Feb 2028 (leap)
+    expect(lastOfMonth(new Date(2026, 3, 1)).getDate()).toBe(30);  // April → 30 days
+    expect(lastOfMonth(new Date(2026, 11, 15)).getDate()).toBe(31); // December → 31
+  });
+});
+
+describe('recordDueDateKey', () => {
+  function rec(due_date: string | null | undefined): WorkOrderCalendarRecord {
+    return {
+      id: 'x',
+      title: 't',
+      due_date,
+    } as WorkOrderCalendarRecord;
+  }
+
+  it('returns null when due_date is absent / null / empty string', () => {
+    expect(recordDueDateKey(rec(null))).toBeNull();
+    expect(recordDueDateKey(rec(undefined))).toBeNull();
+    // @ts-expect-error — intentional empty-string test
+    expect(recordDueDateKey(rec(''))).toBeNull();
+  });
+
+  it('trims ISO timestamps down to YYYY-MM-DD', () => {
+    expect(recordDueDateKey(rec('2026-04-20'))).toBe('2026-04-20');
+    expect(recordDueDateKey(rec('2026-04-20T14:30:00Z'))).toBe('2026-04-20');
+    expect(recordDueDateKey(rec('2026-04-20T00:00:00.123+02:00'))).toBe('2026-04-20');
+  });
+});

--- a/apps/web/src/features/work-orders/useMonthWorkOrders.ts
+++ b/apps/web/src/features/work-orders/useMonthWorkOrders.ts
@@ -1,0 +1,148 @@
+'use client';
+
+/**
+ * useMonthWorkOrders — fetch all work orders with due_date in a given month.
+ *
+ * Dedicated hook (not reusing useFilteredEntityList) because:
+ *   * Calendar needs every WO in the window, not paginated infinite-scroll.
+ *   * Backend supports this via the work_orders-specific `due_from` / `due_to`
+ *     query params added in PR-WO-5 (vessel_surface_routes.py). No client-side
+ *     filter, no N+1.
+ *   * Single `useQuery` with generous `limit=500` — enough for any yacht's
+ *     monthly WO volume (real-world ~20-60 / month).
+ *
+ * Returns raw backend records unchanged so the consumer can map exactly the
+ * columns they need (UX sheet specifies a distinct calendar column set).
+ */
+
+import { useQuery } from '@tanstack/react-query';
+import { supabase } from '@/lib/supabaseClient';
+import { useAuth } from '@/hooks/useAuth';
+import { useActiveVessel } from '@/contexts/VesselContext';
+
+const API_BASE =
+  process.env.NEXT_PUBLIC_API_URL || 'https://pipeline-core.int.celeste7.ai';
+
+/** Raw backend record — whatever vessel_surface_routes._format_record emits. */
+export interface WorkOrderCalendarRecord {
+  id: string;
+  ref?: string;              // wo_number (formatter output)
+  title: string;
+  status?: string;
+  priority?: string;
+  severity?: string | null;
+  wo_type?: string | null;
+  frequency?: string | null;
+  due_date?: string | null;
+  completed_at?: string | null;
+  assigned_to?: string | null;
+  assigned_to_name?: string | null;
+  linked_equipment_id?: string | null;
+  linked_equipment_name?: string | null;
+  updated_at?: string;
+  yacht_id?: string;
+  yacht_name?: string;
+  // Free-form pass-through for anything the formatter adds.
+  [k: string]: unknown;
+}
+
+export interface UseMonthWorkOrdersArgs {
+  /** First day of the month to fetch, in YYYY-MM-DD. Inclusive. */
+  fromISO: string;
+  /** Last day of the month to fetch, in YYYY-MM-DD. Inclusive. */
+  toISO: string;
+  /** Opt-out for pages that know they don't want the fetch. */
+  enabled?: boolean;
+}
+
+export interface UseMonthWorkOrdersResult {
+  records: WorkOrderCalendarRecord[];
+  isLoading: boolean;
+  error: Error | null;
+  refetch: () => void;
+}
+
+export function useMonthWorkOrders({
+  fromISO,
+  toISO,
+  enabled = true,
+}: UseMonthWorkOrdersArgs): UseMonthWorkOrdersResult {
+  const { user } = useAuth();
+  const { vesselId: activeVesselId, isAllVessels } = useActiveVessel();
+  const effectiveVesselId = isAllVessels
+    ? 'all'
+    : activeVesselId || user?.yachtId;
+
+  const query = useQuery({
+    queryKey: ['work-orders-calendar', effectiveVesselId, fromISO, toISO],
+    enabled: enabled && Boolean(effectiveVesselId),
+    queryFn: async (): Promise<WorkOrderCalendarRecord[]> => {
+      if (!effectiveVesselId) throw new Error('No vessel selected');
+
+      const { data: sessionData } = await supabase.auth.getSession();
+      const token = sessionData.session?.access_token;
+      if (!token) throw new Error('Not authenticated');
+
+      const params = new URLSearchParams();
+      params.set('limit', '500');
+      params.set('offset', '0');
+      params.set('sort', 'due_date');
+      params.set('due_from', fromISO);
+      params.set('due_to', toISO);
+
+      const url = `${API_BASE}/api/vessel/${effectiveVesselId}/domain/work_orders/records?${params.toString()}`;
+
+      const response = await fetch(url, {
+        headers: {
+          Authorization: `Bearer ${token}`,
+          'Content-Type': 'application/json',
+        },
+      });
+      if (!response.ok) {
+        throw new Error(`API ${response.status}: ${response.statusText}`);
+      }
+      const data = await response.json();
+      return (data.records || data.items || []) as WorkOrderCalendarRecord[];
+    },
+    staleTime: 60 * 1000, // 1 min
+    refetchOnWindowFocus: false,
+  });
+
+  return {
+    records: query.data ?? [],
+    isLoading: query.isLoading,
+    error: (query.error as Error) ?? null,
+    refetch: () => void query.refetch(),
+  };
+}
+
+// ── Date helpers ───────────────────────────────────────────────────────────
+//
+// Calendar uses local-time date keys (YYYY-MM-DD) to avoid timezone drift when
+// a yacht spans UTC boundaries. Server returns ISO timestamps; we downcast to
+// date-string for bucketing.
+
+export function toISODate(d: Date): string {
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, '0');
+  const day = String(d.getDate()).padStart(2, '0');
+  return `${y}-${m}-${day}`;
+}
+
+export function firstOfMonth(d: Date): Date {
+  return new Date(d.getFullYear(), d.getMonth(), 1);
+}
+
+export function lastOfMonth(d: Date): Date {
+  return new Date(d.getFullYear(), d.getMonth() + 1, 0);
+}
+
+/** Return the due-date ISO for a record, trimmed to YYYY-MM-DD or null. */
+export function recordDueDateKey(
+  record: WorkOrderCalendarRecord,
+): string | null {
+  const raw = record.due_date;
+  if (!raw) return null;
+  // Accept both "YYYY-MM-DD" and "YYYY-MM-DDTHH:MM:SS…Z" shapes.
+  return String(raw).slice(0, 10);
+}


### PR DESCRIPTION
## Summary
UX sheet `/Users/celeste7/Desktop/lens_card_upgrades.md:455-476`. Adds a **Calendar** tab alongside the existing **List** view on `/work-orders`. Monthly grid driven by `pms_work_orders.due_date`; each WO renders as a tokenised chip inside its due-date cell; clicking a chip opens the same overlay the list view uses (zero UX drift).

## Scope (MVP, per CEO spec)
- Monthly grid only. Week starts Monday.
- Up to 3 chips per cell + `+N more` expand/collapse.
- Colour precedence (only populated enum wins): severity > priority. Terminal states override:
  - completed → green
  - cancelled / archived → neutral-grey + strikethrough
- Terminal WOs stay visible (CEO: *"IF work order is deleted, in fault, completed etc. STILL SHOW THIS ON CALENDAR"*).
- Prev / Next / Today navigation. Month state local to the page.

## Out of scope (deferred)
- Multi-day spans (Apple-Calendar horizontal bars).
- Week / day views.
- Drag-to-reschedule.

## Files
- `apps/api/routes/vessel_surface_routes.py` — new `due_from` / `due_to` query params for the work-orders list endpoint.
- `apps/web/src/features/work-orders/useMonthWorkOrders.ts` **(new)** — React Query hook, single fetch per month window, limit=500. Local-TZ date helpers (`toISODate`, `firstOfMonth`, `lastOfMonth`, `recordDueDateKey`).
- `apps/web/src/features/work-orders/WorkOrderCalendar.tsx` **(new)** — month grid + toolbar + chip rendering, 100% tokenised.
- `apps/web/src/app/work-orders/page.tsx` — `ViewToggle` between `list` / `calendar`, URL-tracked via `?view=calendar`.
- `apps/web/src/features/work-orders/__tests__/WorkOrderCalendar.test.tsx` **(new)** — 27 vitest specs.
- `apps/web/src/features/work-orders/__tests__/useMonthWorkOrders.test.ts` **(new)** — 5 date-helper specs.

## Test plan
- [x] `vitest run src/features/work-orders/__tests__` → **43/43 green** (11 columns + 27 calendar + 5 date helpers)
- [x] `npx tsc --noEmit` on apps/web → clean
- [x] `python3 ast.parse` on `vessel_surface_routes.py` → clean
- [ ] Post-merge smoke: `/work-orders?view=calendar`, Today button lands on current month, prev/next cycle, chip click opens WO overlay
- [ ] Post-merge smoke: create a WO with due_date in next month, navigate forward, confirm it renders with correct palette

🤖 Generated with [Claude Code](https://claude.com/claude-code)