### PR TITLE
fix(documents): unbreak viewer 'Yacht context required' + collapse UUID tree clutter on /documents

### DIFF
--- a/apps/web/src/components/documents/docTreeBuilder.ts
+++ b/apps/web/src/components/documents/docTreeBuilder.ts
@@ -138,18 +138,48 @@ export function buildDocTree(docs: Doc[]): TreeNode[] {
     return getOrCreateFolder(rest, depth + 1, folder.children, folderMap, fullPath);
   };
 
-  // UUID pattern — first storage_path segment is the yacht UUID prefix; strip it.
+  // UUID pattern — used twice below:
+  //   1. The leading yacht_uuid segment that always prefixes storage_path.
+  //   2. The per-doc uniqueness UUID segment produced by the lens upload path
+  //      (storage_path_template = "{yacht_id}/documents/{doc_id}/{filename}").
+  //      That second segment is storage housekeeping, NOT a user-intended
+  //      folder — showing it in the tree produces 20+ UUID rows under a
+  //      single "documents" parent. We strip it when the pattern matches.
   const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
   for (const doc of docs) {
     // Use storage_path (the real bucket path) to build the folder hierarchy.
     // storage_path format: {yacht_uuid}/{folder_1}/.../{folder_n}/{filename}
-    // Strip the leading yacht UUID so the tree mirrors the bucket folder structure.
+    // Strip the leading yacht UUID so the tree mirrors the bucket structure.
+    // Additionally collapse the upload-uniqueness namespace
+    // `documents/{doc_uuid}/` when the lens-upload path produced it — that
+    // namespace is for blob-key uniqueness, not user navigation.
     const rawPath = doc.storage_path || '';
     const allSegments = (() => {
       if (!rawPath) return [];
-      const segs = splitPath(rawPath);
-      return segs.length > 0 && UUID_RE.test(segs[0]) ? segs.slice(1) : segs;
+      let segs = splitPath(rawPath);
+      // Strip leading yacht UUID
+      if (segs.length > 0 && UUID_RE.test(segs[0])) {
+        segs = segs.slice(1);
+      }
+      // Collapse `documents/{doc_uuid}/` lens-upload namespace.
+      //   ["documents", "<uuid>", <filename>]     ← typical lens upload
+      //   ["documents", "<uuid>", "sub", <file>]  ← same + extra (rare)
+      // We keep any segments AFTER the uuid. If NO segments remain after
+      // the filename is dropped (common case — just the filename), return
+      // an empty array so the doc_type-fallback bucket takes over. Dumping
+      // the file at root with no folder is worse UX than grouping by type.
+      if (
+        segs.length >= 3 &&
+        segs[0] === 'documents' &&
+        UUID_RE.test(segs[1])
+      ) {
+        segs = segs.slice(2);
+        // After stripping: if only the filename remains, hand off to the
+        // doc_type fallback by returning an empty list here.
+        if (segs.length <= 1) return [];
+      }
+      return segs;
     })();
     // Drop the final segment — it's the file itself, not a folder.
     const folderSegments = allSegments.length > 0 ? allSegments.slice(0, -1) : [];

--- a/apps/web/src/components/lens-v2/entity/DocumentContent.tsx
+++ b/apps/web/src/components/lens-v2/entity/DocumentContent.tsx
@@ -120,10 +120,18 @@ export function DocumentContent() {
 
   React.useEffect(() => {
     if (!entityId) return;
+    // Wait for auth context to resolve yachtId before firing the signed-URL
+    // fetch. Previously we relied on documentLoader's internal getYachtId()
+    // (user_metadata read) which returns null when the JWT was minted without
+    // the yacht_id metadata claim — the viewer then failed with "Yacht
+    // context required" even though AuthContext could have resolved it via
+    // the MASTER DB lookup. Passing user.yachtId explicitly wires the modern
+    // resolution path into the loader.
+    if (!user?.yachtId) return;
     setFileLoading(true);
     setFileError(null);
     setBlobUrl(null);
-    loadDocumentWithBackend(entityId).then((result) => {
+    loadDocumentWithBackend(entityId, user.yachtId).then((result) => {
       if (result.success && result.url) {
         blobUrlRef.current = result.url;
         setBlobUrl(result.url);
@@ -138,7 +146,7 @@ export function DocumentContent() {
         blobUrlRef.current = null;
       }
     };
-  }, [entityId]);
+  }, [entityId, user?.yachtId]);
 
   // ── Extract entity fields ──
   // Memoised so downstream callbacks that depend on payload don't rebuild on

--- a/apps/web/src/lib/documentLoader.ts
+++ b/apps/web/src/lib/documentLoader.ts
@@ -39,16 +39,29 @@ export interface DocumentLoadResult {
  * - Rate limits to prevent bulk downloads
  *
  * @param documentId - Document UUID from doc_metadata table
+ * @param yachtIdArg - Yacht UUID from AuthContext (preferred — useAuth().user.yachtId).
+ *                    Falls back to the deprecated getYachtId() (session user_metadata)
+ *                    only when the caller does not provide it, for backward compat
+ *                    with older call sites. The modern AuthContext path does a MASTER
+ *                    DB lookup and works for users whose JWT user_metadata does not
+ *                    carry yacht_id — the deprecated path silently fails for those
+ *                    users with "Yacht context required" and the viewer never loads.
+ *                    See useCelesteSearch.ts:408 for the "not from deprecated
+ *                    getYachtId()" rule that pre-dates this fix.
  * @returns DocumentLoadResult with blob URL
  */
 export async function loadDocumentWithBackend(
-  documentId: string
+  documentId: string,
+  yachtIdArg?: string | null
 ): Promise<DocumentLoadResult> {
   try {
     console.log('[documentLoader] Loading document via backend:', documentId);
 
-    // Get yacht ID for auth headers
-    const yachtId = await getYachtId();
+    // Prefer the caller-supplied yachtId (from AuthContext). Fall back to the
+    // deprecated user_metadata read only if the caller didn't provide one —
+    // that path is known to return null for users whose JWT is missing the
+    // yacht_id metadata claim.
+    const yachtId = yachtIdArg ?? (await getYachtId());
     if (!yachtId) {
       return {
         success: false,


### PR DESCRIPTION
## Bugs reported

CEO inspected /documents on app.celeste7.ai and flagged two issues:

1. **Tree shows a single `documents/` folder containing 20+ raw UUIDs as children** instead of any meaningful folder hierarchy.
2. **Opening any file yields "Could not load file — Yacht context required"** with no console error, no 404, nothing actionable for the user.

## Root causes (traced, not guessed)

### Bug 1 — viewer
`documentLoader.loadDocumentWithBackend` calls `authHelpers.getYachtId()` which only reads `session.user.user_metadata.yacht_id`. The test yacht's JWT was minted without that metadata claim, so it returns `null` → loader short-circuits with "Yacht context required" → `/v1/documents/{doc_id}/sign` is never called. `useCelesteSearch.ts:408` already warns against this deprecated path. The modern resolution is `useAuth().user.yachtId` via AuthContext + MASTER DB lookup.

### Bug 2 — tree
After tonight's Option A orphan cleanup, all 21 live docs on the test yacht have `storage_path = '{yacht}/documents/{doc_uuid}/{filename}'` — the lens-upload template uses a per-doc UUID namespace for blob-key uniqueness. `original_path` + `metadata.directories` are both NULL on every row. The tree was rendering the only thing it had.

## Fixes

### `apps/web/src/lib/documentLoader.ts`
New optional `yachtIdArg` parameter. If supplied, uses it directly; otherwise falls back to the deprecated `getYachtId()` for backward compat with older call sites.

### `apps/web/src/components/lens-v2/entity/DocumentContent.tsx`
Passes `user.yachtId` from `useAuth()` into `loadDocumentWithBackend()` and gates the useEffect on `user?.yachtId` so the fetch fires only after the auth context has resolved.

### `apps/web/src/components/documents/docTreeBuilder.ts`
Detects the `documents/<UUID>/` lens-upload namespace and collapses it. When collapse leaves only the filename, returns `[]` so the doc_type fallback bucket kicks in. Real nested paths (e.g. legacy NAS `01_BRIDGE/Communications/...`) are untouched.

## Expected post-deploy state

Tree on /documents:
```
Manual/          ← doc_type='manual' (7 docs)
├─ final_test.pdf
├─ retest_fixture.pdf
└─ sweep_s1.pdf
Uploaded/        ← doc_type null fallback
├─ s4_fresh.pdf
├─ test_1_r_sum_.pdf
└─ pw_test_upload.pdf
```

Viewer: clicking `s4_fresh.pdf` now successfully POSTs to `/v1/documents/7fec2ecf…/sign`, receives a 10-min signed URL, fetches the blob, renders the PDF in the hero iframe.

## Verification
- tsc clean on changed files (unrelated pre-existing work-orders test warning)
- DocumentsTableList: 14/14 vitest green
- Node trace confirms all three live path shapes behave correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)