### PR TITLE
feat(handover): fault-list issues 8-11 + cross-cutting add_to_handover surfacing

### DIFF
--- a/apps/api/action_router/dispatchers/internal_dispatcher.py
+++ b/apps/api/action_router/dispatchers/internal_dispatcher.py
@@ -859,9 +859,25 @@ async def update_equipment_status(params: Dict[str, Any]) -> Dict[str, Any]:
 
 async def add_to_handover(params: Dict[str, Any]) -> Dict[str, Any]:
     """
-    Add item to shift handover list.
+    [DEPRECATED — HANDOVER08 flag, 2026-04-24]
 
-    Required params:
+    Duplicate of handlers.handover_handlers.HandoverHandlers.add_to_handover_execute
+    (the canonical path registered at action_router.registry:948-973 → POST
+    /v1/handover/add-item). Does its own handover_items insert, its own
+    category normalisation, its own notifications write — all a copy of what
+    the canonical handler already does. Drift between this and the canonical
+    is a data-integrity hazard.
+
+    Removal plan (tracked as HANDOVER08 task B9, follow-up PR):
+      1. Trace every remaining call site to this module-level function.
+      2. Redirect all callers to HandoverHandlers.add_to_handover_execute.
+      3. Delete this function + its helpers.
+
+    Do NOT add new callers. Do NOT add new behaviour here. If a bug surfaces,
+    patch it in the canonical handler and leave this stub unchanged so the
+    dedupe remains visible to reviewers.
+
+    Original params contract (kept verbatim for traceability):
         - yacht_id: UUID
         - entity_type: str (equipment, fault, work_order, part, document, note, purchase_order)
         - entity_id: UUID (optional for notes)
@@ -872,6 +888,12 @@ async def add_to_handover(params: Dict[str, Any]) -> Dict[str, Any]:
         - section: str (optional: Engineering, Deck, Interior, Command)
         - entity_url: str (optional: deep link back to entity)
     """
+    import logging as _hndvr_logging
+    _hndvr_logging.getLogger(__name__).warning(
+        "[DEPRECATED] action_router.dispatchers.internal_dispatcher.add_to_handover "
+        "called — this duplicates HandoverHandlers.add_to_handover_execute and is "
+        "scheduled for removal. Tracked as HANDOVER08 task B9."
+    )
     import uuid as uuid_lib
     supabase = get_supabase_client()
 

--- a/apps/api/action_router/entity_actions.py
+++ b/apps/api/action_router/entity_actions.py
@@ -18,6 +18,7 @@ from action_router.entity_prefill import (
     resolve_prefill,
     get_field_schema,
 )
+from actions.add_to_handover_gating import user_can_add_entity_type_to_handover
 
 # ── Work Order status sets ─────────────────────────────────────────────────────
 _PRE_START_STATUSES = {"draft", "open", "planned"}
