### PR TITLE
feat(equipment): Add to Handover + prune REMOVE-list + warranty stub (Issue 4 PR-EQ-5)

### DIFF
--- a/apps/api/action_router/entity_actions.py
+++ b/apps/api/action_router/entity_actions.py
@@ -95,6 +95,28 @@ _PURCHASE_ORDER_HIDDEN_ACTIONS = {
     "order_part",
 }
 
+# Equipment REMOVE-list per CEO locked matrix (EQUIPMENT05 PR-EQ-5, 2026-04-24).
+# These actions are structurally wrong for the equipment lens card dropdown.
+# Registry entries and handlers are retained (other callers may depend on them)
+# — this gate is just "don't surface from the equipment lens".
+_EQUIPMENT_HIDDEN_ACTIONS = {
+    # Fleet/vessel-level actions — not per-equipment card context
+    "view_fleet_summary",
+    "open_vessel",
+    "export_fleet_summary",
+    "request_predictive_insight",
+    # Redundant with decommission_equipment (which is kept); the replace variant
+    # conflates two mutations and the matrix drops it in favour of the simpler one.
+    "decommission_and_replace_equipment",
+    # Pure-view actions — user is already viewing the equipment lens, so a
+    # "View Equipment" / "View History" dropdown item is a no-op tautology.
+    # AuditTrailSection + HistorySection render inline on the lens.
+    "view_equipment_details",
+    "view_equipment_history",
+    "view_equipment",
+    "view_maintenance_history",
+}
+
 
 def get_available_actions(
     entity_type: str,
@@ -128,6 +150,8 @@ def get_available_actions(
         if entity_type == "shopping_list" and action_id in _SHOPPING_LIST_HIDDEN_ACTIONS:
             continue
         if entity_type == "purchase_order" and action_id in _PURCHASE_ORDER_HIDDEN_ACTIONS:
+            continue
+        if entity_type == "equipment" and action_id in _EQUIPMENT_HIDDEN_ACTIONS:
             continue
 
         # Role gate: omit entirely if not permitted

--- a/apps/api/action_router/entity_prefill.py
+++ b/apps/api/action_router/entity_prefill.py
@@ -260,22 +260,20 @@ CONTEXT_PREFILL_MAP: Dict[Tuple[str, str], Dict[str, str]] = {
     ("equipment", "add_to_handover"): {
         "entity_id":      "id",
         "title":          "name",
-        # CEO context fields (EQUIPMENT05 request):
-        # code is not surfaced on the lens response today — intentionally
-        # omitted; resolve_prefill drops missing keys. Add here when the
-        # equipment route starts emitting it.
+        # CEO context fields — full 10-field set (EQUIPMENT05 PR-EQ-5).
+        # All keys resolve against the equipment entity response
+        # (entity_routes.py get_equipment_entity) which now emits each
+        # field as a top-level key. resolve_prefill drops None/missing.
+        "code":           "code",
         "name":           "name",
         "manufacturer":   "manufacturer",
         "model":          "model",
         "serial_number":  "serial_number",
         "criticality":    "criticality",
         "status":         "status",
+        "running_hours":  "running_hours",
         "location":       "location",
-        "system_type":    "equipment_type",   # entity_routes.py:1473 maps system_type → equipment_type
-        # running_hours not on the equipment lens response yet (see
-        # pms_equipment.running_hours column usage in equipment_handlers.py:1374).
-        # Left out so we don't ship a key that resolves to None; add when the
-        # equipment route starts surfacing it.
+        "system_type":    "system_type",
     },
     ("part", "add_to_handover"):         {"entity_id": "id", "title": "name"},
     ("certificate", "add_to_handover"):  {"entity_id": "id", "title": "name"},

--- a/apps/api/routes/entity_routes.py
+++ b/apps/api/routes/entity_routes.py
@@ -1512,6 +1512,12 @@ async def get_equipment_entity(equipment_id: str, auth: dict = Depends(get_authe
         _entity_response = {
             "id": data.get('id'),
             "name": data.get('name', 'Unknown Equipment'),
+            # PR-EQ-5: `code` + `system_type` surfaced as top-level keys so
+            # the Handover modal Context block (entity_prefill.py equipment →
+            # add_to_handover map) can read them. `equipment_type` kept as a
+            # backward-compat alias consumed by EquipmentContent.tsx.
+            "code": data.get('code'),
+            "system_type": data.get('system_type'),
             "equipment_type": data.get('system_type') or metadata.get('category', 'General'),
             "manufacturer": data.get('manufacturer'),
             "model": data.get('model'),
@@ -1519,6 +1525,9 @@ async def get_equipment_entity(equipment_id: str, auth: dict = Depends(get_authe
             "location": data.get('location', 'Unknown'),
             "status": metadata.get('status', 'operational'),
             "criticality": data.get('criticality'),
+            # PR-EQ-5: emit running_hours from the pms_equipment column
+            # (equipment_handlers.py:1374 writes it via record_equipment_hours).
+            "running_hours": data.get('running_hours'),
             "installation_date": data.get('installed_date'),
             "last_maintenance": metadata.get('last_maintenance'),
             "next_maintenance": metadata.get('next_maintenance'),

--- a/apps/api/tests/test_add_to_handover_gating.py
+++ b/apps/api/tests/test_add_to_handover_gating.py
@@ -165,28 +165,37 @@ def test_availableActions_hides_add_to_handover_on_hours_of_rest_for_everyone() 
 def test_equipment_add_to_handover_prefill_surfaces_context_fields() -> None:
     from action_router.entity_prefill import resolve_prefill
 
+    # PR-EQ-5: equipment entity now emits the full 10-field context set.
+    # `system_type` is the canonical top-level key (entity_routes.py equipment
+    # branch also retains `equipment_type` as a backward-compat alias).
+    # `code` and `running_hours` are the two fields surfaced by this PR.
     entity = {
         "id": "eq-1",
         "name": "Main Engine",
+        "code": "ME-01",
         "manufacturer": "MTU",
         "model": "16V 4000 M73",
         "serial_number": "MTU-12345",
         "criticality": "high",
         "status": "operational",
+        "running_hours": 12345,
         "location": "Engine Room",
-        "equipment_type": "main_engine",
+        "system_type": "main_engine",
     }
 
     prefill = resolve_prefill("equipment", "add_to_handover", entity)
 
-    # Identity + context
+    # Identity + context — full 10-field surface
     assert prefill["entity_id"] == "eq-1"
     assert prefill["title"] == "Main Engine"
+    assert prefill["code"] == "ME-01"
+    assert prefill["name"] == "Main Engine"
     assert prefill["manufacturer"] == "MTU"
     assert prefill["model"] == "16V 4000 M73"
     assert prefill["serial_number"] == "MTU-12345"
     assert prefill["criticality"] == "high"
     assert prefill["status"] == "operational"
+    assert prefill["running_hours"] == 12345
     assert prefill["location"] == "Engine Room"
     assert prefill["system_type"] == "main_engine"
 

--- a/apps/web/src/components/lens-v2/entity/EquipmentContent.tsx
+++ b/apps/web/src/components/lens-v2/entity/EquipmentContent.tsx
@@ -275,7 +275,20 @@ export function EquipmentContent() {
     await executeAction('create_work_order_for_equipment', { type: 'corrective', priority: 'routine' });
   }, [executeAction]);
 
-  const SPECIAL_HANDLERS: Record<string, () => void> = {};
+  // PR-EQ-5: File Warranty Claim is a navigation stub — CEO brief marks it
+  // PARAMOUNT and wants router.push rather than invoking the backend action
+  // (which would open the warranty modal with partial prefill). Routed to
+  // /warranties?equipment_id=<id> because no dedicated /warranties/new page
+  // exists yet (folder is `warranties` plural, and only list + [id] routes
+  // are present). A follow-up PR can either add a /warranties/new page that
+  // reads ?equipment_id= to prefill a create form, or replace this handler
+  // with a modal — the stub keeps the user-visible contract stable.
+  const SPECIAL_HANDLERS: Record<string, () => void> = {
+    file_warranty_claim: () => {
+      const qs = entityId ? `?equipment_id=${encodeURIComponent(entityId)}` : '';
+      router.push(`/warranties${qs}`);
+    },
+  };
   const DANGER_ACTIONS = new Set(['decommission_equipment', 'archive_equipment']);
   const primaryActionId = 'create_work_order_for_equipment';
 


### PR DESCRIPTION
## Summary
Closes the equipment-lens Issue 4 button matrix — prunes wasteful dropdown entries, exposes the 10-field prefill surface HANDOVER08 needs (PR #700 merged earlier today), and stubs the File Warranty Claim button.

Part of Issue 4 (Equipment lens refactor), 5th of 6 PRs.

## What changes on app.celeste7.ai/equipment/<id>

### 1. "Add to Handover" button now reachable
Cohort action `add_to_handover` (HANDOVER08 PR #700) renders on the equipment dropdown for engineering + deck roles. Opens modal in-place, prefills with equipment context. No code needed here — HANDOVER08 shipped the wiring; this PR ensures the prefill fields actually land.

### 2. 10 context fields surface cleanly in the Handover modal payload
Previously `/v1/entity/equipment/{id}` emitted 7 of HANDOVER08's 10 requested context fields. This PR adds the missing ones as top-level keys sourced from `pms_equipment`:
- `code`
- `system_type` (canonical — previously was an alias)
- `running_hours`

All 10 fields (code, name, manufacturer, model, serial_number, criticality, status, running_hours, location, system_type) now land on the `add_to_handover` payload. **Visible-in-popup-UI rendering of these fields depends on HANDOVER08's B12 ActionPopup PR**, shipping same day as this merge per their coord.

### 3. Dropdown pruning via `_EQUIPMENT_HIDDEN_ACTIONS`
Follows cohort idiom (`_SHOPPING_LIST_HIDDEN_ACTIONS` / `_PURCHASE_ORDER_HIDDEN_ACTIONS`). Backend filter in `entity_actions.py::get_available_actions` — single source of truth, no frontend drift.

Removed from equipment dropdown:
- view_fleet_summary
- open_vessel
- export_fleet_summary
- request_predictive_insight
- decommission_and_replace_equipment
- view_equipment_details
- view_equipment_history
- view_equipment
- view_maintenance_history

(`decommission_equipment` retained — distinct from `_and_replace` variant.)

### 4. File Warranty Claim — routes to /warranties
`SPECIAL_HANDLERS` entry for `file_warranty_claim` does `router.push('/warranties?equipment_id=<id>')`. Not an action invocation — navigation stub per CEO PARAMOUNT brief.

**Gap to be transparent about**: the CEO brief named `/warranty/new?equipment_id=<id>` but that route does not exist in this repo. The current repo has:
- `apps/web/src/app/warranties/page.tsx` (list)
- `apps/web/src/app/warranties/[id]/page.tsx` (detail)
- **No `new/` subroute** and **no `equipment_id` query param handling** anywhere under `/warranties`

So this PR's stub lands the user on the warranties list with a dead query param. Functionally, the user would then click a "+ New" button on the list and re-enter equipment manually. Better than a disabled button; worse than a pre-filled form.

**Follow-up PR recommended**: add `apps/web/src/app/warranties/new/page.tsx` that reads `?equipment_id=` and opens the warranty create flow with equipment pre-selected. Trivial to wire once that page exists — one-line update to the stub. Coord with WARRANTY04 on what the canonical create flow should look like.

### 5. Grey-out principle (no new code needed)
CEO's "grey out unexecutable buttons" rule is already satisfied by existing `_apply_state_gate` + `SplitButton.tsx:114-126` (renders `disabled + tooltip + opacity 0.4`). Role-gate still HIDES rather than greys — that's a cohort-wide choice across all lenses and out of scope for this PR.

## Files changed
- `apps/api/routes/entity_routes.py` — +9 (emit 3 missing fields)
- `apps/api/action_router/entity_prefill.py` — +/-16 (prefill map updated)
- `apps/api/action_router/entity_actions.py` — +24 (hidden-actions set + filter)
- `apps/api/tests/test_add_to_handover_gating.py` — +13 (10-field assertion added)
- `apps/web/src/components/lens-v2/entity/EquipmentContent.tsx` — +15 (SPECIAL_HANDLERS entry)

## Not touched
- Any non-equipment lens file
- `p0_actions_routes.py:781-849` (FAULT05 dedup territory)
- `ActionPopup.tsx` (HANDOVER08 B12 incoming)
- Shared lens-v2 components' internals

## Test plan
- [x] `npx tsc --noEmit` — pass
- [x] `npm run build` — pass
- [x] `pytest tests/ -k "entity or equipment"` — 167 pass, 5 pre-existing failures confirmed via stash-compare (fallout from PR #700 cross-domain injection — not this PR's fault)
- [ ] Live: click "Add to Handover" on an equipment card, confirm modal opens
- [ ] Live: click "File Warranty Claim" → lands on /warranties list
- [ ] Live: verify removed dropdown entries are absent

## Reviewer double-check
The warranty stub's `?equipment_id=` query param is dead on the list page today. If CEO wants a real pre-filled create flow before EQ-5 merges, spin a thin follow-up PR adding `apps/web/src/app/warranties/new/page.tsx` that reads the param.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>