@@ -223,10 +224,22 @@ def _inject_cross_domain_actions(
         if not action_def:
             continue
 
-        # Role gate
+        # Role gate — registry allowed_roles first (union across all contexts),
+        # then the tighter per-entity matrix for add_to_handover specifically.
         allowed = action_def.allowed_roles or []
         if user_role not in allowed:
             continue
+
+        # HANDOVER08 task B6: narrow add_to_handover visibility to the CEO
+        # Issue 4/6/7/8/14 role matrix (2026-04-23). Other cross-domain
+        # actions still use the registry's allowed_roles union.
+        if action_id == "add_to_handover":
+            if not user_can_add_entity_type_to_handover(
+                user_role=user_role,
+                entity_type=entity_type,
+                department=entity_data.get("department"),
+            ):
+                continue
 
         # No state gate for cross-domain actions (they operate on their target domain)
         prefill = resolve_prefill(entity_type, action_id, entity_data)

--- a/apps/api/action_router/entity_prefill.py
+++ b/apps/api/action_router/entity_prefill.py
@@ -180,10 +180,61 @@ CONTEXT_PREFILL_MAP: Dict[Tuple[str, str], Dict[str, str]] = {
     # CROSS-DOMAIN CANONICAL ACTIONS — prefill from source entity context
     # ══════════════════════════════════════════════════════════════════════════
 
-    # add_to_handover: pre-populates entity reference from ANY source entity
-    ("work_order", "add_to_handover"):   {"entity_id": "id", "title": "title"},
-    ("fault", "add_to_handover"):        {"entity_id": "id", "title": "title"},
-    ("equipment", "add_to_handover"):    {"entity_id": "id", "title": "name"},
+    # add_to_handover: pre-populates entity reference from ANY source entity.
+    #
+    # HANDOVER08 task B6 (2026-04-23): extended the equipment/fault/work_order
+    # rows with read-only context fields so ActionPopup can surface the
+    # identifying attributes of the source entity (manufacturer, model, WO#,
+    # severity, etc.) in the "Add to Handover" modal. See
+    # /Users/celeste7/Desktop/list_of_faults.md and the EQUIPMENT05 request
+    # relayed through claude-peers channel.
+    #
+    # All extras are BACKEND_AUTO-style passthroughs — ActionPopup MAY render
+    # them as a read-only context block. Fields missing from entity_data are
+    # dropped silently by resolve_prefill(), so any lens that does not expose
+    # a given key is a no-op (no 400, no crash).
+    #
+    # TODO (ActionPopup consumer): wire a read-only "Source entity" block that
+    # renders these prefill keys above the editable summary/notes inputs.
+    # EQUIPMENT05 owns the frontend side; do NOT edit ActionPopup here.
+    ("work_order", "add_to_handover"): {
+        "entity_id":      "id",
+        "title":          "title",
+        "wo_number":      "wo_number",
+        "priority":       "priority",
+        "status":         "status",
+        "equipment_id":   "equipment_id",
+        "equipment_name": "equipment_name",
+    },
+    ("fault", "add_to_handover"): {
+        "entity_id":      "id",
+        "title":          "title",
+        "fault_code":     "title",            # pms_faults surfaces fault_code via title fallback — entity_routes.py:1280
+        "severity":       "severity",
+        "status":         "status",
+        "equipment_id":   "equipment_id",
+        "equipment_name": "equipment_name",
+    },
+    ("equipment", "add_to_handover"): {
+        "entity_id":      "id",
+        "title":          "name",
+        # CEO context fields (EQUIPMENT05 request):
+        # code is not surfaced on the lens response today — intentionally
+        # omitted; resolve_prefill drops missing keys. Add here when the
+        # equipment route starts emitting it.
+        "name":           "name",
+        "manufacturer":   "manufacturer",
+        "model":          "model",
+        "serial_number":  "serial_number",
+        "criticality":    "criticality",
+        "status":         "status",
+        "location":       "location",
+        "system_type":    "equipment_type",   # entity_routes.py:1473 maps system_type → equipment_type
+        # running_hours not on the equipment lens response yet (see
+        # pms_equipment.running_hours column usage in equipment_handlers.py:1374).
+        # Left out so we don't ship a key that resolves to None; add when the
+        # equipment route starts surfacing it.
+    },
     ("part", "add_to_handover"):         {"entity_id": "id", "title": "name"},
     ("certificate", "add_to_handover"):  {"entity_id": "id", "title": "name"},
     ("document", "add_to_handover"):     {"entity_id": "id", "title": "name"},

--- a/apps/api/actions/add_to_handover_gating.py
+++ b/apps/api/actions/add_to_handover_gating.py
@@ -1,0 +1,155 @@
+# apps/api/actions/add_to_handover_gating.py
+"""
+CelesteOS — Add-to-Handover role matrix (HANDOVER08 task B6)
+============================================================
+
+Single source of truth for which `auth_users_profiles.role` values may surface
+the canonical `add_to_handover` button on each entity lens.
+
+Background
+----------
+The registry entry at apps/api/action_router/registry.py:948-973 declares
+`add_to_handover.allowed_roles` as the UNION of every role that might
+legitimately hand an entity over on SOME lens:
+
+    ["crew", "engineer", "eto", "purser",
+     "chief_engineer", "chief_officer", "chief_steward",
+     "captain", "manager"]
+
+That union is correct for the handler-level authorisation gate — any of those
+roles can POST /v1/handover/add-item on SOME entity. But it is too permissive
+for discovery: a `crew` member should NOT see "Add to Handover" on a
+certificate, and a `chief_steward` should not see it on a work_order.
+
+This module expresses the narrower per-entity-type matrix from CEO's
+Issue 4/6/7/8/14 spec (2026-04-23) and is consulted by
+`entity_actions._inject_cross_domain_actions` — see
+apps/api/action_router/entity_actions.py:207-255.
+
+Role names
+----------
+Source of truth: `auth_users_profiles.role` enum.
+Observed in-use values across the registry (grep registry.py):
+  crew, engineer, eto, purser,
+  chief_engineer, chief_officer, chief_steward,
+  captain, manager
+
+"HOD+" in the CEO matrix maps to the chief_* roles plus captain + manager.
+"""
+from __future__ import annotations
+
+from typing import Optional
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Role cohorts — composed below into the per-entity matrix.
+# Any reshuffling should be done here; the matrix reads them by reference.
+# ─────────────────────────────────────────────────────────────────────────────
+_ENGINEERING_AND_DECK: frozenset[str] = frozenset({
+    "crew",
+    "eto",
+    "engineer",
+    "chief_engineer",
+    "chief_officer",
+    "captain",
+})
+# Engineering/deck crew who can add equipment/fault/work_order/part to handover.
+# Stewards/pursers are deliberately excluded — they do not operate engineering
+# equipment, so surfacing the button for them would be noise.
+
+_HOD_PLUS: frozenset[str] = frozenset({
+    "chief_engineer",
+    "chief_officer",
+    "chief_steward",
+    "captain",
+    "manager",
+})
+# HOD+ band. Owns certificate / warranty / document handover per CEO spec.
+# `purser` intentionally EXCLUDED: purser is a function role, not HOD —
+# the registry already distinguishes them (see registry.py:803, 830, 849).
+
+_PURSER_BAND: frozenset[str] = frozenset({
+    "purser",
+    "chief_engineer",
+    "chief_officer",
+    "chief_steward",
+    "captain",
+    "manager",
+})
+# Purser + HOD+ band — procurement/receiving context.
+
+_EVERYONE_ON_BOARD: frozenset[str] = frozenset({
+    "crew",
+    "engineer",
+    "eto",
+    "purser",
+    "chief_engineer",
+    "chief_officer",
+    "chief_steward",
+    "captain",
+    "manager",
+})
+# Anyone on board who might add a shopping-list note for the incoming watch.
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# The matrix — entity_type → set of roles permitted to see "Add to Handover".
+# Missing key ⇒ action hidden for everyone on that entity type.
+# ─────────────────────────────────────────────────────────────────────────────
+ADD_TO_HANDOVER_ROLE_MATRIX: dict[str, frozenset[str]] = {
+    # Engineering / deck bucket
+    "equipment":   _ENGINEERING_AND_DECK,
+    "fault":       _ENGINEERING_AND_DECK,
+    "work_order":  _ENGINEERING_AND_DECK,
+    "part":        _ENGINEERING_AND_DECK,
+
+    # Procurement bucket
+    "purchase_order": _PURSER_BAND,
+    "receiving":      _PURSER_BAND,
+
+    # HOD+ compliance bucket
+    "certificate": _HOD_PLUS,
+    "warranty":    _HOD_PLUS,
+    "document":    _HOD_PLUS,
+
+    # Open to everyone on board
+    "shopping_list": _EVERYONE_ON_BOARD,
+
+    # `hours_of_rest` intentionally omitted — per CEO spec, a crew member
+    # viewing their own HoR row has no obvious reason to add it to handover.
+    # Revisit if a concrete workflow emerges.
+}
+
+
+def user_can_add_entity_type_to_handover(
+    user_role: str,
+    entity_type: str,
+    department: Optional[str] = None,  # noqa: ARG001 — reserved for future dept scoping
+) -> bool:
+    """
+    Return True iff a user with ``user_role`` may see the "Add to Handover"
+    button on the lens for ``entity_type``.
+
+    Parameters
+    ----------
+    user_role
+        Role string from ``auth_users_profiles.role``. Falsy / unknown roles
+        are treated as unauthorised.
+    entity_type
+        Lens entity type (``equipment``, ``fault``, ...). Missing from the
+        matrix ⇒ False (fail closed).
+    department
+        Reserved. Department scoping (e.g. engineering HOD may add engineering
+        work orders but not deck ones) is deferred for MVP. The engineer/deck
+        cohort in ``_ENGINEERING_AND_DECK`` already covers the intended 99%
+        case. TODO: if per-department scoping is required, look up the entity's
+        department via a column read in entity_routes.py and compare here.
+
+    No I/O. Pure function over the matrix.
+    """
+    if not user_role:
+        return False
+    allowed = ADD_TO_HANDOVER_ROLE_MATRIX.get(entity_type)
+    if allowed is None:
+        return False
+    return user_role in allowed

--- a/apps/api/handlers/handover_handlers.py
+++ b/apps/api/handlers/handover_handlers.py
@@ -696,9 +696,12 @@ class HandoverHandlers:
     # Alias methods for backward compatibility
     # =========================================================================
 
-    # Alias for tests that use summary_text instead of summary
+    # Alias for tests that use summary_text instead of summary.
+    # [DEPRECATED — HANDOVER08 flag, 2026-04-24]
+    # Test-only compatibility shim. Once the test suite is cut over to the
+    # canonical summary param (task B9 follow-up), this method is deleted.
     async def add_to_handover_execute_legacy(self, *args, summary_text: str = None, **kwargs):
-        """Legacy wrapper - converts summary_text to summary."""
+        """Legacy wrapper - converts summary_text to summary. DEPRECATED — see class comment."""
         if summary_text and 'summary' not in kwargs:
             kwargs['summary'] = summary_text
         return await self.add_to_handover_execute(*args, **kwargs)

--- a/apps/api/routes/handlers/handover_handler.py
+++ b/apps/api/routes/handlers/handover_handler.py
@@ -81,6 +81,15 @@ async def filter_handover(
 # ============================================================================
 # add_to_handover  (was L1982-2064 — delegates to HandoverHandlers)
 # ============================================================================
+# [DEPRECATED — HANDOVER08 flag, 2026-04-24]
+# This route-level wrapper thinly delegates to HandoverHandlers but duplicates
+# payload-massaging (summary fallback chain, title+description concatenation,
+# min-length 10 instead of canonical 3) that drifts from the handler. Keep it
+# while tracing call sites; the removal follow-up PR will either (a) fold its
+# payload-massaging into the canonical handler if any caller relies on it, or
+# (b) delete this wrapper and route callers to the canonical directly.
+# Tracked as HANDOVER08 task B9.
+# ============================================================================
 async def add_to_handover(
     payload: dict,
     context: dict,

--- a/apps/api/routes/handover_export_routes.py
+++ b/apps/api/routes/handover_export_routes.py
@@ -469,35 +469,210 @@ async def generate_export_html(
 async def list_exports(
     auth: dict = Depends(get_authenticated_user),
     yacht_id: Optional[str] = Query(None, description="Vessel scope (fleet users)"),
-    limit: int = Query(20, ge=1, le=100),
-    offset: int = Query(0, ge=0)
+    limit: int = Query(50, ge=1, le=100),
+    offset: int = Query(0, ge=0),
 ):
     """
-    List handover exports for a yacht.
+    List handover exports visible to the current user on their yacht.
 
-    Returns export records with metadata (not the actual HTML content).
+    Scope (applied in-code, mirroring what a future RLS policy would do):
+      - always scoped to user's yacht_id
+      - HODs (chief_engineer, chief_officer, captain, manager) see all rows
+      - everyone else sees rows where they are outgoing/incoming user OR role
+        (same-role back-to-back peer visibility)
+
+    Enrichment:
+      - outgoing_user_name / incoming_user_name resolved from
+        auth_users_profiles via one batched lookup (no N+1)
+      - returned shape matches the /handover-export Exported tab UX spec
+        (see docs: lens_card_upgrades.md "Exported tab" section).
     """
     try:
         yacht_id = resolve_yacht_id(auth, yacht_id)
+        user_id = auth["user_id"]
+        user_role = auth.get("role", "crew")
+
+        HOD_ROLES = {"chief_engineer", "chief_officer", "captain", "manager"}
+        is_hod = user_role in HOD_ROLES
 
         from integrations.supabase import get_supabase_client
         db = get_supabase_client()
 
-        result = db.table("handover_exports").select(
-            "id, draft_id, export_type, exported_at, exported_by_user_id, "
-            "document_hash, export_status, file_name"
-        ).eq("yacht_id", yacht_id).order(
-            "exported_at", desc=True
-        ).range(offset, offset + limit - 1).execute()
+        select_cols = (
+            "id, draft_id, yacht_id, export_type, exported_at, exported_by_user_id, "
+            "document_hash, export_status, file_name, "
+            "period_start, period_end, department, "
+            "outgoing_user_id, outgoing_role, outgoing_signed_at, "
+            "incoming_user_id, incoming_role, incoming_signed_at, "
+            "hod_signature, hod_signed_at, "
+            "user_signed_at, review_status, signoff_complete, "
+            "original_storage_url, signed_storage_url"
+        )
+
+        query = db.table("handover_exports").select(select_cols, count="exact").eq(
+            "yacht_id", yacht_id
+        )
+
+        if not is_hod:
+            # Same-role back-to-back peer visibility: own rows OR same-role on either side.
+            filter_expr = (
+                f"outgoing_user_id.eq.{user_id},"
+                f"incoming_user_id.eq.{user_id},"
+                f"outgoing_role.eq.{user_role},"
+                f"incoming_role.eq.{user_role}"
+            )
+            query = query.or_(filter_expr)
+
+        result = query.order("exported_at", desc=True).range(
+            offset, offset + limit - 1
+        ).execute()
+
+        rows = result.data or []
+        total_count = getattr(result, "count", None)
+
+        # Collect user_ids for name resolution.
+        user_ids: set = set()
+        for r in rows:
+            if r.get("outgoing_user_id"):
+                user_ids.add(r["outgoing_user_id"])
+            if r.get("incoming_user_id"):
+                user_ids.add(r["incoming_user_id"])
+
+        name_map: dict = {}
+        if user_ids:
+            try:
+                profiles = db.table("auth_users_profiles").select(
+                    "id, name, email"
+                ).in_("id", list(user_ids)).execute()
+                for p in (profiles.data or []):
+                    name_map[p["id"]] = p.get("name") or p.get("email") or ""
+            except Exception as perr:
+                logger.warning("list_exports: failed to resolve user names: %s", perr)
+
+        exports = []
+        for r in rows:
+            exports.append({
+                "id": r.get("id"),
+                "draft_id": r.get("draft_id"),
+                "yacht_id": r.get("yacht_id"),
+                "exported_at": r.get("exported_at"),
+                "period_start": r.get("period_start"),
+                "period_end": r.get("period_end"),
+                "department": r.get("department"),
+                "export_type": r.get("export_type"),
+                "export_status": r.get("export_status"),
+                "file_name": r.get("file_name"),
+                "document_hash": r.get("document_hash"),
+                "outgoing_user_id": r.get("outgoing_user_id"),
+                "outgoing_user_name": name_map.get(r.get("outgoing_user_id") or "", None),
+                "outgoing_role": r.get("outgoing_role"),
+                "outgoing_signed_at": r.get("outgoing_signed_at"),
+                "incoming_user_id": r.get("incoming_user_id"),
+                "incoming_user_name": name_map.get(r.get("incoming_user_id") or "", None),
+                "incoming_role": r.get("incoming_role"),
+                "incoming_signed_at": r.get("incoming_signed_at"),
+                "hod_signed_at": r.get("hod_signed_at"),
+                "user_signed_at": r.get("user_signed_at"),
+                "review_status": r.get("review_status"),
+                "signoff_complete": r.get("signoff_complete"),
+                # Storage refs kept private; clients mint a URL via POST /export/{id}/signed-url.
+                "has_signed_document": bool(r.get("signed_storage_url")),
+                "has_original_document": bool(r.get("original_storage_url")),
+            })
 
         return {
             "status": "success",
-            "exports": result.data or [],
-            "count": len(result.data or [])
+            "exports": exports,
+            "count": len(exports),
+            "total_count": total_count if total_count is not None else len(exports),
+            "scope": "all" if is_hod else "own_and_same_role",
         }
 
     except Exception as e:
         logger.exception(f"Error listing exports: {e}")
+        raise HTTPException(status_code=500, detail=str(e))
+
+
+@router.post("/export/{export_id}/signed-url")
+async def mint_export_signed_url(
+    export_id: str,
+    auth: dict = Depends(get_authenticated_user),
+    yacht_id: Optional[str] = Query(None, description="Vessel scope (fleet users)"),
+):
+    """
+    Mint a short-TTL signed URL for a completed handover export.
+
+    Scope mirrors GET /v1/handover/exports:
+      - must be on the user's yacht
+      - user must be HOD+ OR outgoing/incoming user/role on the row.
+
+    Prefers signed_storage_url (final signed document), falls back to
+    original_storage_url when HOD countersignature is pending.
+
+    TTL is 300s (5 minutes).
+    """
+    try:
+        resolved_yacht_id = resolve_yacht_id(auth, yacht_id)
+        user_id = auth["user_id"]
+        user_role = auth.get("role", "crew")
+        HOD_ROLES = {"chief_engineer", "chief_officer", "captain", "manager"}
+        is_hod = user_role in HOD_ROLES
+
+        from integrations.supabase import get_supabase_client
+        db = get_supabase_client()
+
+        r = db.table("handover_exports").select(
+            "id, yacht_id, signed_storage_url, original_storage_url, "
+            "outgoing_user_id, outgoing_role, incoming_user_id, incoming_role"
+        ).eq("id", export_id).eq("yacht_id", resolved_yacht_id).limit(1).execute()
+
+        if not r.data:
+            raise HTTPException(status_code=404, detail="Export not found")
+
+        row = r.data[0]
+
+        if not is_hod:
+            allowed = (
+                row.get("outgoing_user_id") == user_id
+                or row.get("incoming_user_id") == user_id
+                or row.get("outgoing_role") == user_role
+                or row.get("incoming_role") == user_role
+            )
+            if not allowed:
+                raise HTTPException(status_code=403, detail="Not authorised for this export")
+
+        raw_url = row.get("signed_storage_url") or row.get("original_storage_url")
+        if not raw_url:
+            raise HTTPException(status_code=404, detail="Export document not available")
+
+        storage_path = raw_url.replace("handover-exports/", "", 1) if raw_url.startswith("handover-exports/") else raw_url
+
+        TTL_SECONDS = 300
+        try:
+            signed = db.storage.from_("handover-exports").create_signed_url(
+                storage_path, TTL_SECONDS
+            )
+        except Exception as sign_err:
+            logger.error("mint_export_signed_url: create_signed_url failed: %s", sign_err)
+            raise HTTPException(status_code=500, detail="Failed to sign URL")
+
+        # supabase-py returns {'signedURL': ...} or {'signedUrl': ...} across versions.
+        url = None
+        if isinstance(signed, dict):
+            url = signed.get("signedURL") or signed.get("signedUrl") or signed.get("signed_url")
+        if not url:
+            logger.error("mint_export_signed_url: malformed signer response: %s", signed)
+            raise HTTPException(status_code=500, detail="Failed to sign URL")
+
+        from datetime import timezone, timedelta
+        expires_at = (datetime.now(timezone.utc) + timedelta(seconds=TTL_SECONDS)).isoformat()
+
+        return {"url": url, "expires_at": expires_at, "ttl_seconds": TTL_SECONDS}
+
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.exception(f"Error minting signed url for export {export_id}: {e}")
         raise HTTPException(status_code=500, detail=str(e))
 
 
@@ -1460,6 +1635,134 @@ async def mark_handover_items_exported(
         return {"status": "ok", "updated": len(result.data or [])}
     except Exception as e:
         logger.error(f"mark_handover_items_exported failed: {e}", exc_info=True)
+        raise HTTPException(status_code=500, detail=str(e))
+
+
+# ============================================================================
+# HANDOVER ENTITY PICKERS — /v1/handover/pickers/{entity_type}
+# ----------------------------------------------------------------------------
+# Minimal-shape list endpoints used by the "+ Add Draft Item" modal to populate
+# its value dropdown after the user picks a key (domain). Scoped by yacht_id
+# (RLS-enforced via resolve_yacht_id); alphabetical ordering applied here.
+#
+# Shape returned:
+#   {
+#     "entity_type": "work_order" | "equipment" | "part" | "fault",
+#     "items": [ { id, code, title, sub_a, sub_b } ]
+#   }
+#
+# - `code`  = overline identifier (wo_number / equipment code / part_number /
+#             fault_code). Mono-rendered in the picker.
+# - `title` = primary label (title or name).
+# - `sub_a` = manufacturer / severity — secondary caption line.
+# - `sub_b` = description (truncated to 50 chars to match CEO list format).
+# ============================================================================
+
+_PICKER_CONFIG = {
+    "work_order": {
+        "table": "pms_work_orders",
+        "select": "id, wo_number, title, description, status",
+        "code_col": "wo_number",
+        "title_col": "title",
+        "sub_a_col": "status",
+        "sub_b_col": "description",
+        "order_col": "wo_number",
+    },
+    "equipment": {
+        "table": "pms_equipment",
+        "select": "id, code, name, manufacturer, description",
+        "code_col": "code",
+        "title_col": "name",
+        "sub_a_col": "manufacturer",
+        "sub_b_col": "description",
+        "order_col": "code",
+    },
+    "part": {
+        "table": "pms_parts",
+        "select": "id, part_number, name, manufacturer, description",
+        "code_col": "part_number",
+        "title_col": "name",
+        "sub_a_col": "manufacturer",
+        "sub_b_col": "description",
+        "order_col": "part_number",
+    },
+    "fault": {
+        "table": "pms_faults",
+        "select": "id, fault_code, title, description, severity",
+        "code_col": "fault_code",
+        "title_col": "title",
+        "sub_a_col": "severity",
+        "sub_b_col": "description",
+        "order_col": "fault_code",
+    },
+}
+
+
+def _truncate(text, max_len: int = 50):
+    if not text:
+        return None
+    text = str(text)
+    if len(text) <= max_len:
+        return text
+    cut = text[:max_len]
+    last_space = cut.rfind(" ")
+    base = cut[:last_space] if last_space > max_len * 0.6 else cut
+    return base.rstrip() + "…"
+
+
+@router.get("/pickers/{entity_type}")
+async def list_picker_entities(
+    entity_type: str,
+    auth: dict = Depends(get_authenticated_user),
+    limit: int = Query(500, le=2000),
+):
+    """
+    Return minimal picker rows for the "+ Add Draft Item" modal value dropdown.
+
+    Scope: yacht_id (from auth), deleted_at IS NULL, alphabetical by code/number.
+    RLS enforcement: service client is used, so scoping is applied here via
+    yacht_id eq and soft-delete filter — matching the pattern used by
+    list_handover_items above.
+    """
+    cfg = _PICKER_CONFIG.get(entity_type)
+    if not cfg:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Unsupported entity_type: {entity_type}. "
+                   f"Must be one of: {', '.join(_PICKER_CONFIG.keys())}",
+        )
+
+    from integrations.supabase import get_supabase_client
+    db = get_supabase_client()
+    yacht_id = resolve_yacht_id(auth, None)
+
+    try:
+        query = db.table(cfg["table"]).select(cfg["select"]).eq("yacht_id", yacht_id)
+        # Filter soft-deleted rows when the column exists on the table.
+        # pms_* tables uniformly include deleted_at; swallowing the error is a
+        # safety net — the list still returns on schemas that haven't added it.
+        try:
+            query = query.is_("deleted_at", "null")
+        except Exception:
+            pass
+        result = query.order(cfg["order_col"], desc=False).limit(limit).execute()
+        rows = result.data or []
+
+        items = []
+        for r in rows:
+            items.append({
+                "id": r.get("id"),
+                "code": r.get(cfg["code_col"]),
+                "title": r.get(cfg["title_col"]),
+                "sub_a": r.get(cfg["sub_a_col"]),
+                "sub_b": _truncate(r.get(cfg["sub_b_col"]), 50),
+            })
+
+        return {"entity_type": entity_type, "items": items, "count": len(items)}
+    except Exception as e:
+        logger.error(
+            f"list_picker_entities({entity_type}) failed: {e}", exc_info=True
+        )
         raise HTTPException(status_code=500, detail=str(e))
 
 

--- a/apps/api/tests/test_add_to_handover_gating.py
+++ b/apps/api/tests/test_add_to_handover_gating.py
@@ -1,0 +1,245 @@
+# apps/api/tests/test_add_to_handover_gating.py
+"""
+HANDOVER08 task B6 — unit tests for the add-to-handover role matrix and the
+entity_actions cross-domain injection path that consults it.
+
+No DB, no HTTP. Pure function tests + a small patch-based integration test
+that drives `get_available_actions` through the real registry entry.
+"""
+from __future__ import annotations
+
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Role × entity_type truth table straight from CEO's Issue 4/6/7/8/14 spec
+# (2026-04-23) — kept here (not imported) so a matrix drift in the production
+# module will make these tests fail loudly.
+# ─────────────────────────────────────────────────────────────────────────────
+_ALL_ROLES = [
+    "crew", "engineer", "eto", "purser",
+    "chief_engineer", "chief_officer", "chief_steward",
+    "captain", "manager",
+]
+
+_EXPECTED: dict[str, set[str]] = {
+    "equipment":      {"crew", "engineer", "eto", "chief_engineer", "chief_officer", "captain"},
+    "fault":          {"crew", "engineer", "eto", "chief_engineer", "chief_officer", "captain"},
+    "work_order":     {"crew", "engineer", "eto", "chief_engineer", "chief_officer", "captain"},
+    "part":           {"crew", "engineer", "eto", "chief_engineer", "chief_officer", "captain"},
+    "purchase_order": {"purser", "chief_engineer", "chief_officer", "chief_steward", "captain", "manager"},
+    "receiving":      {"purser", "chief_engineer", "chief_officer", "chief_steward", "captain", "manager"},
+    "certificate":    {"chief_engineer", "chief_officer", "chief_steward", "captain", "manager"},
+    "warranty":       {"chief_engineer", "chief_officer", "chief_steward", "captain", "manager"},
+    "document":       {"chief_engineer", "chief_officer", "chief_steward", "captain", "manager"},
+    "shopping_list":  set(_ALL_ROLES),
+    # hours_of_rest intentionally omitted — fails closed for every role.
+    "hours_of_rest":  set(),
+}
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 1. Role matrix — parametrised sweep across every (role, entity) combo.
+# ─────────────────────────────────────────────────────────────────────────────
+
+@pytest.mark.parametrize(
+    "entity_type,role",
+    [(et, r) for et in _EXPECTED for r in _ALL_ROLES],
+)
+def test_role_matrix(entity_type: str, role: str) -> None:
+    from actions.add_to_handover_gating import user_can_add_entity_type_to_handover
+
+    expected = role in _EXPECTED[entity_type]
+    actual = user_can_add_entity_type_to_handover(role, entity_type)
+    assert actual is expected, (
+        f"add_to_handover gating mismatch: entity_type={entity_type!r} role={role!r} "
+        f"expected={expected} got={actual}"
+    )
+
+
+def test_unknown_entity_type_denies() -> None:
+    from actions.add_to_handover_gating import user_can_add_entity_type_to_handover
+    assert user_can_add_entity_type_to_handover("captain", "spaceship") is False
+
+
+def test_empty_role_denies() -> None:
+    from actions.add_to_handover_gating import user_can_add_entity_type_to_handover
+    assert user_can_add_entity_type_to_handover("", "equipment") is False
+    assert user_can_add_entity_type_to_handover(None, "equipment") is False  # type: ignore[arg-type]
+
+
+def test_hours_of_rest_always_denies() -> None:
+    from actions.add_to_handover_gating import user_can_add_entity_type_to_handover
+    for role in _ALL_ROLES:
+        assert user_can_add_entity_type_to_handover(role, "hours_of_rest") is False
+
+
+def test_department_param_is_accepted_but_ignored_for_mvp() -> None:
+    """Signature accepts the ``department`` kwarg; MVP does not scope on it."""
+    from actions.add_to_handover_gating import user_can_add_entity_type_to_handover
+    # engineering HOD on a 'deck'-department work order still passes today —
+    # department scoping is deferred per module TODO.
+    assert user_can_add_entity_type_to_handover(
+        "chief_engineer", "work_order", department="deck"
+    ) is True
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 2. End-to-end through get_available_actions — asserts the gating module is
+#    actually consulted by the cross-domain injection path.
+# ─────────────────────────────────────────────────────────────────────────────
+
+def _action_ids(result: list[dict]) -> set[str]:
+    return {a["action_id"] for a in result}
+
+
+def test_availableActions_includes_add_to_handover_for_crew_on_equipment() -> None:
+    from action_router.entity_actions import get_available_actions
+
+    result = get_available_actions(
+        "equipment",
+        {"id": "eq-1", "name": "Main Engine", "status": "operational"},
+        "crew",
+    )
+    assert "add_to_handover" in _action_ids(result)
+
+
+def test_availableActions_includes_add_to_handover_for_captain_on_purchase_order() -> None:
+    from action_router.entity_actions import get_available_actions
+
+    result = get_available_actions(
+        "purchase_order",
+        {"id": "po-1", "po_number": "PO-0001", "status": "draft", "department": "engineering"},
+        "captain",
+    )
+    assert "add_to_handover" in _action_ids(result)
+
+
+def test_availableActions_hides_add_to_handover_for_chief_steward_on_work_order() -> None:
+    """Steward is not in the engineering/deck cohort for work_order."""
+    from action_router.entity_actions import get_available_actions
+
+    result = get_available_actions(
+        "work_order",
+        {"id": "wo-1", "title": "Fix pump", "status": "open"},
+        "chief_steward",
+    )
+    assert "add_to_handover" not in _action_ids(result)
+
+
+def test_availableActions_hides_add_to_handover_for_crew_on_certificate() -> None:
+    """Crew is not in HOD+ — must not see it on certificate."""
+    from action_router.entity_actions import get_available_actions
+
+    result = get_available_actions(
+        "certificate",
+        {"id": "cert-1", "name": "SOLAS", "status": "active"},
+        "crew",
+    )
+    assert "add_to_handover" not in _action_ids(result)
+
+
+def test_availableActions_hides_add_to_handover_on_hours_of_rest_for_everyone() -> None:
+    from action_router.entity_actions import get_available_actions
+
+    for role in _ALL_ROLES:
+        result = get_available_actions(
+            "hours_of_rest",
+            {"id": "hor-1", "status": "draft"},
+            role,
+        )
+        assert "add_to_handover" not in _action_ids(result), (
+            f"hours_of_rest should not expose add_to_handover to {role}"
+        )
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 3. Prefill regression — new equipment / fault / work_order context fields.
+# ─────────────────────────────────────────────────────────────────────────────
+
+def test_equipment_add_to_handover_prefill_surfaces_context_fields() -> None:
+    from action_router.entity_prefill import resolve_prefill
+
+    entity = {
+        "id": "eq-1",
+        "name": "Main Engine",
+        "manufacturer": "MTU",
+        "model": "16V 4000 M73",
+        "serial_number": "MTU-12345",
+        "criticality": "high",
+        "status": "operational",
+        "location": "Engine Room",
+        "equipment_type": "main_engine",
+    }
+
+    prefill = resolve_prefill("equipment", "add_to_handover", entity)
+
+    # Identity + context
+    assert prefill["entity_id"] == "eq-1"
+    assert prefill["title"] == "Main Engine"
+    assert prefill["manufacturer"] == "MTU"
+    assert prefill["model"] == "16V 4000 M73"
+    assert prefill["serial_number"] == "MTU-12345"
+    assert prefill["criticality"] == "high"
+    assert prefill["status"] == "operational"
+    assert prefill["location"] == "Engine Room"
+    assert prefill["system_type"] == "main_engine"
+
+
+def test_fault_add_to_handover_prefill_surfaces_context_fields() -> None:
+    from action_router.entity_prefill import resolve_prefill
+
+    entity = {
+        "id": "fault-1",
+        "title": "F-0042",
+        "severity": "critical",
+        "status": "open",
+        "equipment_id": "eq-1",
+        "equipment_name": "Main Engine",
+    }
+
+    prefill = resolve_prefill("fault", "add_to_handover", entity)
+    assert prefill["entity_id"] == "fault-1"
+    assert prefill["title"] == "F-0042"
+    assert prefill["severity"] == "critical"
+    assert prefill["status"] == "open"
+    assert prefill["equipment_id"] == "eq-1"
+    assert prefill["equipment_name"] == "Main Engine"
+
+
+def test_work_order_add_to_handover_prefill_surfaces_context_fields() -> None:
+    from action_router.entity_prefill import resolve_prefill
+
+    entity = {
+        "id": "wo-1",
+        "title": "Replace impeller",
+        "wo_number": "WO-0099",
+        "priority": "high",
+        "status": "in_progress",
+        "equipment_id": "eq-1",
+        "equipment_name": "Main Engine",
+    }
+
+    prefill = resolve_prefill("work_order", "add_to_handover", entity)
+    assert prefill["wo_number"] == "WO-0099"
+    assert prefill["priority"] == "high"
+    assert prefill["equipment_id"] == "eq-1"
+    assert prefill["equipment_name"] == "Main Engine"
+    assert prefill["status"] == "in_progress"
+
+
+def test_prefill_missing_keys_are_dropped_silently() -> None:
+    """Lenses that do not emit a given key must not raise or inject None."""
+    from action_router.entity_prefill import resolve_prefill
+
+    prefill = resolve_prefill("equipment", "add_to_handover", {"id": "eq-1", "name": "Pump"})
+    # Extras absent from entity_data must not appear.
+    assert "manufacturer" not in prefill
+    assert "serial_number" not in prefill
+    assert prefill["entity_id"] == "eq-1"
+    assert prefill["title"] == "Pump"

--- a/apps/api/tests/test_handover_export_list.py
+++ b/apps/api/tests/test_handover_export_list.py
@@ -1,0 +1,324 @@
+"""
+GET /v1/handover/exports — Exported-tab List Tests
+==================================================
+
+Exercises the scope + enrichment rules added for the /handover-export
+"Exported" tab (Issue 11 / HANDOVER08):
+
+  - HOD (chief_engineer / chief_officer / captain / manager) sees ALL yacht rows
+  - non-HOD sees only rows they outgoing/incoming OR same-role back-to-back
+  - outgoing_user_name / incoming_user_name resolved via auth_users_profiles
+  - response shape matches Exported-tab UX spec
+
+And the companion POST /v1/handover/export/{id}/signed-url endpoint:
+  - HOD can mint
+  - non-HOD on their own row can mint
+  - stranger gets 403
+  - missing document → 404
+
+LAW 17: in-memory via httpx.AsyncClient, DB mocked via patch.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import uuid
+import pytest
+import pytest_asyncio
+import httpx
+from typing import Optional
+from unittest.mock import MagicMock, patch
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from pipeline_service import app
+from middleware.auth import get_authenticated_user
+
+YACHT_ID = "85fe1119-b04c-41ac-80f1-829d23322598"
+USER_ID = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+OTHER_USER_ID = "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"
+EXPORT_ID = "cccccccc-cccc-cccc-cccc-cccccccccccc"
+
+_AUTH_HOD = {
+    "user_id": USER_ID,
+    "email": "hod@yacht.test",
+    "yacht_id": YACHT_ID,
+    "org_id": YACHT_ID,
+    "tenant_key_alias": "y85fe111",
+    "role": "chief_engineer",
+    "vessel_ids": [YACHT_ID],
+    "is_fleet_user": False,
+    "yacht_name": "M/Y Test",
+}
+
+_AUTH_CREW = {
+    **_AUTH_HOD,
+    "email": "crew@yacht.test",
+    "role": "engineer",
+}
+
+
+def _row(
+    export_id: str,
+    outgoing_user_id: Optional[str] = None,
+    outgoing_role: Optional[str] = None,
+    incoming_user_id: Optional[str] = None,
+    incoming_role: Optional[str] = None,
+    review_status: str = "complete",
+    signoff_complete: bool = True,
+):
+    return {
+        "id": export_id,
+        "draft_id": str(uuid.uuid4()),
+        "yacht_id": YACHT_ID,
+        "export_type": "html",
+        "exported_at": "2026-04-20T10:00:00+00:00",
+        "exported_by_user_id": outgoing_user_id,
+        "document_hash": "abc",
+        "export_status": "completed",
+        "file_name": None,
+        "period_start": "2026-04-01T00:00:00+00:00",
+        "period_end": "2026-04-20T00:00:00+00:00",
+        "department": "Engineering",
+        "outgoing_user_id": outgoing_user_id,
+        "outgoing_role": outgoing_role,
+        "outgoing_signed_at": "2026-04-20T09:00:00+00:00",
+        "incoming_user_id": incoming_user_id,
+        "incoming_role": incoming_role,
+        "incoming_signed_at": "2026-04-20T11:00:00+00:00" if incoming_user_id else None,
+        "hod_signature": None,
+        "hod_signed_at": "2026-04-20T12:00:00+00:00",
+        "user_signed_at": "2026-04-20T09:00:00+00:00",
+        "review_status": review_status,
+        "signoff_complete": signoff_complete,
+        "original_storage_url": "handover-exports/y/original/x.html",
+        "signed_storage_url": "handover-exports/y/signed/x.html",
+    }
+
+
+def _build_db_mock(exports_rows, profile_rows=None, signer_result=None):
+    """Mock that returns exports_rows for handover_exports, profile_rows
+    for auth_users_profiles, and signer_result for storage.create_signed_url."""
+    m = MagicMock()
+
+    exports_chain = MagicMock()
+    exports_exec = MagicMock()
+    exports_exec.data = exports_rows
+    exports_exec.count = len(exports_rows)
+    exports_chain.execute.return_value = exports_exec
+    for meth in ("eq", "or_", "order", "range", "limit", "in_", "neq"):
+        getattr(exports_chain, meth).return_value = exports_chain
+
+    profiles_chain = MagicMock()
+    profiles_exec = MagicMock()
+    profiles_exec.data = profile_rows or []
+    profiles_chain.execute.return_value = profiles_exec
+    for meth in ("eq", "in_", "order", "range", "limit"):
+        getattr(profiles_chain, meth).return_value = profiles_chain
+
+    def _select_table(name):
+        tbl = MagicMock()
+        if name == "handover_exports":
+            tbl.select.return_value = exports_chain
+        elif name == "auth_users_profiles":
+            tbl.select.return_value = profiles_chain
+        else:
+            c = MagicMock()
+            c.execute.return_value = MagicMock(data=[])
+            for meth in ("eq", "or_", "order", "range", "limit", "in_"):
+                getattr(c, meth).return_value = c
+            tbl.select.return_value = c
+        return tbl
+
+    m.table.side_effect = _select_table
+
+    # Storage signer
+    storage_bucket = MagicMock()
+    storage_bucket.create_signed_url.return_value = signer_result or {"signedURL": "https://signed.example/handover.html"}
+    m.storage.from_.return_value = storage_bucket
+
+    return m, exports_chain
+
+
+@pytest_asyncio.fixture
+async def client_hod():
+    async def _mock_auth():
+        return _AUTH_HOD
+    app.dependency_overrides[get_authenticated_user] = _mock_auth
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test", timeout=10.0) as c:
+        yield c
+    app.dependency_overrides.clear()
+
+
+@pytest_asyncio.fixture
+async def client_crew():
+    async def _mock_auth():
+        return _AUTH_CREW
+    app.dependency_overrides[get_authenticated_user] = _mock_auth
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test", timeout=10.0) as c:
+        yield c
+    app.dependency_overrides.clear()
+
+
+# ── LIST tests ────────────────────────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_list_exports_hod_sees_all(client_hod):
+    """HOD role skips the or_() filter — sees every row on yacht."""
+    rows = [
+        _row(str(uuid.uuid4()), outgoing_user_id=OTHER_USER_ID, outgoing_role="engineer"),
+        _row(str(uuid.uuid4()), outgoing_user_id=USER_ID, outgoing_role="chief_engineer"),
+    ]
+    profiles = [
+        {"id": OTHER_USER_ID, "name": "Other Crew", "email": "other@y.test"},
+        {"id": USER_ID, "name": "Chief HOD", "email": "hod@y.test"},
+    ]
+    db, exports_chain = _build_db_mock(rows, profile_rows=profiles)
+    with patch("integrations.supabase.get_supabase_client", return_value=db):
+        resp = await client_hod.get("/v1/handover/exports")
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["scope"] == "all"
+    assert body["count"] == 2
+    assert body["exports"][0]["outgoing_user_name"] in ("Other Crew", "Chief HOD")
+    # or_() must NOT have been called for HOD role.
+    assert exports_chain.or_.call_count == 0
+
+
+@pytest.mark.asyncio
+async def test_list_exports_crew_applies_or_filter(client_crew):
+    """Non-HOD role calls or_() with the four-predicate same-role scope."""
+    row = _row(
+        str(uuid.uuid4()),
+        outgoing_user_id=USER_ID,
+        outgoing_role="engineer",
+        incoming_user_id=OTHER_USER_ID,
+        incoming_role="engineer",
+    )
+    profiles = [
+        {"id": USER_ID, "name": "Me Engineer", "email": "me@y.test"},
+        {"id": OTHER_USER_ID, "name": "Peer Engineer", "email": "peer@y.test"},
+    ]
+    db, exports_chain = _build_db_mock([row], profile_rows=profiles)
+    with patch("integrations.supabase.get_supabase_client", return_value=db):
+        resp = await client_crew.get("/v1/handover/exports")
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["scope"] == "own_and_same_role"
+    assert body["count"] == 1
+    assert exports_chain.or_.call_count == 1
+    filter_arg = exports_chain.or_.call_args[0][0]
+    assert f"outgoing_user_id.eq.{USER_ID}" in filter_arg
+    assert f"incoming_user_id.eq.{USER_ID}" in filter_arg
+    assert "outgoing_role.eq.engineer" in filter_arg
+    assert "incoming_role.eq.engineer" in filter_arg
+
+    exported = body["exports"][0]
+    assert exported["outgoing_user_name"] == "Me Engineer"
+    assert exported["incoming_user_name"] == "Peer Engineer"
+    # Storage URLs must NOT leak raw.
+    assert "signed_storage_url" not in exported
+    assert "original_storage_url" not in exported
+    assert exported["has_signed_document"] is True
+    assert exported["has_original_document"] is True
+
+
+@pytest.mark.asyncio
+async def test_list_exports_empty_no_profiles_lookup(client_crew):
+    """Zero rows → no profile lookup, returns empty list not null."""
+    db, _ = _build_db_mock([])
+    with patch("integrations.supabase.get_supabase_client", return_value=db):
+        resp = await client_crew.get("/v1/handover/exports")
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["exports"] == []
+    assert body["count"] == 0
+
+
+# ── SIGNED-URL tests ──────────────────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_signed_url_hod_success(client_hod):
+    """HOD mints signed URL regardless of outgoing/incoming role."""
+    row = _row(EXPORT_ID, outgoing_user_id=OTHER_USER_ID, outgoing_role="engineer")
+    db, _ = _build_db_mock([row])
+    with patch("integrations.supabase.get_supabase_client", return_value=db):
+        resp = await client_hod.post(f"/v1/handover/export/{EXPORT_ID}/signed-url")
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["url"].startswith("https://")
+    assert body["ttl_seconds"] == 300
+    assert "expires_at" in body
+
+
+@pytest.mark.asyncio
+async def test_signed_url_own_row_success(client_crew):
+    """Non-HOD outgoing user on the row can mint."""
+    row = _row(EXPORT_ID, outgoing_user_id=USER_ID, outgoing_role="engineer")
+    db, _ = _build_db_mock([row])
+    with patch("integrations.supabase.get_supabase_client", return_value=db):
+        resp = await client_crew.post(f"/v1/handover/export/{EXPORT_ID}/signed-url")
+
+    assert resp.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_signed_url_same_role_success(client_crew):
+    """Non-HOD with same role on incoming side can mint (back-to-back peer)."""
+    row = _row(
+        EXPORT_ID,
+        outgoing_user_id=OTHER_USER_ID,
+        outgoing_role="engineer",  # matches crew's engineer role
+    )
+    db, _ = _build_db_mock([row])
+    with patch("integrations.supabase.get_supabase_client", return_value=db):
+        resp = await client_crew.post(f"/v1/handover/export/{EXPORT_ID}/signed-url")
+
+    assert resp.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_signed_url_stranger_forbidden(client_crew):
+    """Non-HOD with no role/user overlap gets 403."""
+    row = _row(
+        EXPORT_ID,
+        outgoing_user_id=OTHER_USER_ID,
+        outgoing_role="deck",
+        incoming_user_id=OTHER_USER_ID,
+        incoming_role="deck",
+    )
+    db, _ = _build_db_mock([row])
+    with patch("integrations.supabase.get_supabase_client", return_value=db):
+        resp = await client_crew.post(f"/v1/handover/export/{EXPORT_ID}/signed-url")
+
+    assert resp.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_signed_url_missing_export(client_hod):
+    """Unknown export → 404."""
+    db, _ = _build_db_mock([])
+    with patch("integrations.supabase.get_supabase_client", return_value=db):
+        resp = await client_hod.post(f"/v1/handover/export/{EXPORT_ID}/signed-url")
+
+    assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_signed_url_no_document(client_hod):
+    """Row exists but no signed/original URL → 404."""
+    row = _row(EXPORT_ID, outgoing_user_id=USER_ID, outgoing_role="chief_engineer")
+    row["signed_storage_url"] = None
+    row["original_storage_url"] = None
+    db, _ = _build_db_mock([row])
+    with patch("integrations.supabase.get_supabase_client", return_value=db):
+        resp = await client_hod.post(f"/v1/handover/export/{EXPORT_ID}/signed-url")
+
+    assert resp.status_code == 404

--- a/apps/web/src/app/handover-export/page.tsx
+++ b/apps/web/src/app/handover-export/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 /**
- * Handover — Queue + Draft tabs
+ * Handover — Queue + Draft + Exported tabs
  *
  * Tab 1 — Queue: auto-detected items ready to add to next handover.
  *   Calls GET /v1/handover/queue via HandoverQueueView.
@@ -11,14 +11,19 @@
  *   Reuses HandoverDraftPanel with variant='page' for in-page rendering.
  *   Includes Export button that navigates to /handover-export/[id] on success.
  *
+ * Tab 3 — Exported: this user's prior handovers plus same-role back-to-back
+ *   peers. Calls GET /v1/handover/exports via ExportedHandoversView.
+ *   Row click opens /handover-export/{id}.
+ *
  * The /handover-export/[id] lens for completed exports is untouched.
  */
 
 import * as React from 'react';
 import { HandoverQueueView } from '@/components/handover/HandoverQueueView';
 import { HandoverDraftPanel } from '@/components/handover/HandoverDraftPanel';
+import { ExportedHandoversView } from '@/components/handover/ExportedHandoversView';
 
-type Tab = 'queue' | 'draft';
+type Tab = 'queue' | 'draft' | 'exported';
 
 export default function HandoverExportPage() {
   const [activeTab, setActiveTab] = React.useState<Tab>('queue');
@@ -41,7 +46,7 @@ export default function HandoverExportPage() {
         flexShrink: 0,
         background: 'var(--surface)',
       }}>
-        {(['queue', 'draft'] as Tab[]).map(tab => (
+        {(['queue', 'draft', 'exported'] as Tab[]).map(tab => (
           <button
             key={tab}
             onClick={() => setActiveTab(tab)}
@@ -61,7 +66,7 @@ export default function HandoverExportPage() {
               letterSpacing: '0.01em',
             }}
           >
-            {tab === 'queue' ? 'Queue' : 'Draft Items'}
+            {tab === 'queue' ? 'Queue' : tab === 'draft' ? 'Draft Items' : 'Exported'}
           </button>
         ))}
       </div>
@@ -90,6 +95,16 @@ export default function HandoverExportPage() {
             onClose={() => setActiveTab('queue')}
             variant="page"
           />
+        </div>
+
+        {/* Exported tab */}
+        <div style={{
+          position: 'absolute', inset: 0,
+          overflow: 'hidden',
+          visibility: activeTab === 'exported' ? 'visible' : 'hidden',
+          pointerEvents: activeTab === 'exported' ? 'auto' : 'none',
+        }}>
+          <ExportedHandoversView />
         </div>
       </div>
     </div>

--- a/apps/web/src/components/handover/AddDraftItemModal.tsx
+++ b/apps/web/src/components/handover/AddDraftItemModal.tsx
@@ -1,0 +1,619 @@
+'use client';
+
+/**
+ * AddDraftItemModal — "+ Add Draft Item" modal for the handover draft panel.
+ *
+ * Replaces the old "Add Note" ItemPopup add-mode with a key/value entity
+ * selector as mandated by HANDOVER08 Issue 8b.
+ *
+ * Behaviour:
+ * 1. User picks a KEY (domain): Work Order · Equipment · Parts · Fault · Location.
+ * 2. A VALUE field is rendered appropriate to the key:
+ *    - Entity keys: searchable type-to-filter list, loaded from
+ *      `GET /v1/handover/pickers/{entity_type}` (yacht-scoped, alphabetical).
+ *    - Location: free text input (no location table exists by design).
+ * 3. Required summary textarea (3–2000 chars per canonical handler).
+ * 4. Optional notes textarea (stored in the summary tail for now — kept
+ *    separate in UI for future expansion to a structured notes column).
+ *
+ * Submit path:
+ *   POST /v1/actions/execute  { action: 'add_to_handover', payload: {...} }
+ *
+ *   - Entity keys (work_order / equipment / part / fault):
+ *        entity_type = <key>, entity_id = <picked UUID>, summary = <text>.
+ *   - Location:
+ *        entity_type = 'note', entity_id = null,
+ *        summary = "[Location: <label>] " + <text>.
+ *     The canonical handler already accepts entity_type='note' with a null
+ *     entity_id, so no backend contract extension is required.
+ *
+ * Styling: tokenised CSS vars only. Teal accent, 44-px row heights in the
+ * picker, monospace for codes + timestamps. Matches HandoverDraftPanel's
+ * existing design language.
+ *
+ * Keyboard:
+ *   - Escape: close.
+ *   - Enter (while summary focused with value valid): submit.
+ */
+
+import * as React from 'react';
+import { X, Plus, Wrench, Package, AlertTriangle, FileText, MapPin, Check, type LucideIcon } from 'lucide-react';
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+export type AddDraftEntityKey =
+  | 'work_order'
+  | 'equipment'
+  | 'part'
+  | 'fault'
+  | 'location';
+
+export interface AddDraftPickerItem {
+  id: string;
+  code?: string | null;
+  title?: string | null;
+  sub_a?: string | null;
+  sub_b?: string | null;
+}
+
+export interface AddDraftItemSubmitPayload {
+  entity_type: 'work_order' | 'equipment' | 'part' | 'fault' | 'note';
+  entity_id: string | null;
+  summary: string;
+  notes?: string;
+  /** Only present when the user chose the Location key. */
+  location_label?: string;
+}
+
+export interface AddDraftItemModalProps {
+  open: boolean;
+  onClose: () => void;
+  /**
+   * Loader invoked each time the user switches the KEY dropdown to an entity
+   * type. Parent is responsible for auth + API base URL + yacht scoping.
+   * Must resolve with a yacht-scoped, alphabetical list.
+   */
+  loadEntities: (key: Exclude<AddDraftEntityKey, 'location'>) => Promise<AddDraftPickerItem[]>;
+  /**
+   * Called with the final payload. Modal closes on resolve; on reject an
+   * inline error is surfaced and the modal stays open.
+   */
+  onSubmit: (payload: AddDraftItemSubmitPayload) => Promise<void>;
+  /** Disable submit while user context is still loading. */
+  userReady?: boolean;
+}
+
+// ─── Static config ────────────────────────────────────────────────────────────
+
+const KEY_OPTIONS: { value: AddDraftEntityKey; label: string; Icon: LucideIcon }[] = [
+  { value: 'work_order', label: 'Work Order', Icon: Wrench },
+  { value: 'equipment',  label: 'Equipment',  Icon: Package },
+  { value: 'part',       label: 'Parts',      Icon: Package },
+  { value: 'fault',      label: 'Fault',      Icon: AlertTriangle },
+  { value: 'location',   label: 'Location',   Icon: MapPin },
+];
+
+const SUMMARY_MIN = 3;
+const SUMMARY_MAX = 2000;
+
+// ─── Styles ───────────────────────────────────────────────────────────────────
+
+const S = {
+  overlay: {
+    position: 'fixed' as const, inset: 0, zIndex: 200,
+    display: 'flex', alignItems: 'center', justifyContent: 'center',
+    padding: 16,
+  },
+  backdrop: {
+    position: 'absolute' as const, inset: 0,
+    background: 'var(--overlay-bg)',
+  },
+  modal: {
+    position: 'relative' as const, width: '100%', maxWidth: 560,
+    maxHeight: '90vh',
+    background: 'var(--surface-el)',
+    borderRadius: 12,
+    borderTop: '1px solid var(--border-top)',
+    borderRight: '1px solid var(--border-side)',
+    borderBottom: '1px solid var(--border-bottom)',
+    borderLeft: '1px solid var(--border-side)',
+    boxShadow: 'var(--shadow-panel)',
+    display: 'flex', flexDirection: 'column' as const, overflow: 'hidden',
+  },
+  header: {
+    display: 'flex', alignItems: 'flex-start', gap: 12,
+    padding: '20px 24px 16px',
+    borderBottom: '1px solid var(--border-sub)',
+  },
+  headerIcon: {
+    width: 32, height: 32, borderRadius: 8,
+    background: 'var(--teal-bg)', color: 'var(--mark)',
+    display: 'flex', alignItems: 'center', justifyContent: 'center', flexShrink: 0,
+  },
+  title: { fontSize: 18, fontWeight: 600, color: 'var(--txt)' },
+  subtitle: { fontSize: 13, color: 'var(--txt2)', marginTop: 3 },
+  closeBtn: {
+    width: 36, height: 36, borderRadius: 8,
+    display: 'flex', alignItems: 'center', justifyContent: 'center',
+    cursor: 'pointer', color: 'var(--txt-ghost)',
+    background: 'none', border: 'none',
+  },
+  body: {
+    padding: '16px 24px',
+    overflowY: 'auto' as const, flex: 1,
+  },
+  fieldLabel: {
+    fontSize: 11, fontWeight: 500, color: 'var(--txt3)',
+    textTransform: 'uppercase' as const, letterSpacing: '0.04em',
+    marginBottom: 8,
+  },
+  keyRow: {
+    display: 'grid',
+    gridTemplateColumns: 'repeat(5, 1fr)',
+    gap: 6,
+    marginBottom: 16,
+  },
+  keyOption: (selected: boolean) => ({
+    display: 'flex', flexDirection: 'column' as const,
+    alignItems: 'center', justifyContent: 'center', gap: 4,
+    padding: '10px 6px', borderRadius: 6,
+    cursor: 'pointer', userSelect: 'none' as const,
+    border: `1px solid ${selected ? 'var(--mark-underline)' : 'var(--border-sub)'}`,
+    background: selected ? 'var(--teal-bg)' : 'transparent',
+    color: selected ? 'var(--mark)' : 'var(--txt2)',
+    fontSize: 11, fontWeight: selected ? 600 : 500,
+    transition: 'background 80ms, border-color 80ms, color 80ms',
+  }),
+  searchInput: {
+    width: '100%', boxSizing: 'border-box' as const,
+    background: 'var(--surface-base)',
+    border: '1px solid var(--border-chrome)',
+    borderRadius: 6,
+    padding: '10px 12px',
+    fontSize: 13, color: 'var(--txt)',
+    fontFamily: 'var(--font-sans)', outline: 'none',
+  },
+  list: {
+    marginTop: 8,
+    maxHeight: 240, overflowY: 'auto' as const,
+    border: '1px solid var(--border-sub)',
+    borderRadius: 6,
+    background: 'var(--surface-base)',
+  },
+  listItem: (selected: boolean, hover: boolean) => ({
+    display: 'flex', alignItems: 'center', gap: 10,
+    minHeight: 44,
+    padding: '8px 12px',
+    cursor: 'pointer',
+    borderBottom: '1px solid var(--border-faint)',
+    background: selected
+      ? 'var(--teal-bg)'
+      : (hover ? 'var(--surface-hover)' : 'transparent'),
+    transition: 'background 60ms',
+  }),
+  listItemCode: {
+    fontFamily: 'var(--font-mono)',
+    fontSize: 11,
+    color: 'var(--txt3)',
+    letterSpacing: '0.02em',
+    flexShrink: 0,
+  },
+  listItemTitle: {
+    fontSize: 13, fontWeight: 500, color: 'var(--txt)',
+    overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' as const,
+  },
+  listItemSubline: {
+    fontSize: 11, color: 'var(--txt2)',
+    marginTop: 1, display: 'flex', alignItems: 'center', gap: 8,
+    overflow: 'hidden', whiteSpace: 'nowrap' as const,
+  },
+  listStateMsg: {
+    padding: '24px 16px', textAlign: 'center' as const,
+    fontSize: 12, color: 'var(--txt3)',
+  },
+  textarea: {
+    width: '100%', boxSizing: 'border-box' as const,
+    background: 'var(--surface-base)',
+    border: '1px solid var(--border-chrome)',
+    borderRadius: 6,
+    padding: '10px 12px',
+    fontSize: 13, color: 'var(--txt)',
+    fontFamily: 'var(--font-sans)',
+    lineHeight: 1.5, outline: 'none',
+    resize: 'vertical' as const,
+  },
+  charCount: {
+    fontSize: 10, fontFamily: 'var(--font-mono)',
+    color: 'var(--txt-ghost)', marginTop: 4, textAlign: 'right' as const,
+  },
+  errorMsg: {
+    fontSize: 12, color: 'var(--red)',
+    marginTop: 8,
+  },
+  footer: {
+    display: 'flex', alignItems: 'center', gap: 8,
+    padding: '16px 24px',
+    borderTop: '1px solid var(--border-sub)',
+    flexShrink: 0,
+  },
+  btnPrimary: {
+    display: 'flex', alignItems: 'center', gap: 6,
+    padding: '9px 16px', borderRadius: 8,
+    fontSize: 13, fontWeight: 600,
+    cursor: 'pointer',
+    border: '1px solid var(--mark-underline)',
+    background: 'var(--teal-bg)', color: 'var(--mark)',
+    fontFamily: 'var(--font-sans)', minHeight: 40,
+  },
+  btnSecondary: {
+    display: 'flex', alignItems: 'center', gap: 6,
+    padding: '9px 16px', borderRadius: 8,
+    fontSize: 13, fontWeight: 500,
+    cursor: 'pointer',
+    border: '1px solid var(--border-sub)',
+    background: 'none', color: 'var(--txt2)',
+    fontFamily: 'var(--font-sans)', minHeight: 40,
+  },
+};
+
+// ─── Component ───────────────────────────────────────────────────────────────
+
+export function AddDraftItemModal({
+  open, onClose, loadEntities, onSubmit, userReady = true,
+}: AddDraftItemModalProps) {
+  const [entityKey, setEntityKey] = React.useState<AddDraftEntityKey | null>(null);
+
+  // Entity picker state
+  const [items, setItems] = React.useState<AddDraftPickerItem[] | null>(null);
+  const [loadError, setLoadError] = React.useState<string | null>(null);
+  const [loadingList, setLoadingList] = React.useState(false);
+  const [query, setQuery] = React.useState('');
+  const [selectedEntityId, setSelectedEntityId] = React.useState<string | null>(null);
+  const [hoverId, setHoverId] = React.useState<string | null>(null);
+
+  // Location state
+  const [locationLabel, setLocationLabel] = React.useState('');
+
+  // Summary + notes
+  const [summary, setSummary] = React.useState('');
+  const [notes, setNotes] = React.useState('');
+
+  // Submit state
+  const [submitting, setSubmitting] = React.useState(false);
+  const [submitError, setSubmitError] = React.useState<string | null>(null);
+
+  const summaryRef = React.useRef<HTMLTextAreaElement>(null);
+  const searchRef = React.useRef<HTMLInputElement>(null);
+  const locationRef = React.useRef<HTMLInputElement>(null);
+
+  // Reset on open
+  React.useEffect(() => {
+    if (open) {
+      setEntityKey(null);
+      setItems(null);
+      setLoadError(null);
+      setLoadingList(false);
+      setQuery('');
+      setSelectedEntityId(null);
+      setLocationLabel('');
+      setSummary('');
+      setNotes('');
+      setSubmitting(false);
+      setSubmitError(null);
+    }
+  }, [open]);
+
+  // Escape closes
+  React.useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => { if (e.key === 'Escape') onClose(); };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [open, onClose]);
+
+  // Load entity list when key changes to a non-location type
+  React.useEffect(() => {
+    if (!open) return;
+    if (!entityKey || entityKey === 'location') {
+      setItems(null);
+      setLoadError(null);
+      return;
+    }
+    let cancelled = false;
+    setLoadingList(true);
+    setLoadError(null);
+    setItems(null);
+    setSelectedEntityId(null);
+    setQuery('');
+    loadEntities(entityKey)
+      .then((rows) => {
+        if (cancelled) return;
+        setItems(rows);
+        // Autofocus search once the list arrives.
+        requestAnimationFrame(() => searchRef.current?.focus());
+      })
+      .catch((err) => {
+        if (cancelled) return;
+        setLoadError(err instanceof Error ? err.message : 'Failed to load list');
+      })
+      .finally(() => { if (!cancelled) setLoadingList(false); });
+    return () => { cancelled = true; };
+  }, [entityKey, open, loadEntities]);
+
+  // Focus location input when user flips to location key
+  React.useEffect(() => {
+    if (open && entityKey === 'location') {
+      requestAnimationFrame(() => locationRef.current?.focus());
+    }
+  }, [entityKey, open]);
+
+  // Client-side filter
+  const filteredItems = React.useMemo(() => {
+    if (!items) return [];
+    const q = query.trim().toLowerCase();
+    if (!q) return items;
+    return items.filter((it) => {
+      return (
+        (it.code ?? '').toLowerCase().includes(q) ||
+        (it.title ?? '').toLowerCase().includes(q) ||
+        (it.sub_a ?? '').toLowerCase().includes(q) ||
+        (it.sub_b ?? '').toLowerCase().includes(q)
+      );
+    });
+  }, [items, query]);
+
+  // Validation
+  const summaryTrimmed = summary.trim();
+  const summaryValid = summaryTrimmed.length >= SUMMARY_MIN && summaryTrimmed.length <= SUMMARY_MAX;
+  const entitySelected = entityKey === 'location'
+    ? locationLabel.trim().length > 0
+    : (entityKey !== null && selectedEntityId !== null);
+  const canSubmit = entitySelected && summaryValid && !submitting && userReady;
+
+  const buildPayload = React.useCallback((): AddDraftItemSubmitPayload | null => {
+    if (!entityKey) return null;
+    if (entityKey === 'location') {
+      const label = locationLabel.trim();
+      if (!label) return null;
+      // entity_type='note' + prepended [Location: ...] is the simplest route
+      // that needs no backend contract extension. The location label is also
+      // returned separately so callers that want to persist it into metadata
+      // can do so.
+      return {
+        entity_type: 'note',
+        entity_id: null,
+        summary: `[Location: ${label}] ${summaryTrimmed}`,
+        notes: notes.trim() || undefined,
+        location_label: label,
+      };
+    }
+    if (!selectedEntityId) return null;
+    return {
+      entity_type: entityKey,
+      entity_id: selectedEntityId,
+      summary: summaryTrimmed,
+      notes: notes.trim() || undefined,
+    };
+  }, [entityKey, selectedEntityId, locationLabel, summaryTrimmed, notes]);
+
+  const handleSubmit = React.useCallback(async () => {
+    if (!canSubmit) return;
+    const payload = buildPayload();
+    if (!payload) return;
+    setSubmitting(true);
+    setSubmitError(null);
+    try {
+      await onSubmit(payload);
+      onClose();
+    } catch (err) {
+      setSubmitError(err instanceof Error ? err.message : 'Failed to add draft item');
+    } finally {
+      setSubmitting(false);
+    }
+  }, [canSubmit, buildPayload, onSubmit, onClose]);
+
+  // Enter submits when summary valid and focus is in summary or textarea region
+  const onSummaryKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+    if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) {
+      e.preventDefault();
+      handleSubmit();
+    }
+  };
+
+  if (!open) return null;
+
+  const keyMeta = entityKey ? KEY_OPTIONS.find((o) => o.value === entityKey) : null;
+
+  return (
+    <div style={S.overlay} role="dialog" aria-modal="true" aria-label="Add Draft Item">
+      <div style={S.backdrop} onClick={onClose} />
+      <div style={S.modal} onClick={(e) => e.stopPropagation()}>
+        {/* Header */}
+        <div style={S.header}>
+          <div style={S.headerIcon}>
+            <Plus size={16} />
+          </div>
+          <div style={{ flex: 1 }}>
+            <div style={S.title}>Add Draft Item</div>
+            <div style={S.subtitle}>
+              Link a domain entity or a location label, then describe what the
+              next crew needs to know.
+            </div>
+          </div>
+          <button type="button" style={S.closeBtn} onClick={onClose} aria-label="Close">
+            <X size={14} />
+          </button>
+        </div>
+
+        {/* Body */}
+        <div style={S.body}>
+          {/* KEY picker */}
+          <div>
+            <div style={S.fieldLabel}>Key</div>
+            <div style={S.keyRow}>
+              {KEY_OPTIONS.map(({ value, label, Icon }) => {
+                const selected = entityKey === value;
+                return (
+                  <button
+                    key={value}
+                    type="button"
+                    onClick={() => setEntityKey(value)}
+                    style={S.keyOption(selected)}
+                  >
+                    <Icon size={14} />
+                    {label}
+                  </button>
+                );
+              })}
+            </div>
+          </div>
+
+          {/* VALUE picker */}
+          {entityKey && (
+            <div style={{ marginTop: 4 }}>
+              <div style={S.fieldLabel}>Value</div>
+
+              {entityKey === 'location' ? (
+                <input
+                  ref={locationRef}
+                  type="text"
+                  value={locationLabel}
+                  onChange={(e) => setLocationLabel(e.target.value)}
+                  placeholder="e.g. Sun deck, Engine room, Bridge"
+                  style={S.searchInput}
+                  maxLength={200}
+                />
+              ) : (
+                <>
+                  <input
+                    ref={searchRef}
+                    type="search"
+                    value={query}
+                    onChange={(e) => setQuery(e.target.value)}
+                    placeholder={`Search ${keyMeta?.label.toLowerCase() ?? 'list'}…`}
+                    style={S.searchInput}
+                    disabled={loadingList || !!loadError}
+                  />
+                  <div style={S.list}>
+                    {loadingList && (
+                      <div style={S.listStateMsg}>Loading…</div>
+                    )}
+                    {loadError && !loadingList && (
+                      <div style={{ ...S.listStateMsg, color: 'var(--red)' }} role="alert">
+                        {loadError}
+                      </div>
+                    )}
+                    {!loadingList && !loadError && items && filteredItems.length === 0 && (
+                      <div style={S.listStateMsg}>
+                        {query ? 'No matches.' : 'No items on this vessel.'}
+                      </div>
+                    )}
+                    {!loadingList && !loadError && filteredItems.map((it) => {
+                      const selected = selectedEntityId === it.id;
+                      const hover = hoverId === it.id;
+                      return (
+                        <div
+                          key={it.id}
+                          role="option"
+                          aria-selected={selected}
+                          onClick={() => setSelectedEntityId(it.id)}
+                          onMouseEnter={() => setHoverId(it.id)}
+                          onMouseLeave={() => setHoverId((h) => h === it.id ? null : h)}
+                          style={S.listItem(selected, hover)}
+                        >
+                          {it.code && (
+                            <span style={S.listItemCode}>{it.code}</span>
+                          )}
+                          <div style={{ flex: 1, minWidth: 0 }}>
+                            <div style={S.listItemTitle}>
+                              {it.title || '—'}
+                            </div>
+                            {(it.sub_a || it.sub_b) && (
+                              <div style={S.listItemSubline}>
+                                {it.sub_a && <span>{it.sub_a}</span>}
+                                {it.sub_a && it.sub_b && <span style={{ opacity: 0.5 }}>·</span>}
+                                {it.sub_b && (
+                                  <span style={{
+                                    overflow: 'hidden',
+                                    textOverflow: 'ellipsis',
+                                    whiteSpace: 'nowrap',
+                                  }}>
+                                    {it.sub_b}
+                                  </span>
+                                )}
+                              </div>
+                            )}
+                          </div>
+                          {selected && (
+                            <Check size={14} style={{ color: 'var(--mark)', flexShrink: 0 }} />
+                          )}
+                        </div>
+                      );
+                    })}
+                  </div>
+                </>
+              )}
+            </div>
+          )}
+
+          {/* Summary */}
+          <div style={{ marginTop: 16 }}>
+            <div style={S.fieldLabel}>Summary <span style={{ color: 'var(--red)' }}>*</span></div>
+            <textarea
+              ref={summaryRef}
+              value={summary}
+              onChange={(e) => setSummary(e.target.value)}
+              onKeyDown={onSummaryKeyDown}
+              placeholder="What does the incoming crew need to know?"
+              style={{ ...S.textarea, minHeight: 80 }}
+              maxLength={SUMMARY_MAX}
+            />
+            <div style={S.charCount}>
+              {summaryTrimmed.length}/{SUMMARY_MAX}
+              {summaryTrimmed.length > 0 && summaryTrimmed.length < SUMMARY_MIN && (
+                <span style={{ color: 'var(--amber)', marginLeft: 8 }}>
+                  (minimum {SUMMARY_MIN})
+                </span>
+              )}
+            </div>
+          </div>
+
+          {/* Notes */}
+          <div style={{ marginTop: 12 }}>
+            <div style={S.fieldLabel}>Notes (optional)</div>
+            <textarea
+              value={notes}
+              onChange={(e) => setNotes(e.target.value)}
+              placeholder="Additional context, observations, follow-up…"
+              style={{ ...S.textarea, minHeight: 60 }}
+              maxLength={2000}
+            />
+          </div>
+
+          {submitError && (
+            <div style={S.errorMsg} role="alert">{submitError}</div>
+          )}
+        </div>
+
+        {/* Footer */}
+        <div style={S.footer}>
+          <button
+            type="button"
+            style={{ ...S.btnPrimary, opacity: canSubmit ? 1 : 0.5, cursor: canSubmit ? 'pointer' : 'not-allowed' }}
+            onClick={handleSubmit}
+            disabled={!canSubmit}
+          >
+            <Plus size={14} />
+            {submitting ? 'Adding…' : 'Add Draft Item'}
+          </button>
+          <button type="button" style={S.btnSecondary} onClick={onClose}>Cancel</button>
+          <div style={{ flex: 1 }} />
+          <div style={{ fontSize: 10, color: 'var(--txt-ghost)', fontFamily: 'var(--font-mono)' }}>
+            <FileText size={10} style={{ verticalAlign: -1, marginRight: 4 }} />
+            Cmd/Ctrl+Enter to submit
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/handover/ConfirmExportModal.tsx
+++ b/apps/web/src/components/handover/ConfirmExportModal.tsx
@@ -1,0 +1,143 @@
+'use client';
+
+/**
+ * ConfirmExportModal — pre-flight confirm for the handover export flow.
+ *
+ * Gates the POST /v1/handover/export call so the user sees (a) how many items
+ * are about to be packaged, (b) where the result will land. Rendered by
+ * AppShell for the subbar "Create Handover" primary action. The draft panel
+ * in-page button has its own context (users are already looking at the list)
+ * so it doesn't require the same guardrail — keep it simple for MVP.
+ *
+ * Pure presentational — the export work lives in `useHandoverExport`.
+ */
+
+import * as React from 'react';
+import { X, Loader2, Upload } from 'lucide-react';
+
+export interface ConfirmExportModalProps {
+  open: boolean;
+  itemCount: number;
+  isExporting: boolean;
+  onConfirm: () => void;
+  onClose: () => void;
+}
+
+export function ConfirmExportModal({
+  open,
+  itemCount,
+  isExporting,
+  onConfirm,
+  onClose,
+}: ConfirmExportModalProps) {
+  React.useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape' && !isExporting) onClose();
+      if (e.key === 'Enter' && !isExporting && itemCount > 0) onConfirm();
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [open, isExporting, itemCount, onClose, onConfirm]);
+
+  if (!open) return null;
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="confirm-export-title"
+      style={{
+        position: 'fixed', inset: 0, zIndex: 1000,
+        background: 'var(--scrim, rgba(0,0,0,0.55))',
+        display: 'flex', alignItems: 'center', justifyContent: 'center',
+        padding: 16,
+      }}
+      onClick={isExporting ? undefined : onClose}
+    >
+      <div
+        onClick={(e) => e.stopPropagation()}
+        style={{
+          width: '100%', maxWidth: 440,
+          background: 'var(--surface)', color: 'var(--txt)',
+          borderRadius: 8, border: '1px solid var(--border-sub)',
+          boxShadow: 'var(--shadow-lg, 0 18px 48px rgba(0,0,0,0.35))',
+          fontFamily: 'var(--font-sans)',
+        }}
+      >
+        <div style={{
+          display: 'flex', alignItems: 'center', justifyContent: 'space-between',
+          padding: '14px 16px', borderBottom: '1px solid var(--border-faint)',
+        }}>
+          <div id="confirm-export-title" style={{ fontSize: 13, fontWeight: 600 }}>
+            Create handover
+          </div>
+          <button
+            onClick={onClose}
+            disabled={isExporting}
+            aria-label="Close"
+            style={{
+              background: 'none', border: 'none', padding: 4,
+              cursor: isExporting ? 'not-allowed' : 'pointer',
+              color: 'var(--txt-ghost)', borderRadius: 4,
+            }}
+          >
+            <X size={14} />
+          </button>
+        </div>
+
+        <div style={{ padding: '16px 18px 4px', fontSize: 13, lineHeight: 1.55, color: 'var(--txt2)' }}>
+          <p style={{ margin: 0 }}>
+            You&apos;re about to export{' '}
+            <span style={{ fontFamily: 'var(--font-mono)', fontWeight: 600, color: 'var(--txt)' }}>
+              {itemCount}
+            </span>{' '}
+            {itemCount === 1 ? 'item' : 'items'} from your draft.
+          </p>
+          <ul style={{ margin: '12px 0 0', paddingLeft: 18, color: 'var(--txt3)', fontSize: 12 }}>
+            <li>Generation usually takes 15–30 seconds.</li>
+            <li>The signed document will appear in your notifications.</li>
+            <li>You&apos;ll also find it in the <strong style={{ color: 'var(--txt2)' }}>Exported</strong> tab.</li>
+            <li>Once exported, the items leave your draft queue.</li>
+          </ul>
+        </div>
+
+        <div style={{
+          display: 'flex', justifyContent: 'flex-end', gap: 8,
+          padding: '16px 18px 18px',
+        }}>
+          <button
+            onClick={onClose}
+            disabled={isExporting}
+            style={{
+              padding: '7px 14px', borderRadius: 6,
+              background: 'none', color: 'var(--txt2)',
+              fontSize: 12, fontWeight: 500, border: '1px solid var(--border-sub)',
+              cursor: isExporting ? 'not-allowed' : 'pointer',
+              fontFamily: 'var(--font-sans)',
+            }}
+          >
+            Cancel
+          </button>
+          <button
+            onClick={onConfirm}
+            disabled={isExporting || itemCount === 0}
+            style={{
+              display: 'flex', alignItems: 'center', gap: 6,
+              padding: '7px 14px', borderRadius: 6,
+              background: 'var(--teal-bg)', color: 'var(--mark)',
+              fontSize: 12, fontWeight: 600,
+              border: '1px solid var(--mark-underline)',
+              cursor: (isExporting || itemCount === 0) ? 'not-allowed' : 'pointer',
+              opacity: (isExporting || itemCount === 0) ? 0.5 : 1,
+              fontFamily: 'var(--font-sans)',
+            }}
+          >
+            {isExporting ? <Loader2 size={13} className="animate-spin" /> : <Upload size={13} />}
+            {isExporting ? 'Exporting…' : 'Create handover'}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/handover/ExportedHandoversView.tsx
+++ b/apps/web/src/components/handover/ExportedHandoversView.tsx
@@ -1,0 +1,681 @@
+'use client';
+
+/**
+ * ExportedHandoversView — Exported tab on /handover-export.
+ *
+ * Lists prior handovers the current user can see:
+ *   - HODs (chief_engineer / chief_officer / captain / manager) see all rows
+ *     for the active yacht.
+ *   - Everyone else sees rows where they are outgoing/incoming user OR where
+ *     their role appears on either side (same-role back-to-back peer visibility).
+ *
+ * Columns (per UX spec in lens_card_upgrades.md "Exported tab"):
+ *   Generated | Rotation | Outgoing | HOD signed | Incoming signed | Status | ⋯
+ *
+ * Row click → navigate to the existing /handover-export/{id} lens.
+ * Kebab menu → Open · Download PDF (mints signed URL) · Resend email (HOD+).
+ *
+ * Styling: tokens only, mirrors HandoverQueueView patterns
+ * (see apps/web/src/components/handover/HandoverQueueView.tsx).
+ */
+
+import * as React from 'react';
+import { useRouter } from 'next/navigation';
+import {
+  Loader2, RefreshCw, MoreHorizontal, ArrowUp, ArrowDown,
+  FileText, Download, Mail, ExternalLink,
+} from 'lucide-react';
+import { useAuth } from '@/hooks/useAuth';
+import { toast } from 'sonner';
+import {
+  fetchHandoverExports,
+  mintHandoverExportSignedUrl,
+  type HandoverExportListItem,
+  type HandoverExportListResponse,
+} from '@/components/shell/api';
+
+// ============================================================================
+// TYPES
+// ============================================================================
+
+type SortKey =
+  | 'exported_at'
+  | 'period_start'
+  | 'outgoing_user_name'
+  | 'hod_signed_at'
+  | 'incoming_signed_at'
+  | 'review_status';
+
+type SortDir = 'asc' | 'desc';
+
+const HOD_ROLES = new Set(['chief_engineer', 'chief_officer', 'captain', 'manager']);
+
+// ============================================================================
+// HELPERS
+// ============================================================================
+
+function formatTimestamp(iso: string | null | undefined): string {
+  if (!iso) return '—';
+  try {
+    const d = new Date(iso);
+    if (Number.isNaN(d.getTime())) return '—';
+    // YYYY-MM-DD HH:MM (UTC-neutral, locale-independent, monospace-friendly)
+    const pad = (n: number) => String(n).padStart(2, '0');
+    return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())} ${pad(d.getHours())}:${pad(d.getMinutes())}`;
+  } catch {
+    return '—';
+  }
+}
+
+function formatDate(iso: string | null | undefined): string {
+  if (!iso) return '—';
+  try {
+    const d = new Date(iso);
+    if (Number.isNaN(d.getTime())) return '—';
+    const pad = (n: number) => String(n).padStart(2, '0');
+    return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}`;
+  } catch {
+    return '—';
+  }
+}
+
+function roleLabel(role: string | null): string {
+  if (!role) return '';
+  return role.replace(/_/g, ' ');
+}
+
+type StatusPill = {
+  label: string;
+  fg: string;
+  bg: string;
+  border: string;
+};
+
+function resolveStatusPill(row: HandoverExportListItem): StatusPill {
+  const rs = (row.review_status || '').toLowerCase();
+  const signoff = row.signoff_complete === true;
+
+  if (rs === 'complete' && signoff) {
+    return { label: 'Complete', fg: 'var(--green)', bg: 'var(--green-bg)', border: 'var(--green)' };
+  }
+  if (rs === 'complete' && !signoff) {
+    return { label: 'Awaiting incoming', fg: 'var(--amber)', bg: 'var(--amber-bg)', border: 'var(--amber)' };
+  }
+  if (rs === 'pending_hod_signature') {
+    return { label: 'Pending HOD', fg: 'var(--amber)', bg: 'var(--amber-bg)', border: 'var(--amber)' };
+  }
+  if (rs === 'pending_review') {
+    return { label: 'Pending review', fg: 'var(--txt3)', bg: 'var(--neutral-bg)', border: 'var(--border-sub)' };
+  }
+  return { label: rs || 'Unknown', fg: 'var(--txt3)', bg: 'var(--neutral-bg)', border: 'var(--border-sub)' };
+}
+
+function getSortValue(row: HandoverExportListItem, key: SortKey): string {
+  switch (key) {
+    case 'exported_at': return row.exported_at || '';
+    case 'period_start': return row.period_start || '';
+    case 'outgoing_user_name': return row.outgoing_user_name || '';
+    case 'hod_signed_at': return row.hod_signed_at || '';
+    case 'incoming_signed_at': return row.incoming_signed_at || '';
+    case 'review_status': return row.review_status || '';
+  }
+}
+
+// ============================================================================
+// COLUMN HEADER
+// ============================================================================
+
+function SortableHeader({
+  label, colKey, active, dir, onClick, width, align,
+}: {
+  label: string;
+  colKey: SortKey;
+  active: boolean;
+  dir: SortDir;
+  onClick: (k: SortKey) => void;
+  width: string;
+  align?: 'left' | 'right';
+}) {
+  return (
+    <button
+      type="button"
+      onClick={() => onClick(colKey)}
+      style={{
+        width,
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: align === 'right' ? 'flex-end' : 'flex-start',
+        gap: 4,
+        padding: '0 12px',
+        background: 'none',
+        border: 'none',
+        color: active ? 'var(--txt)' : 'var(--txt3)',
+        fontSize: 10,
+        fontWeight: 600,
+        letterSpacing: '0.06em',
+        textTransform: 'uppercase',
+        fontFamily: 'var(--font-sans)',
+        cursor: 'pointer',
+        height: '100%',
+      }}
+    >
+      <span>{label}</span>
+      {active ? (
+        dir === 'asc'
+          ? <ArrowUp size={10} style={{ color: 'var(--mark)' }} />
+          : <ArrowDown size={10} style={{ color: 'var(--mark)' }} />
+      ) : null}
+    </button>
+  );
+}
+
+// ============================================================================
+// KEBAB MENU
+// ============================================================================
+
+function KebabMenu({
+  row, isHod, onOpen, onDownload,
+}: {
+  row: HandoverExportListItem;
+  isHod: boolean;
+  onOpen: () => void;
+  onDownload: () => void;
+}) {
+  const [open, setOpen] = React.useState(false);
+  const ref = React.useRef<HTMLDivElement | null>(null);
+
+  React.useEffect(() => {
+    if (!open) return;
+    const onDoc = (e: MouseEvent) => {
+      if (ref.current && !ref.current.contains(e.target as Node)) setOpen(false);
+    };
+    document.addEventListener('mousedown', onDoc);
+    return () => document.removeEventListener('mousedown', onDoc);
+  }, [open]);
+
+  const handleResendEmail = () => {
+    setOpen(false);
+    // TODO: endpoint not yet available — surface a user-friendly notice.
+    toast.info('Resend email — coming soon');
+  };
+
+  return (
+    <div ref={ref} style={{ position: 'relative' }}>
+      <button
+        type="button"
+        onClick={(e) => { e.stopPropagation(); setOpen(v => !v); }}
+        style={{
+          width: 28, height: 28, display: 'flex', alignItems: 'center', justifyContent: 'center',
+          borderRadius: 4, background: 'none', border: 'none',
+          color: 'var(--txt3)', cursor: 'pointer',
+        }}
+        onMouseEnter={e => { (e.currentTarget as HTMLElement).style.background = 'var(--surface-hover)'; }}
+        onMouseLeave={e => { (e.currentTarget as HTMLElement).style.background = 'none'; }}
+        aria-label="Row actions"
+      >
+        <MoreHorizontal size={14} />
+      </button>
+      {open && (
+        <div
+          style={{
+            position: 'absolute', right: 0, top: '100%', marginTop: 4,
+            minWidth: 180, zIndex: 10,
+            background: 'var(--surface)',
+            border: '1px solid var(--border-sub)',
+            borderRadius: 6,
+            boxShadow: '0 4px 16px rgba(0,0,0,0.22)',
+            padding: 4,
+          }}
+          onClick={e => e.stopPropagation()}
+        >
+          <MenuItem icon={<ExternalLink size={12} />} label="Open" onClick={() => { setOpen(false); onOpen(); }} />
+          <MenuItem icon={<Download size={12} />} label="Download PDF" onClick={() => { setOpen(false); onDownload(); }} disabled={!row.has_signed_document && !row.has_original_document} />
+          {isHod && (
+            <MenuItem icon={<Mail size={12} />} label="Resend email" onClick={handleResendEmail} />
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function MenuItem({
+  icon, label, onClick, disabled = false,
+}: {
+  icon: React.ReactNode;
+  label: string;
+  onClick: () => void;
+  disabled?: boolean;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      disabled={disabled}
+      style={{
+        width: '100%',
+        display: 'flex', alignItems: 'center', gap: 8,
+        padding: '7px 10px',
+        border: 'none', background: 'none',
+        color: disabled ? 'var(--txt-ghost)' : 'var(--txt2)',
+        fontSize: 12, fontFamily: 'var(--font-sans)',
+        cursor: disabled ? 'not-allowed' : 'pointer',
+        borderRadius: 4,
+        textAlign: 'left',
+      }}
+      onMouseEnter={e => { if (!disabled) (e.currentTarget as HTMLElement).style.background = 'var(--surface-hover)'; }}
+      onMouseLeave={e => { (e.currentTarget as HTMLElement).style.background = 'none'; }}
+    >
+      {icon}
+      <span>{label}</span>
+    </button>
+  );
+}
+
+// ============================================================================
+// SKELETON ROW
+// ============================================================================
+
+function SkeletonRow() {
+  return (
+    <div style={{
+      display: 'flex', alignItems: 'center',
+      height: 44, padding: '0 12px',
+      borderTop: '1px solid var(--border-faint)',
+    }}>
+      {[180, 180, 140, 130, 130, 100].map((w, i) => (
+        <div key={i} style={{
+          width: w, height: 12, marginRight: 12,
+          borderRadius: 3, background: 'var(--border-sub)', opacity: 0.5,
+        }} />
+      ))}
+    </div>
+  );
+}
+
+// ============================================================================
+// MAIN COMPONENT
+// ============================================================================
+
+// Column widths sum = table minimum; table is horizontally scrollable if needed.
+const COL_WIDTHS = {
+  generated: '160px',
+  rotation: '200px',
+  outgoing: '200px',
+  hod: '160px',
+  incoming: '200px',
+  status: '140px',
+  kebab: '40px',
+};
+
+export function ExportedHandoversView() {
+  const router = useRouter();
+  const { user } = useAuth();
+
+  const userRole = (user as { role?: string } | null)?.role || '';
+  const userId = user?.id || '';
+  const isHod = HOD_ROLES.has(userRole);
+
+  const [data, setData] = React.useState<HandoverExportListResponse | null>(null);
+  const [loading, setLoading] = React.useState(false);
+  const [error, setError] = React.useState<string | null>(null);
+  const [sortKey, setSortKey] = React.useState<SortKey>('exported_at');
+  const [sortDir, setSortDir] = React.useState<SortDir>('desc');
+  const [downloadingId, setDownloadingId] = React.useState<string | null>(null);
+
+  const load = React.useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const result = await fetchHandoverExports();
+      setData(result);
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : 'Failed to load exports';
+      setError(msg);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  React.useEffect(() => { load(); }, [load]);
+
+  const handleSort = React.useCallback((key: SortKey) => {
+    setSortKey(prev => {
+      if (prev === key) {
+        setSortDir(d => (d === 'asc' ? 'desc' : 'asc'));
+        return prev;
+      }
+      setSortDir('desc');
+      return key;
+    });
+  }, []);
+
+  const sortedRows = React.useMemo(() => {
+    if (!data) return [];
+    const rows = [...data.exports];
+    rows.sort((a, b) => {
+      const av = getSortValue(a, sortKey);
+      const bv = getSortValue(b, sortKey);
+      if (av === bv) return 0;
+      const cmp = av < bv ? -1 : 1;
+      return sortDir === 'asc' ? cmp : -cmp;
+    });
+    return rows;
+  }, [data, sortKey, sortDir]);
+
+  const handleOpen = React.useCallback((id: string) => {
+    router.push(`/handover-export/${id}`);
+  }, [router]);
+
+  const handleDownload = React.useCallback(async (id: string) => {
+    setDownloadingId(id);
+    try {
+      const signed = await mintHandoverExportSignedUrl(id);
+      window.open(signed.url, '_blank', 'noopener,noreferrer');
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : 'Failed to open document');
+    } finally {
+      setDownloadingId(null);
+    }
+  }, []);
+
+  // ── Error state ───────────────────────────────────────────────────────────
+  if (error && !loading) {
+    return (
+      <div style={{
+        display: 'flex', flexDirection: 'column', alignItems: 'center',
+        justifyContent: 'center', padding: '60px 24px', textAlign: 'center', gap: 8,
+      }}>
+        <div style={{ fontSize: 14, fontWeight: 500, color: 'var(--txt2)' }}>Failed to load exported handovers</div>
+        <div style={{ fontSize: 12, color: 'var(--txt-ghost)', marginBottom: 8 }}>{error}</div>
+        <button
+          onClick={load}
+          style={{
+            display: 'flex', alignItems: 'center', gap: 6, padding: '8px 14px',
+            borderRadius: 6, fontSize: 12, fontWeight: 500, cursor: 'pointer',
+            border: '1px solid var(--border-sub)', background: 'none', color: 'var(--txt2)',
+            fontFamily: 'var(--font-sans)',
+          }}
+        >
+          <RefreshCw size={12} /> Retry
+        </button>
+      </div>
+    );
+  }
+
+  const totalCount = data?.total_count ?? 0;
+  const shown = data?.count ?? 0;
+  const showingAll = totalCount <= shown;
+
+  return (
+    <div style={{ padding: '16px 16px 32px', height: '100%', overflow: 'auto' }}>
+      {/* Header row */}
+      <div style={{
+        display: 'flex', alignItems: 'center', justifyContent: 'space-between',
+        marginBottom: 12,
+      }}>
+        <div>
+          <div style={{ fontSize: 13, fontWeight: 600, color: 'var(--txt)' }}>Exported Handovers</div>
+          <div style={{ fontSize: 11, color: 'var(--txt3)', fontFamily: 'var(--font-mono)', marginTop: 2 }}>
+            {loading
+              ? 'Loading…'
+              : shown === 0
+                ? 'No exported handovers yet'
+                : showingAll
+                  ? `${shown} total`
+                  : `Showing latest ${shown} of ${totalCount}`}
+          </div>
+        </div>
+        <button
+          onClick={load}
+          disabled={loading}
+          style={{
+            display: 'flex', alignItems: 'center', gap: 5, padding: '6px 10px',
+            borderRadius: 5, fontSize: 11, fontWeight: 500, cursor: 'pointer',
+            border: '1px solid var(--border-sub)', background: 'none', color: 'var(--txt3)',
+            fontFamily: 'var(--font-sans)', opacity: loading ? 0.5 : 1,
+          }}
+        >
+          <RefreshCw size={11} style={loading ? { animation: 'spin 0.8s linear infinite' } : {}} /> Refresh
+        </button>
+      </div>
+
+      {/* Table */}
+      <div style={{
+        background: 'var(--surface)',
+        borderTop: '1px solid var(--border-top)',
+        borderRight: '1px solid var(--border-side)',
+        borderBottom: '1px solid var(--border-bottom)',
+        borderLeft: '1px solid var(--border-side)',
+        borderRadius: 6,
+        overflow: 'hidden',
+      }}>
+        {/* Column header row (glass) */}
+        <div style={{
+          display: 'flex',
+          alignItems: 'center',
+          height: 36,
+          background: 'var(--surface-glass, var(--surface))',
+          backdropFilter: 'blur(10px)',
+          WebkitBackdropFilter: 'blur(10px)',
+          borderBottom: '1px solid var(--border-sub)',
+        }}>
+          <SortableHeader label="Generated" colKey="exported_at" active={sortKey === 'exported_at'} dir={sortDir} onClick={handleSort} width={COL_WIDTHS.generated} />
+          <SortableHeader label="Rotation" colKey="period_start" active={sortKey === 'period_start'} dir={sortDir} onClick={handleSort} width={COL_WIDTHS.rotation} />
+          <SortableHeader label="Outgoing" colKey="outgoing_user_name" active={sortKey === 'outgoing_user_name'} dir={sortDir} onClick={handleSort} width={COL_WIDTHS.outgoing} />
+          <SortableHeader label="HOD signed" colKey="hod_signed_at" active={sortKey === 'hod_signed_at'} dir={sortDir} onClick={handleSort} width={COL_WIDTHS.hod} />
+          <SortableHeader label="Incoming signed" colKey="incoming_signed_at" active={sortKey === 'incoming_signed_at'} dir={sortDir} onClick={handleSort} width={COL_WIDTHS.incoming} />
+          <SortableHeader label="Status" colKey="review_status" active={sortKey === 'review_status'} dir={sortDir} onClick={handleSort} width={COL_WIDTHS.status} />
+          <div style={{ width: COL_WIDTHS.kebab }} />
+        </div>
+
+        {/* Body */}
+        {loading ? (
+          <>
+            {[0, 1, 2, 3, 4].map(i => <SkeletonRow key={i} />)}
+          </>
+        ) : sortedRows.length === 0 ? (
+          <div style={{
+            padding: '60px 24px',
+            textAlign: 'center',
+            color: 'var(--txt3)',
+            fontSize: 12,
+          }}>
+            <FileText size={22} style={{ color: 'var(--txt-ghost)', marginBottom: 8 }} />
+            <div style={{ fontSize: 13, color: 'var(--txt2)', fontWeight: 500, marginBottom: 4 }}>
+              No exported handovers yet
+            </div>
+            <div style={{ fontSize: 11, color: 'var(--txt-ghost)', fontFamily: 'var(--font-sans)' }}>
+              Generate one from your Draft tab.
+            </div>
+          </div>
+        ) : (
+          sortedRows.map(row => (
+            <ExportedRow
+              key={row.id}
+              row={row}
+              isHod={isHod}
+              currentUserRole={userRole}
+              currentUserId={userId}
+              downloading={downloadingId === row.id}
+              onRowClick={() => handleOpen(row.id)}
+              onOpen={() => handleOpen(row.id)}
+              onDownload={() => handleDownload(row.id)}
+            />
+          ))
+        )}
+      </div>
+
+      <style>{`@keyframes spin { to { transform: rotate(360deg); } }`}</style>
+    </div>
+  );
+}
+
+// ============================================================================
+// ROW
+// ============================================================================
+
+function ExportedRow({
+  row, isHod, currentUserRole, currentUserId, downloading,
+  onRowClick, onOpen, onDownload,
+}: {
+  row: HandoverExportListItem;
+  isHod: boolean;
+  currentUserRole: string;
+  currentUserId: string;
+  downloading: boolean;
+  onRowClick: () => void;
+  onOpen: () => void;
+  onDownload: () => void;
+}) {
+  const status = resolveStatusPill(row);
+
+  // Red "Incoming signed" cell when: this user should sign, handover is complete,
+  // but incoming has not been signed yet.
+  const incomingOverdueForMe =
+    !row.incoming_signed_at &&
+    row.review_status === 'complete' &&
+    row.incoming_role === currentUserRole &&
+    currentUserRole !== '' &&
+    row.incoming_user_id !== currentUserId; // user hasn't claimed the row yet
+
+  const rotation = row.period_start && row.period_end
+    ? `${formatDate(row.period_start)} → ${formatDate(row.period_end)}`
+    : '—';
+
+  return (
+    <div
+      role="button"
+      tabIndex={0}
+      onClick={onRowClick}
+      onKeyDown={(e) => { if (e.key === 'Enter') onRowClick(); }}
+      style={{
+        display: 'flex',
+        alignItems: 'center',
+        minHeight: 44,
+        borderTop: '1px solid var(--border-faint)',
+        cursor: 'pointer',
+        transition: 'background 60ms',
+      }}
+      onMouseEnter={e => { (e.currentTarget as HTMLElement).style.background = 'var(--surface-hover)'; }}
+      onMouseLeave={e => { (e.currentTarget as HTMLElement).style.background = ''; }}
+    >
+      {/* Generated */}
+      <div style={{
+        width: COL_WIDTHS.generated, padding: '0 12px',
+        fontSize: 12, fontFamily: 'var(--font-mono)', color: 'var(--txt2)',
+        whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis',
+      }}>
+        {formatTimestamp(row.exported_at)}
+      </div>
+
+      {/* Rotation */}
+      <div style={{
+        width: COL_WIDTHS.rotation, padding: '0 12px',
+        fontSize: 12, fontFamily: 'var(--font-mono)', color: 'var(--txt2)',
+        whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis',
+      }}>
+        {rotation}
+      </div>
+
+      {/* Outgoing (name + role) */}
+      <div style={{
+        width: COL_WIDTHS.outgoing, padding: '0 12px',
+        display: 'flex', flexDirection: 'column', justifyContent: 'center', gap: 2,
+        minWidth: 0,
+      }}>
+        <div style={{
+          fontSize: 13, fontWeight: 500, color: 'var(--txt)',
+          whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis',
+        }}>
+          {row.outgoing_user_name || '—'}
+        </div>
+        {row.outgoing_role && (
+          <div style={{
+            fontSize: 10, fontFamily: 'var(--font-mono)', color: 'var(--txt3)',
+            whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis',
+          }}>
+            {roleLabel(row.outgoing_role)}
+          </div>
+        )}
+      </div>
+
+      {/* HOD signed */}
+      <div style={{
+        width: COL_WIDTHS.hod, padding: '0 12px',
+        fontSize: 12, fontFamily: 'var(--font-mono)',
+        color: row.hod_signed_at ? 'var(--txt2)' : 'var(--txt-ghost)',
+        whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis',
+      }}>
+        {formatTimestamp(row.hod_signed_at)}
+      </div>
+
+      {/* Incoming signed (name + role + timestamp, dim/red rules) */}
+      <div style={{
+        width: COL_WIDTHS.incoming, padding: '0 12px',
+        display: 'flex', flexDirection: 'column', justifyContent: 'center', gap: 2,
+        minWidth: 0,
+      }}>
+        {row.incoming_user_name || row.incoming_role ? (
+          <>
+            <div style={{
+              fontSize: 13, fontWeight: 500,
+              color: row.incoming_signed_at
+                ? 'var(--txt)'
+                : incomingOverdueForMe ? 'var(--red)' : 'var(--txt-ghost)',
+              whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis',
+            }}>
+              {row.incoming_user_name || roleLabel(row.incoming_role || '')}
+            </div>
+            <div style={{
+              fontSize: 10, fontFamily: 'var(--font-mono)',
+              color: row.incoming_signed_at
+                ? 'var(--txt3)'
+                : incomingOverdueForMe ? 'var(--red)' : 'var(--txt-ghost)',
+              whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis',
+            }}>
+              {row.incoming_signed_at ? formatTimestamp(row.incoming_signed_at) : 'awaiting signature'}
+            </div>
+          </>
+        ) : (
+          <div style={{
+            fontSize: 12, fontFamily: 'var(--font-mono)', color: 'var(--txt-ghost)',
+          }}>
+            —
+          </div>
+        )}
+      </div>
+
+      {/* Status pill */}
+      <div style={{
+        width: COL_WIDTHS.status, padding: '0 12px',
+        display: 'flex', alignItems: 'center',
+      }}>
+        <span style={{
+          display: 'inline-flex', alignItems: 'center',
+          padding: '3px 8px', borderRadius: 3,
+          fontSize: 10, fontWeight: 600, letterSpacing: '0.02em',
+          fontFamily: 'var(--font-sans)',
+          color: status.fg,
+          background: status.bg,
+          border: `1px solid ${status.border}33`,
+          whiteSpace: 'nowrap',
+        }}>
+          {status.label}
+        </span>
+      </div>
+
+      {/* Kebab */}
+      <div style={{
+        width: COL_WIDTHS.kebab,
+        display: 'flex', alignItems: 'center', justifyContent: 'center',
+        flexShrink: 0,
+      }}>
+        {downloading
+          ? <Loader2 size={13} style={{ color: 'var(--txt-ghost)', animation: 'spin 0.8s linear infinite' }} />
+          : <KebabMenu row={row} isHod={isHod} onOpen={onOpen} onDownload={onDownload} />
+        }
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/handover/HandoverDraftPanel.tsx
+++ b/apps/web/src/components/handover/HandoverDraftPanel.tsx
@@ -24,6 +24,13 @@ import { useAuth } from '@/hooks/useAuth';
 import { useActiveVessel } from '@/contexts/VesselContext';
 import { getEntityRoute } from '@/lib/entityRoutes';
 import { toast } from 'sonner';
+import { ConfirmExportModal } from './ConfirmExportModal';
+import {
+  AddDraftItemModal,
+  type AddDraftEntityKey,
+  type AddDraftPickerItem,
+  type AddDraftItemSubmitPayload,
+} from './AddDraftItemModal';
 
 const RENDER_API_URL = process.env.NEXT_PUBLIC_API_URL || 'https://pipeline-core.int.celeste7.ai';
 
@@ -600,6 +607,62 @@ export function HandoverDraftPanel({ isOpen, onClose, variant = 'drawer' }: Hand
     fetchItems();
   }, [user?.id, activeVesselId, user?.yachtId, fetchItems]);
 
+  // ── Entity picker loader for Add Draft Item modal ──
+  // Hits the new /v1/handover/pickers/{entity_type} endpoint (yacht-scoped,
+  // alphabetical). Fetched lazily on key switch so we only pull a list when
+  // the user actually picks a domain.
+  const loadPickerEntities = useCallback(async (
+    key: Exclude<AddDraftEntityKey, 'location'>,
+  ): Promise<AddDraftPickerItem[]> => {
+    const { data: sessionData } = await supabase.auth.getSession();
+    const token = sessionData?.session?.access_token;
+    if (!token) throw new Error('Not authenticated');
+    const res = await fetch(`${RENDER_API_URL}/v1/handover/pickers/${key}`, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    if (!res.ok) {
+      const err = await res.json().catch(() => ({}));
+      throw new Error(err.detail || `Failed to load ${key} list (${res.status})`);
+    }
+    const json = await res.json();
+    return (json.items || []) as AddDraftPickerItem[];
+  }, []);
+
+  // ── Submit handler for Add Draft Item modal ──
+  // Single POST to the canonical add_to_handover action. Location entries are
+  // sent as entity_type='note' with the label prepended into summary — the
+  // existing handler accepts this natively (entity_id null allowed for notes).
+  const handleAddDraftItem = useCallback(async (payload: AddDraftItemSubmitPayload) => {
+    if (!user?.id) throw new Error('Not authenticated');
+    const { data: sessionData } = await supabase.auth.getSession();
+    const token = sessionData?.session?.access_token;
+    if (!token) throw new Error('Not authenticated');
+
+    const body = {
+      action: 'add_to_handover',
+      context: { yacht_id: activeVesselId || user.yachtId },
+      payload: {
+        entity_type: payload.entity_type,
+        entity_id: payload.entity_id,
+        summary: payload.summary,
+        category: 'standard',
+        ...(payload.notes ? { action_summary: payload.notes } : {}),
+        ...(payload.location_label ? { metadata: { location_label: payload.location_label } } : {}),
+      },
+    };
+    const res = await fetch(`${RENDER_API_URL}/v1/actions/execute`, {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    });
+    if (!res.ok) {
+      const err = await res.json().catch(() => ({}));
+      throw new Error(err.message || err.detail || `Add failed (${res.status})`);
+    }
+    toast.success('Draft item added');
+    fetchItems();
+  }, [user?.id, activeVesselId, user?.yachtId, fetchItems]);
+
   // ── Delete (soft) — routed through Render API ──
   const handleDelete = useCallback(async (id: string) => {
     if (!user?.id) return;
@@ -620,6 +683,16 @@ export function HandoverDraftPanel({ isOpen, onClose, variant = 'drawer' }: Hand
   }, [user?.id, fetchItems]);
 
   // ── Export ──
+  // `handleExport` runs the actual POST. It is invoked either directly (if
+  // no confirm modal is shown) or from the ConfirmExportModal onConfirm.
+  // `requestExport` is the user-facing click handler that opens the confirm
+  // modal first — matching the subbar "Create Handover" flow wired in
+  // AppShell so both entry points get the same guardrail.
+  const [confirmExportOpen, setConfirmExportOpen] = useState(false);
+  const requestExport = useCallback(() => {
+    if (!user?.id || !(activeVesselId || user?.yachtId) || items.length === 0) return;
+    setConfirmExportOpen(true);
+  }, [user?.id, activeVesselId, user?.yachtId, items.length]);
   const handleExport = useCallback(async () => {
     if (!user?.id || !(activeVesselId || user?.yachtId) || items.length === 0) return;
     setExporting(true);
@@ -735,7 +808,7 @@ export function HandoverDraftPanel({ isOpen, onClose, variant = 'drawer' }: Hand
         {/* Actions */}
         <div style={S.actionBar}>
           <button
-            onClick={handleExport}
+            onClick={requestExport}
             disabled={exporting || items.length === 0}
             style={{
               display: 'flex', alignItems: 'center', gap: 6,
@@ -759,7 +832,7 @@ export function HandoverDraftPanel({ isOpen, onClose, variant = 'drawer' }: Hand
               cursor: 'pointer', fontFamily: 'var(--font-sans)',
             }}
           >
-            <Plus size={12} /> Add Note
+            <Plus size={12} /> Add Draft Item
           </button>
         </div>
 
@@ -855,20 +928,55 @@ export function HandoverDraftPanel({ isOpen, onClose, variant = 'drawer' }: Hand
     </div>
   );
 
+  // Shared confirm modal — mirrors the subbar entry's guardrail so the
+  // in-page "Export Handover" button also gets the pre-flight summary.
+  const confirmModal = (
+    <ConfirmExportModal
+      open={confirmExportOpen}
+      itemCount={items.length}
+      isExporting={exporting}
+      onConfirm={async () => {
+        await handleExport();
+        setConfirmExportOpen(false);
+      }}
+      onClose={() => setConfirmExportOpen(false)}
+    />
+  );
+
+  // `add` mode uses the new AddDraftItemModal (key/value entity selection).
+  // `edit` and `delete` still render the legacy ItemPopup — preserved so
+  // existing flows keep working while only the "Add" flow is rebuilt.
+  const renderPopup = () => {
+    if (!popup) return null;
+    if (popup.type === 'add') {
+      return (
+        <AddDraftItemModal
+          open
+          onClose={() => setPopup(null)}
+          loadEntities={loadPickerEntities}
+          onSubmit={handleAddDraftItem}
+          userReady={userReady}
+        />
+      );
+    }
+    return (
+      <ItemPopup
+        mode={popup}
+        onClose={() => setPopup(null)}
+        onSave={handleSave}
+        onDelete={handleDelete}
+        onSwitchToDelete={(item) => setPopup({ type: 'delete', item })}
+        userReady={userReady}
+      />
+    );
+  };
+
   if (variant === 'page') {
     return (
       <>
         {content}
-        {popup && (
-          <ItemPopup
-            mode={popup}
-            onClose={() => setPopup(null)}
-            onSave={handleSave}
-            onDelete={handleDelete}
-            onSwitchToDelete={(item) => setPopup({ type: 'delete', item })}
-            userReady={userReady}
-          />
-        )}
+        {renderPopup()}
+        {confirmModal}
       </>
     );
   }
@@ -878,16 +986,8 @@ export function HandoverDraftPanel({ isOpen, onClose, variant = 'drawer' }: Hand
       {/* Backdrop */}
       <div style={{ ...S.backdrop, opacity: 1, pointerEvents: 'auto' }} onClick={onClose} />
       {content}
-      {/* Popup */}
-      {popup && (
-        <ItemPopup
-          mode={popup}
-          onClose={() => setPopup(null)}
-          onSave={handleSave}
-          onDelete={handleDelete}
-          onSwitchToDelete={(item) => setPopup({ type: 'delete', item })}
-        />
-      )}
+      {renderPopup()}
+      {confirmModal}
     </>
   );
 }

--- a/apps/web/src/components/handover/HandoverQueueView.tsx
+++ b/apps/web/src/components/handover/HandoverQueueView.tsx
@@ -363,9 +363,19 @@ export function HandoverQueueView() {
     );
   }
 
-  const totalItems = data
-    ? (data.open_faults.length + data.overdue_work_orders.length + data.low_stock_parts.length + data.pending_orders.length)
-    : 0;
+  // Subheader copy — we deliberately avoid a single "N items detected" number.
+  // The backend caps each section at 20 rows (p0_actions_routes.py:2357/2370/
+  // 2391/2402), so a real yacht with 3,000+ open items still shows "80"; the
+  // number is honest at the per-section level (each group-heading below shows
+  // its own count) but misleading as a top-line total. Instead we render an
+  // action-oriented prompt plus the one count the user controls — how many
+  // items they've already added to their own draft.
+  const queuedCount = alreadyQueued.size;
+  const subheaderCopy = loading
+    ? 'Loading…'
+    : queuedCount === 0
+      ? 'Pick items to add to your draft'
+      : `Pick items to add to your draft · ${queuedCount} already in draft`;
 
   return (
     <div style={{ padding: '16px 16px 32px' }}>
@@ -377,7 +387,7 @@ export function HandoverQueueView() {
         <div>
           <div style={{ fontSize: 13, fontWeight: 600, color: 'var(--txt)' }}>Handover Queue</div>
           <div style={{ fontSize: 11, color: 'var(--txt3)', fontFamily: 'var(--font-mono)', marginTop: 2 }}>
-            {loading ? 'Loading…' : `${totalItems} items detected · ${alreadyQueued.size} added to draft`}
+            {subheaderCopy}
           </div>
         </div>
         <button

--- a/apps/web/src/components/handover/useHandoverExport.ts
+++ b/apps/web/src/components/handover/useHandoverExport.ts
@@ -1,0 +1,196 @@
+'use client';
+
+/**
+ * useHandoverExport — Shared handover export flow.
+ *
+ * Extracted from HandoverDraftPanel.handleExport so the Subbar "Create Handover"
+ * primary action button (AppShell.handlePrimaryAction for the 'handover-export'
+ * domain) can trigger the exact same backend flow without duplicating logic.
+ *
+ * The hook:
+ *   1. Loads the caller's queued handover_items via GET /v1/handover/items
+ *      (filtered server-side by user + not-exported). Exposes `items` +
+ *      `itemCount` + `loading` so callers can guard the button.
+ *   2. Exposes `exportHandover()` which:
+ *        a. POST /v1/handover/export { export_type: 'html', filter_by_user: true }
+ *        b. POST /v1/handover/items/mark-exported { item_ids: items.map(i=>i.id) }
+ *        c. Routes to /handover-export/{export_id}
+ *      — exactly mirroring HandoverDraftPanel's original handler.
+ *   3. Exposes `isExporting` for loading state.
+ *
+ * B4 will wrap the trigger in a pre-export confirm modal. This hook is shaped
+ * so B4 can simply gate the click on confirm → then call `exportHandover()`.
+ * No transformation of the hook body is required.
+ *
+ * Backend endpoints used:
+ *   - GET  {NEXT_PUBLIC_API_URL}/v1/handover/items            (fetch queued)
+ *   - POST {NEXT_PUBLIC_API_URL}/v1/handover/export           (generate)
+ *   - POST {NEXT_PUBLIC_API_URL}/v1/handover/items/mark-exported  (clear queue)
+ */
+
+import { useCallback, useEffect, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { toast } from 'sonner';
+import { supabase } from '@/lib/supabaseClient';
+import { useAuth } from '@/hooks/useAuth';
+import { useActiveVessel } from '@/contexts/VesselContext';
+
+const RENDER_API_URL = process.env.NEXT_PUBLIC_API_URL || 'https://pipeline-core.int.celeste7.ai';
+
+interface HandoverItem {
+  id: string;
+}
+
+export interface UseHandoverExportOptions {
+  /**
+   * When false the hook does not fetch the queued-items list on mount.
+   * `exportHandover()` still works but will lazily refresh first.
+   * Default true. Callers mounted on non-handover pages (e.g. AppShell on
+   * every route) should pass `enabled: activeDomain === 'handover-export'`
+   * to avoid a useless GET on every page load.
+   */
+  enabled?: boolean;
+}
+
+export interface UseHandoverExportResult {
+  /** Raw queued items belonging to the current user (not-exported). */
+  items: HandoverItem[];
+  /** Convenience count for disabled/empty-state UI. */
+  itemCount: number;
+  /** True while the initial items fetch is in-flight. */
+  loading: boolean;
+  /** True while the export POST + mark-exported POST are running. */
+  isExporting: boolean;
+  /**
+   * Fire the full export flow (POST /v1/handover/export → mark-exported →
+   * route to /handover-export/{id}). Safe no-op when there are no items or
+   * auth is not ready — callers should typically disable their trigger in
+   * those cases for a better UX.
+   */
+  exportHandover: () => Promise<void>;
+  /** Manual refresh of the queued items list (e.g. after adding a draft item). */
+  refresh: () => Promise<void>;
+}
+
+export function useHandoverExport(opts: UseHandoverExportOptions = {}): UseHandoverExportResult {
+  const { enabled = true } = opts;
+  const { user } = useAuth();
+  const { vesselId: activeVesselId } = useActiveVessel();
+  const router = useRouter();
+
+  const [items, setItems] = useState<HandoverItem[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [isExporting, setIsExporting] = useState(false);
+
+  // ── Fetch queued items (same endpoint HandoverDraftPanel uses) ─────────────
+  // We only need the ids here (for mark-exported + count), so we keep the
+  // shape minimal — the draft panel keeps its own rich local state for
+  // rendering, this hook is only about the export trigger.
+  const refresh = useCallback(async () => {
+    if (!enabled || !user?.id) return;
+    setLoading(true);
+    try {
+      const { data: sessionData } = await supabase.auth.getSession();
+      const token = sessionData?.session?.access_token;
+      if (!token) {
+        setItems([]);
+        return;
+      }
+      const res = await fetch(`${RENDER_API_URL}/v1/handover/items`, {
+        headers: { Authorization: `Bearer ${token}` },
+      });
+      if (!res.ok) {
+        // Silent failure — button will fall back to disabled state.
+        setItems([]);
+        return;
+      }
+      const body = await res.json();
+      const fetched: HandoverItem[] = Array.isArray(body?.items)
+        ? body.items.map((i: { id: string }) => ({ id: i.id }))
+        : [];
+      setItems(fetched);
+    } catch {
+      setItems([]);
+    } finally {
+      setLoading(false);
+    }
+  }, [enabled, user?.id]);
+
+  useEffect(() => {
+    if (!enabled) return;
+    void refresh();
+  }, [enabled, refresh]);
+
+  // ── Export — mirrors HandoverDraftPanel.handleExport exactly ──────────────
+  const exportHandover = useCallback(async () => {
+    if (!user?.id || !(activeVesselId || user?.yachtId)) return;
+    if (items.length === 0) {
+      // Mirror the draft panel's empty-state behaviour: show a friendly
+      // toast instead of silently no-op'ing so the user knows why nothing
+      // happened when they click via the subbar (which has no drawer view
+      // of the queue alongside it).
+      toast.info('Add items to your draft first');
+      return;
+    }
+
+    setIsExporting(true);
+    const pendingToastId = toast.info(
+      'Generating handover — this may take up to 2 minutes',
+      { duration: 120_000 }
+    );
+    try {
+      const { data: sessionData } = await supabase.auth.getSession();
+      const token = sessionData?.session?.access_token;
+      if (!token) throw new Error('Authentication required — please log in again');
+
+      const response = await fetch(`${RENDER_API_URL}/v1/handover/export`, {
+        method: 'POST',
+        headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
+        body: JSON.stringify({ export_type: 'html', filter_by_user: true }),
+      });
+      if (!response.ok) {
+        const err = await response.json().catch(() => ({ detail: 'Export failed' }));
+        throw new Error(err.detail || `Export failed (${response.status})`);
+      }
+      const result = await response.json();
+
+      // Mark items exported via Render API (not direct supabase — wrong DB).
+      await fetch(`${RENDER_API_URL}/v1/handover/items/mark-exported`, {
+        method: 'POST',
+        headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
+        body: JSON.stringify({ item_ids: items.map((i) => i.id) }),
+      });
+
+      toast.dismiss(pendingToastId);
+      toast.success(`Handover exported — ${result.total_items ?? items.length} items`, {
+        duration: 10_000,
+        action: {
+          label: 'View',
+          onClick: () => router.push(`/handover-export/${result.export_id}`),
+        },
+      });
+
+      // Navigate straight to the export view — matches draft-panel intent
+      // (it offered a "View" button; from the subbar we drive the user there
+      // directly since the subbar click is itself the primary action).
+      router.push(`/handover-export/${result.export_id}`);
+
+      // Refresh the local list so the next click sees the cleared queue.
+      await refresh();
+    } catch (err) {
+      toast.dismiss(pendingToastId);
+      toast.error(err instanceof Error ? err.message : 'Failed to export handover');
+    } finally {
+      setIsExporting(false);
+    }
+  }, [user?.id, user?.yachtId, activeVesselId, items, router, refresh]);
+
+  return {
+    items,
+    itemCount: items.length,
+    loading,
+    isExporting,
+    exportHandover,
+    refresh,
+  };
+}

--- a/apps/web/src/components/lens-v2/entity/HandoverContent.tsx
+++ b/apps/web/src/components/lens-v2/entity/HandoverContent.tsx
@@ -359,6 +359,31 @@ export function HandoverContent() {
     ? { disabled: false, disabled_reason: null }
     : null;
 
+  // ── First-open acknowledgement prompt (Issue 10, part 2) ─────────────────
+  // When an incoming crew member opens a completed handover they must still
+  // sign to close the compliance chain. The sign block sits far down the
+  // page; users routinely miss it. Fire a one-shot toast the first time the
+  // lens is opened for a given export id + user, with a jump-to action.
+  const PROMPT_STORAGE_PREFIX = 'handover-ack-prompted:';
+  React.useEffect(() => {
+    if (!canAcknowledge || !entityId || !user?.id) return;
+    if (typeof window === 'undefined') return;
+    const key = `${PROMPT_STORAGE_PREFIX}${user.id}:${entityId}`;
+    if (window.sessionStorage.getItem(key)) return;
+    window.sessionStorage.setItem(key, '1');
+    toast.info('This handover needs your acknowledgement', {
+      description: 'Review and sign at the bottom of the page to close the handover.',
+      duration: 8_000,
+      action: {
+        label: 'Go to sign-off',
+        onClick: () => {
+          const el = document.querySelector('[data-handover-sign-block]') as HTMLElement | null;
+          if (el) el.scrollIntoView({ behavior: 'smooth', block: 'center' });
+        },
+      },
+    });
+  }, [canAcknowledge, entityId, user?.id]);
+
   // BACKEND_AUTO moved to mapActionFields.ts
   const [actionPopupConfig, setActionPopupConfig] = React.useState<{
     actionId: string; title: string; fields: ActionPopupField[]; signatureLevel: 0|1|2|3|4|5;
@@ -877,6 +902,7 @@ export function HandoverContent() {
             </div>
 
             {/* ── Signature Block (dynamic: outgoing / HOD / incoming) ── */}
+            <div data-handover-sign-block>
             <SignatureBlock
               outgoing={{
                 name: (user_sig?.signer_name as string | undefined) ?? from_crew,
@@ -899,6 +925,7 @@ export function HandoverContent() {
                   : undefined,
               }}
             />
+            </div>
 
             {/* ── Footer ── */}
             <div style={{

--- a/apps/web/src/components/shell/AppShell.tsx
+++ b/apps/web/src/components/shell/AppShell.tsx
@@ -41,6 +41,8 @@ import { ReportFaultModal } from '@/components/modals/ReportFaultModal';
 import { FileWarrantyClaimModal } from '@/components/lens-v2/actions/FileWarrantyClaimModal';
 import { AttachmentUploadModal } from '@/components/lens-v2/actions/AttachmentUploadModal';
 import { LedgerPanel } from '@/components/ledger';
+import { useHandoverExport } from '@/components/handover/useHandoverExport';
+import { ConfirmExportModal } from '@/components/handover/ConfirmExportModal';
 import { useQueryClient } from '@tanstack/react-query';
 import { getAuthHeaders, getYachtId } from '@/lib/authHelpers';
 import { useAuth } from '@/hooks/useAuth';
@@ -144,10 +146,15 @@ export function AppShell({ children }: AppShellProps) {
   // - warranties: crew cannot file claims (HOD+ only)
   // - documents: crew cannot upload (HOD+ only) — backend returns 403, but
   //   the button must also be disabled/hidden so crew don't see a broken action.
+  // - handover-export: disabled while the user's draft is empty, so the
+  //   "Create Handover" button in the subbar doesn't kick off an export
+  //   that the backend would reject with 0 items.
   const { user } = useAuth();
+  const handoverExport = useHandoverExport({ enabled: activeDomain === 'handover-export' });
   const primaryActionDisabled =
     (activeDomain === 'warranties' && !isHOD(user)) ||
-    (activeDomain === 'documents' && !isHOD(user));
+    (activeDomain === 'documents' && !isHOD(user)) ||
+    (activeDomain === 'handover-export' && (handoverExport.isExporting || handoverExport.itemCount === 0));
 
   // Global search overlay state
   const [searchOpen, setSearchOpen] = React.useState(false);
@@ -160,6 +167,7 @@ export function AppShell({ children }: AppShellProps) {
   const [reportFaultOpen, setReportFaultOpen] = React.useState(false);
   const [fileWarrantyOpen, setFileWarrantyOpen] = React.useState(false);
   const [documentUploadOpen, setDocumentUploadOpen] = React.useState(false);
+  const [confirmExportOpen, setConfirmExportOpen] = React.useState(false);
 
   // React Query client — used to invalidate the documents list after an upload
   // so the newly-uploaded document appears immediately. Mirrors the pattern
@@ -192,11 +200,17 @@ export function AppShell({ children }: AppShellProps) {
       case 'documents':
         setDocumentUploadOpen(true);
         break;
+      case 'handover-export':
+        // Open the pre-export confirm first. On user confirm we invoke
+        // handoverExport.exportHandover(); the hook already drives POST
+        // /v1/handover/export + mark-exported + route-to-export-view.
+        setConfirmExportOpen(true);
+        break;
       default:
         // Domains without a create modal — navigate to domain (already there, but no-op is fine)
         break;
     }
-  }, [activeDomain]);
+  }, [activeDomain, handoverExport]);
 
   // ------------------------------------------------------------------
   // Document upload handler passed to AttachmentUploadModal in custom mode.
@@ -297,6 +311,16 @@ export function AppShell({ children }: AppShellProps) {
         description="Add a document to the vessel library. Accepted: PDF, images, office docs; max 15 MB."
         onUpload={handleDocumentUpload}
         showMetadataFields
+      />
+      <ConfirmExportModal
+        open={confirmExportOpen}
+        itemCount={handoverExport.itemCount}
+        isExporting={handoverExport.isExporting}
+        onConfirm={async () => {
+          await handoverExport.exportHandover();
+          setConfirmExportOpen(false);
+        }}
+        onClose={() => setConfirmExportOpen(false)}
       />
     </ShellProvider>
   );

--- a/apps/web/src/components/shell/api.ts
+++ b/apps/web/src/components/shell/api.ts
@@ -228,6 +228,81 @@ export function fetchHandoverQueue(vesselId: string): Promise<HandoverQueueRespo
 }
 
 /* ─────────────────────────────────────────────
+   HANDOVER — EXPORTED LIST
+   /v1/handover/exports returns the current user's
+   visible handover exports (own + same-role peer)
+   for the Exported tab on /handover-export.
+   ───────────────────────────────────────────── */
+
+export interface HandoverExportListItem {
+  id: string;
+  draft_id: string | null;
+  yacht_id: string;
+  exported_at: string;
+  period_start: string | null;
+  period_end: string | null;
+  department: string | null;
+  export_type: string | null;
+  export_status: string | null;
+  file_name: string | null;
+  document_hash: string | null;
+  outgoing_user_id: string | null;
+  outgoing_user_name: string | null;
+  outgoing_role: string | null;
+  outgoing_signed_at: string | null;
+  incoming_user_id: string | null;
+  incoming_user_name: string | null;
+  incoming_role: string | null;
+  incoming_signed_at: string | null;
+  hod_signed_at: string | null;
+  user_signed_at: string | null;
+  review_status: string | null;
+  signoff_complete: boolean | null;
+  has_signed_document: boolean;
+  has_original_document: boolean;
+}
+
+export interface HandoverExportListResponse {
+  status: string;
+  exports: HandoverExportListItem[];
+  count: number;
+  total_count: number;
+  scope: 'all' | 'own_and_same_role';
+}
+
+/** Fetch handover exports list for the Exported tab */
+export function fetchHandoverExports(): Promise<HandoverExportListResponse> {
+  return apiFetch(`/v1/handover/exports?limit=50`);
+}
+
+export interface HandoverExportSignedUrl {
+  url: string;
+  expires_at: string;
+  ttl_seconds: number;
+}
+
+/** Mint a short-TTL signed URL for a handover export document */
+export async function mintHandoverExportSignedUrl(exportId: string): Promise<HandoverExportSignedUrl> {
+  const token = await getToken();
+  if (!token) throw new Error('Not authenticated');
+
+  const res = await fetch(`${API_BASE}/v1/handover/export/${encodeURIComponent(exportId)}/signed-url`, {
+    method: 'POST',
+    headers: {
+      'Authorization': `Bearer ${token}`,
+      'Content-Type': 'application/json',
+    },
+  });
+
+  if (!res.ok) {
+    const body = await res.json().catch(() => ({}));
+    throw new Error(body?.detail || `Failed to mint signed URL (${res.status})`);
+  }
+
+  return res.json();
+}
+
+/* ─────────────────────────────────────────────
    DOMAIN ID MAPPING
    Frontend routes use hyphens, API uses underscores.
    ───────────────────────────────────────────── */

--- a/docs/ongoing_work/handover/PENDING_MIGRATIONS.md
+++ b/docs/ongoing_work/handover/PENDING_MIGRATIONS.md
@@ -1,0 +1,52 @@
+# Handover domain — pending manual migrations
+
+Per `feedback_migration_convention.md`: SQL migration files are temporary — apply to TENANT, verify, then delete from this doc.
+
+**Target DB:** TENANT `vzsohavtuotocgrfkfyd`. Do **not** run against MASTER.
+
+## HANDOVER08-M01 — drop orphaned `handover_draft_edits`
+
+**Status:** pending CEO manual apply
+**Evidence:**
+- `SELECT count(*) FROM handover_draft_edits` → **0** (probe 2026-04-23)
+- Code grep across `apps/api`, `apps/web`, `supabase/migrations` → **0** readers, **0** writers
+- Table was provisioned but never wired. Snapshot-log design was left incomplete; the surviving write path uses `handover_entries` (7,270 rows) as the immutable audit layer.
+
+**Pre-apply checks (re-run before DDL):**
+```sql
+SELECT count(*) FROM handover_draft_edits;             -- must still be 0
+SELECT count(*) FROM pg_trigger t
+  JOIN pg_class c ON c.oid = t.tgrelid
+ WHERE c.relname = 'handover_draft_edits';             -- must be 0 (no triggers)
+SELECT count(*) FROM information_schema.view_column_usage
+ WHERE table_name = 'handover_draft_edits';            -- must be 0 (no views depend on it)
+```
+
+**DDL (run as service_role):**
+```sql
+BEGIN;
+-- Drop RLS policies first so DROP TABLE doesn't error on policy dependencies.
+DROP POLICY IF EXISTS handover_draft_edits_service_all ON handover_draft_edits;
+DROP POLICY IF EXISTS handover_draft_edits_owner_read  ON handover_draft_edits;
+-- (add any other policy names the probe surfaced.)
+
+DROP TABLE IF EXISTS public.handover_draft_edits CASCADE;
+COMMIT;
+```
+
+**Post-apply verify:**
+```sql
+SELECT to_regclass('public.handover_draft_edits');     -- must return NULL
+```
+
+**Rollback plan:** none needed — table was empty and unreferenced. If regret surfaces, re-create from original migration (check git log for the CREATE TABLE DDL).
+
+---
+
+## HANDOVER08-M02 — documented, NOT dropping
+
+`handover_draft_sections` (274 rows) and `handover_draft_items` (7,235 rows) have **live data** from the microservice-snapshot write path (`handover_export_routes.py:270, 284`) but **0 readers** in current code. Do **not** drop.
+
+**Action:** document in `docs/ongoing_work/handover/ARCHITECTURE.md` as *microservice-snapshot reserved — read path is a planned feature, do not repurpose, do not truncate.*
+
+Documentation update will ship alongside the B10 doc pass.


### PR DESCRIPTION
## Summary

Handover-domain fault-list fixes (issues 8-11 in `list_of_faults.md`) plus central add_to_handover role-gating so the 9 sibling lenses can finally surface the button. Feature-branch PR; Vercel preview URL below.

### Shipped (user-facing)

- **"+ Create Handover" subbar button now works** — was a no-op; wired to existing export flow via `useHandoverExport`. Disabled when draft is empty.
- **"+ Add Note" → "+ Add Draft Item"** — new `AddDraftItemModal` with Work Order / Equipment / Parts / Fault / Location key+value picker (searchable, yacht-scoped, alphabetical). New `GET /v1/handover/pickers/{entity_type}` endpoint backs it.
- **Pre-export confirm modal** on both entry points (subbar + draft tab) — shows item count + expected destination before kicking off the LLM export.
- **First-open incoming-sign toast** — once-per-export-per-user reminder with jump-to-sign-block action.
- **Honest queue header copy** — replaces misleading "N items detected" (was the sum of per-section LIMIT 20 caps, not real counts).
- **New "Exported" tab** on `/handover-export` — list scoped to yacht + fleet + same-role back-to-back peers; HODs see all. Columns per `lens_card_upgrades.md` spec. Click → lens. Kebab → Open / Download PDF / (HOD+) Resend email.
- **`add_to_handover` now surfaces on the 9 sibling lenses** via a new central role matrix (equipment, fault, work_order, part, purchase_order, receiving, certificate, warranty, document, shopping_list). Per CEO role gating.

### Backend changes

- New: `apps/api/actions/add_to_handover_gating.py` — single dict-of-sets role matrix.
- New: `GET /v1/handover/pickers/{entity_type}` (picker endpoint for draft-item modal).
- New: `POST /v1/handover/export/{id}/signed-url` (short-TTL PDF access for Exported tab).
- Extended: `GET /v1/handover/exports` — RLS scope via `.or_()` + batched name resolution.
- Extended: `entity_prefill.py` — equipment/fault/work_order context fields per EQUIPMENT05 coord.
- Wired: `entity_actions._inject_cross_domain_actions` runs the gating matrix for `add_to_handover`.

### Cleanup (flag only in this PR — actual removal in follow-up)

DEPRECATED markers on three duplicate handlers:
- `apps/api/action_router/dispatchers/internal_dispatcher.py:860` `add_to_handover` (with runtime WARN log)
- `apps/api/routes/handlers/handover_handler.py:84` `add_to_handover`
- `apps/api/handlers/handover_handlers.py:700` `add_to_handover_execute_legacy`

### Docs

- `docs/ongoing_work/handover/PENDING_MIGRATIONS.md` — HANDOVER08-M01 DDL to drop orphan `handover_draft_edits` (0 rows, 0 refs).
- `/Users/celeste7/Desktop/lens_card_upgrades.md` — handover section (document-hero UX v2 + signature-overlay MVP + full column visibility spec + 3-tab column spec).

### Peer coordination

- **EQUIPMENT05** + **FAULT05** holding their per-lens "Add to Handover" wiring — unblocked by this PR (run `openActionPopup(getAction('add_to_handover'))` on their lens cards).
- **WORKORDER05** PR #697 — entityRoutes matrix is source-of-truth for the entity_url backfill planned in follow-up PR.

### Not in this PR — tracked follow-up

- Actual deletion of the three DEPRECATED handler paths (needs call-site tracing).
- Apply `handover_draft_edits` DROP per PENDING_MIGRATIONS.md.
- `handover_items.entity_url` backfill for pre-March null rows.
- Handover lens UX v2 (document-hero iframe) — design landed, implementation pending CEO green-light.

## Test plan
- [ ] Sign in as crew, go to `/handover-export`, verify "Pick items to add to your draft" header (not "N items detected").
- [ ] With empty draft, verify subbar "+ Create Handover" button is disabled/greyed.
- [ ] Add an item to the draft via "+ Add Draft Item" → pick Work Order key → search + pick a WO → fill summary → submit. Confirm item appears in Draft.
- [ ] Same flow but pick Location key → type "Engine room port" → summary → submit.
- [ ] Click subbar "+ Create Handover" → confirm modal appears with item count + destination bullets.
- [ ] Same from draft-tab "Export Handover" button → confirm modal appears.
- [ ] Click a third tab "Exported" → see your own + back-to-back peer rows. Try Download PDF on a complete row → PDF opens in new tab.
- [ ] Open a completed handover as the incoming crew member → verify toast "This handover needs your acknowledgement" fires once with a "Go to sign-off" button that scrolls to signature block.
- [ ] On any sibling lens card (equipment, fault, work_order) as an engineer/eto role → verify "Add to Handover" now appears in the actions dropdown.
- [ ] As a purser → verify "Add to Handover" appears on purchase_order but not on equipment.
- [ ] Build: `npm run build` exit 0.
- [ ] Backend: `python3 -m pytest tests/ -k 'add_to_handover_gating or handover_export_list' -x -v` → all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)