### PR TITLE
feat(lens-v2): render prefill context as read-only Source rows in ActionPopup

### DIFF
--- a/apps/web/src/components/lens-v2/ActionPopup.tsx
+++ b/apps/web/src/components/lens-v2/ActionPopup.tsx
@@ -58,6 +58,14 @@ export interface ActionPopupProps {
   onClose: () => void;
   /** Preview summary rows (shown above signature) */
   previewRows?: { key: string; value: string }[];
+  /**
+   * Server-populated context for the action (e.g. equipment.code,
+   * equipment.name, criticality, running_hours…). Keys NOT mapped to a
+   * user-editable field in `fields[]` render as a read-only "Source" block
+   * at the top of the popup. Keys that ARE editable fields are skipped here
+   * (the field editor renders them). Back-end-only keys are never rendered.
+   */
+  prefill?: Record<string, unknown>;
 }
 
 // ---------------------------------------------------------------------------
@@ -77,6 +85,147 @@ const BACKDROP_CLASS: Record<string, string> = {
 function backdropClass(mode: 'read' | 'mutate', level: number): string {
   if (mode === 'read') return BACKDROP_CLASS.read;
   return BACKDROP_CLASS[`l${level}`] ?? BACKDROP_CLASS.l1;
+}
+
+// ---------------------------------------------------------------------------
+// Source-context block (renders prefill keys NOT in fields[])
+// ---------------------------------------------------------------------------
+
+/** Keys that are backend-only plumbing and must NEVER surface to the user. */
+const SOURCE_NEVER_RENDER = new Set<string>([
+  'entity_id',
+  'entity_type',
+  'yacht_id',
+  'fleet_id',
+  'user_id',
+  'tenant_id',
+  'id',
+  'url',
+  'entity_url',
+  'metadata',
+]);
+
+/** Keys whose values are machine identifiers and should render in monospace. */
+const SOURCE_MONO_KEYS = new Set<string>([
+  'code',
+  'part_number',
+  'wonumber',
+  'fault_code',
+  'po_number',
+  'serial_number',
+]);
+
+/** `serial_number` -> "Serial number"; "running_hours" -> "Running hours". */
+function humanizeKey(key: string): string {
+  const spaced = key.replace(/_/g, ' ').trim();
+  if (!spaced) return key;
+  return spaced.charAt(0).toUpperCase() + spaced.slice(1);
+}
+
+interface SourceRow {
+  key: string;
+  label: string;
+  value: string;
+  mono: boolean;
+}
+
+function buildSourceRows(
+  prefill: Record<string, unknown> | undefined,
+  fieldNames: Set<string>,
+): SourceRow[] {
+  if (!prefill) return [];
+  const rows: SourceRow[] = [];
+  // Insertion order — Object.keys preserves it for string keys.
+  for (const key of Object.keys(prefill)) {
+    if (SOURCE_NEVER_RENDER.has(key)) continue;
+    if (fieldNames.has(key)) continue;
+    const raw = prefill[key];
+    if (raw === null || raw === undefined) continue;
+
+    let value: string;
+    let mono = SOURCE_MONO_KEYS.has(key);
+
+    if (typeof raw === 'string') {
+      value = raw;
+    } else if (typeof raw === 'number') {
+      value = String(raw);
+      mono = true;
+    } else if (typeof raw === 'boolean') {
+      value = raw ? 'Yes' : 'No';
+    } else {
+      // array / object — last-resort stringify, truncated.
+      const json = JSON.stringify(raw);
+      value = json && json.length > 60 ? json.slice(0, 60) + '…' : json ?? '';
+    }
+
+    rows.push({ key, label: humanizeKey(key), value, mono });
+  }
+  return rows;
+}
+
+function SourceBlock({ rows }: { rows: SourceRow[] }) {
+  return (
+    <div
+      data-testid="action-popup-source"
+      style={{
+        margin: '0 24px',
+        padding: '12px 0 12px 0',
+        borderBottom: '1px solid var(--border-faint)',
+      }}
+    >
+      <div
+        style={{
+          fontSize: 10,
+          fontWeight: 600,
+          textTransform: 'uppercase',
+          letterSpacing: '0.06em',
+          color: 'var(--txt3)',
+          marginBottom: 8,
+          fontFamily: 'var(--font-sans)',
+        }}
+      >
+        Source
+      </div>
+      {rows.map((row) => (
+        <div
+          key={row.key}
+          data-testid={`action-popup-source-row-${row.key}`}
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: 8,
+            minHeight: 44,
+            fontSize: 12,
+          }}
+        >
+          <span
+            style={{
+              color: 'var(--txt3)',
+              minWidth: 112,
+              fontSize: 10,
+              textTransform: 'uppercase',
+              letterSpacing: '0.04em',
+              fontFamily: 'var(--font-sans)',
+            }}
+          >
+            {row.label}
+          </span>
+          <span
+            data-testid={`action-popup-source-val-${row.key}`}
+            style={{
+              color: 'var(--txt2)',
+              fontFamily: row.mono ? 'var(--font-mono)' : 'var(--font-sans)',
+              whiteSpace: 'nowrap',
+              overflow: 'hidden',
+              textOverflow: 'ellipsis',
+            }}
+          >
+            {row.value}
+          </span>
+        </div>
+      ))}
+    </div>
+  );
 }
 
 // ---------------------------------------------------------------------------
@@ -550,6 +699,7 @@ export function ActionPopup({
   onSubmit,
   onClose,
   previewRows,
+  prefill,
 }: ActionPopupProps) {
   // L0 = tap only — execute inline, no modal needed
   // L0 = fire-and-forget (no form, no signature). Only auto-submit if there
@@ -566,6 +716,13 @@ export function ActionPopup({
   });
   const [pin, setPin] = React.useState('');
   const [sigName, setSigName] = React.useState('');
+
+  // Source-context rows: prefill keys NOT mapped to a user-editable field.
+  // Invisible when no usable rows remain.
+  const sourceRows = React.useMemo(() => {
+    const fieldNames = new Set(fields.map((f) => f.name));
+    return buildSourceRows(prefill, fieldNames);
+  }, [prefill, fields]);
 
   const setValue = (name: string, value: string) =>
     setValues((prev) => ({ ...prev, [name]: value }));
@@ -669,6 +826,9 @@ export function ActionPopup({
 
         {/* Divider (mutate only) */}
         {mode === 'mutate' && <div className={s.popupDivider} />}
+
+        {/* Source-context block — prefill keys that are not editable fields. */}
+        {sourceRows.length > 0 && <SourceBlock rows={sourceRows} />}
 
         {/* Body — fields */}
         <div className={mode === 'read' ? s.popupBodyRead : s.popupBody}>

--- a/apps/web/src/components/lens-v2/ActionPopup.tsx
+++ b/apps/web/src/components/lens-v2/ActionPopup.tsx
@@ -93,6 +93,7 @@ function backdropClass(mode: 'read' | 'mutate', level: number): string {
 
 /** Keys that are backend-only plumbing and must NEVER surface to the user. */
 const SOURCE_NEVER_RENDER = new Set<string>([
+  // Generic plumbing
   'entity_id',
   'entity_type',
   'yacht_id',
@@ -103,6 +104,36 @@ const SOURCE_NEVER_RENDER = new Set<string>([
   'url',
   'entity_url',
   'metadata',
+  // Foreign-key UUIDs. Each of these is expected to come alongside a
+  // human-readable *_name (e.g. `equipment_id` + `equipment_name`). The UUID
+  // is routing plumbing; only the name belongs in the Source block.
+  // Per FAULT05 cohort review of PR #704 (2026-04-24): skipping UUID surfacing.
+  'equipment_id',
+  'part_id',
+  'work_order_id',
+  'fault_id',
+  'certificate_id',
+  'document_id',
+  'purchase_order_id',
+  'receiving_id',
+  'warranty_id',
+  'shopping_list_id',
+  'shopping_item_id',
+  'hours_of_rest_id',
+  'handover_id',
+  'handover_item_id',
+  'handover_export_id',
+  'previous_export_id',
+  'draft_id',
+  'added_by',
+  'updated_by',
+  'deleted_by',
+  'resolved_by',
+  'completed_by',
+  'reported_by',
+  'exported_by_user_id',
+  'outgoing_user_id',
+  'incoming_user_id',
 ]);
 
 /** Keys whose values are machine identifiers and should render in monospace. */
@@ -115,8 +146,23 @@ const SOURCE_MONO_KEYS = new Set<string>([
   'serial_number',
 ]);
 
+/**
+ * Per-key label overrides for prefill keys whose humanised form reads weakly
+ * because of an embedded acronym (e.g. "Po number" vs "PO number"). Keep this
+ * narrow — only add overrides when the default humanise produces something
+ * genuinely worse. Per PURCHASE05 cohort review of PR #704 (2026-04-24).
+ */
+const SOURCE_LABEL_OVERRIDES: Record<string, string> = {
+  po_number: 'PO number',
+  wonumber: 'WO number',
+  wo_number: 'WO number',
+  sku: 'SKU',
+};
+
 /** `serial_number` -> "Serial number"; "running_hours" -> "Running hours". */
 function humanizeKey(key: string): string {
+  const override = SOURCE_LABEL_OVERRIDES[key];
+  if (override) return override;
   const spaced = key.replace(/_/g, ' ').trim();
   if (!spaced) return key;
   return spaced.charAt(0).toUpperCase() + spaced.slice(1);

--- a/apps/web/src/components/lens-v2/__tests__/ActionPopup.prefill.test.tsx
+++ b/apps/web/src/components/lens-v2/__tests__/ActionPopup.prefill.test.tsx
@@ -124,4 +124,85 @@ describe('ActionPopup — Source context (prefill rendering)', () => {
       screen.queryByTestId('action-popup-source-row-some_null_field'),
     ).toBeNull();
   });
+
+  it('9. skips FK UUID rows when a paired human-readable name exists', () => {
+    // Per FAULT05 PR #704 review: equipment_id / part_id / work_order_id / etc.
+    // are routing plumbing; only the human-readable name surfaces to the user.
+    renderPopup({
+      prefill: {
+        fault_code: 'F-0102',
+        severity: 'high',
+        equipment_id: '11111111-2222-3333-4444-555555555555',
+        equipment_name: 'Main Engine',
+      },
+    });
+    expect(screen.getByTestId('action-popup-source-row-fault_code')).toBeTruthy();
+    expect(screen.getByTestId('action-popup-source-row-severity')).toBeTruthy();
+    expect(screen.getByTestId('action-popup-source-row-equipment_name')).toBeTruthy();
+    expect(
+      screen.queryByTestId('action-popup-source-row-equipment_id'),
+    ).toBeNull();
+  });
+
+  it('10a. applies acronym label overrides (po_number, wo_number, sku)', () => {
+    // Per PURCHASE05 PR #704 review: humanizeKey defaults read weakly when an
+    // embedded acronym is present ("Po number"). Override map fixes the
+    // common ones without burning a general acronym inflector.
+    renderPopup({
+      prefill: {
+        po_number: 'PO-2026-0042',
+        wonumber: 'WO-0074',
+        sku: 'XY-123',
+      },
+    });
+    // Each row's textContent contains both label + value; assert label token.
+    expect(
+      screen.getByTestId('action-popup-source-row-po_number'),
+    ).toHaveTextContent('PO number');
+    expect(
+      screen.getByTestId('action-popup-source-row-wonumber'),
+    ).toHaveTextContent('WO number');
+    expect(
+      screen.getByTestId('action-popup-source-row-sku'),
+    ).toHaveTextContent('SKU');
+    // Negative check: the raw humanised form must NOT leak through.
+    expect(
+      screen.getByTestId('action-popup-source-row-po_number'),
+    ).not.toHaveTextContent('Po number');
+  });
+
+  it('10. skips every FK UUID key in the hidden list', () => {
+    // Regression guard for the never-render list. If a FK UUID ever surfaces
+    // visually, this test should catch it.
+    renderPopup({
+      prefill: {
+        code: 'EQ-001',
+        equipment_id: 'x',
+        part_id: 'x',
+        work_order_id: 'x',
+        fault_id: 'x',
+        certificate_id: 'x',
+        purchase_order_id: 'x',
+        previous_export_id: 'x',
+        added_by: 'x',
+        outgoing_user_id: 'x',
+      },
+    });
+    expect(screen.getByTestId('action-popup-source-row-code')).toBeTruthy();
+    [
+      'equipment_id',
+      'part_id',
+      'work_order_id',
+      'fault_id',
+      'certificate_id',
+      'purchase_order_id',
+      'previous_export_id',
+      'added_by',
+      'outgoing_user_id',
+    ].forEach((key) => {
+      expect(
+        screen.queryByTestId(`action-popup-source-row-${key}`),
+      ).toBeNull();
+    });
+  });
 });

--- a/apps/web/src/components/lens-v2/__tests__/ActionPopup.prefill.test.tsx
+++ b/apps/web/src/components/lens-v2/__tests__/ActionPopup.prefill.test.tsx
@@ -1,0 +1,127 @@
+/**
+ * ActionPopup — Source-context (prefill) rendering tests (HANDOVER08 task B12).
+ *
+ * Contract:
+ *   Prefill keys NOT mapped to a user-editable field render as a read-only
+ *   "Source" block at the top of the popup. Back-end-only keys
+ *   (entity_id, yacht_id, …) are never rendered. Null/undefined rows are
+ *   skipped. Codes/identifiers render in monospace; numbers render in
+ *   monospace; booleans render as Yes/No; the block is invisible when no
+ *   rows survive filtering.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import * as React from 'react';
+import { ActionPopup, type ActionPopupField } from '../ActionPopup';
+
+// useAuth is only consumed by FieldEntitySearch; none of these tests render
+// that field, but the import chain still evaluates the hook module. Stub to
+// keep tests hermetic.
+vi.mock('@/hooks/useAuth', () => ({
+  useAuth: () => ({ user: null, session: null }),
+}));
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+function renderPopup(
+  over: Partial<React.ComponentProps<typeof ActionPopup>> = {},
+) {
+  const props: React.ComponentProps<typeof ActionPopup> = {
+    mode: 'mutate',
+    title: 'Test action',
+    fields: [],
+    signatureLevel: 1,
+    onSubmit: vi.fn(),
+    onClose: vi.fn(),
+    ...over,
+  };
+  return render(<ActionPopup {...props} />);
+}
+
+function getSourceBlock() {
+  return screen.queryByTestId('action-popup-source');
+}
+
+// ─── Tests ──────────────────────────────────────────────────────────────────
+
+describe('ActionPopup — Source context (prefill rendering)', () => {
+  it('1. renders NO source block when prefill prop is absent', () => {
+    renderPopup();
+    expect(getSourceBlock()).toBeNull();
+  });
+
+  it('2. renders NO source block when prefill is {} (no keys)', () => {
+    renderPopup({ prefill: {} });
+    expect(getSourceBlock()).toBeNull();
+  });
+
+  it('3. renders code in monospace and name in sans when both are non-editable', () => {
+    renderPopup({
+      prefill: { code: 'EQ-001', name: 'Main Engine' },
+      fields: [],
+    });
+    expect(getSourceBlock()).not.toBeNull();
+
+    const codeRow = screen.getByTestId('action-popup-source-row-code');
+    const nameRow = screen.getByTestId('action-popup-source-row-name');
+    expect(codeRow).toHaveTextContent('Code');
+    expect(codeRow).toHaveTextContent('EQ-001');
+    expect(nameRow).toHaveTextContent('Name');
+    expect(nameRow).toHaveTextContent('Main Engine');
+
+    // monospace vs sans is driven by inline font-family on the value span.
+    const codeVal = screen.getByTestId('action-popup-source-val-code');
+    const nameVal = screen.getByTestId('action-popup-source-val-name');
+    expect(codeVal.getAttribute('style')).toContain('var(--font-mono)');
+    expect(nameVal.getAttribute('style')).toContain('var(--font-sans)');
+  });
+
+  it('4. excludes prefill keys that collide with a user-editable field', () => {
+    const fields: ActionPopupField[] = [
+      { name: 'summary', label: 'Summary', type: 'text-area' },
+    ];
+    renderPopup({
+      prefill: { code: 'EQ-001', summary: 'hi' },
+      fields,
+    });
+    expect(screen.getByTestId('action-popup-source-row-code')).toBeTruthy();
+    expect(screen.queryByTestId('action-popup-source-row-summary')).toBeNull();
+  });
+
+  it('5. omits backend-only keys (entity_id) from the Source block', () => {
+    renderPopup({
+      prefill: { entity_id: '00000000-0000-0000-0000-000000000000', code: 'X' },
+    });
+    expect(screen.getByTestId('action-popup-source-row-code')).toBeTruthy();
+    expect(screen.queryByTestId('action-popup-source-row-entity_id')).toBeNull();
+  });
+
+  it('6. renders numbers in monospace', () => {
+    renderPopup({ prefill: { running_hours: 1234 } });
+    const row = screen.getByTestId('action-popup-source-row-running_hours');
+    expect(row).toHaveTextContent('Running hours');
+    expect(row).toHaveTextContent('1234');
+    const val = screen.getByTestId('action-popup-source-val-running_hours');
+    expect(val.getAttribute('style')).toContain('var(--font-mono)');
+  });
+
+  it('7. renders booleans as Yes / No', () => {
+    renderPopup({ prefill: { is_critical: true, is_archived: false } });
+    expect(
+      screen.getByTestId('action-popup-source-row-is_critical'),
+    ).toHaveTextContent('Yes');
+    expect(
+      screen.getByTestId('action-popup-source-row-is_archived'),
+    ).toHaveTextContent('No');
+  });
+
+  it('8. skips rows whose value is null', () => {
+    renderPopup({ prefill: { some_null_field: null, code: 'X' } });
+    expect(screen.getByTestId('action-popup-source-row-code')).toBeTruthy();
+    expect(
+      screen.queryByTestId('action-popup-source-row-some_null_field'),
+    ).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

Cross-cutting cohort win. Every lens that uses `ActionPopup` receives a `prefill` object with server-populated context (entity code, name, manufacturer, status, etc). Today those values are invisible in the popup — users submit without seeing what they're packaging. This PR renders them as a compact read-only "Source" block at the top of the popup body.

**Draft PR — 48h cohort review window before merge** per the FAULT05 / EQUIPMENT05 / HANDOVER08 reconciliation from 2026-04-24.

## What changed

- `apps/web/src/components/lens-v2/ActionPopup.tsx` — optional `prefill` prop + compact `<SourceBlock>` rendered above the editable fields.
- `apps/web/src/components/lens-v2/__tests__/ActionPopup.prefill.test.tsx` — 8 new vitest specs.

## Visual behaviour

- Invisible when `prefill` is absent, empty, or all its keys are in `fields[]`/the never-render list. Zero visual change for the 15 existing callers.
- When active: a "SOURCE" micro-header (uppercase, `var(--txt3)`) on top of a 44px-row list with two columns — humanised key label (left, muted) and value (right).
- Value typography: monospace for codes (`code`, `part_number`, `wonumber`, `fault_code`, `po_number`, `serial_number`), numbers, and booleans-rendered-as-"Yes/No"; sans for names and prose.
- Backend-only keys filtered out: `entity_id`, `entity_type`, `yacht_id`, `fleet_id`, `user_id`, `tenant_id`, `id`, `url`, `entity_url`, `metadata`.

## Why now

- HANDOVER08 PR #700 shipped the gating matrix that surfaces "Add to Handover" on equipment / fault / work_order / purchase / certificate / warranty / receiving / shopping_list / document lens cards.
- EQUIPMENT05 PR #703 extended `/v1/entity/equipment/{id}` to emit the full 10 context fields (code, name, manufacturer, model, serial_number, criticality, status, running_hours, system_type, location).
- The payload chain is now live end-to-end. Without this PR, crew click "Add to Handover" on an equipment card and get a textarea with no indication of what equipment they're talking about. With this PR, the 10 fields render as a "Source" block above the summary textarea.

## Test evidence

```
Test Files  4 passed (4)
Tests       39 passed (39)
```
- 8 new `ActionPopup.prefill.test.tsx`
- 31 pre-existing lens-v2 tests stay green
- `npm run build` exit 0

## Callers verified safe

All 15 callers of `ActionPopup` today pass no `prefill` — they remain unchanged visually because the block is invisible when prefill is empty. List in commit body.

## Out of scope (explicit)

- **Submit payload semantics unchanged.** Prefill is merged backend-side by the action_router, not re-submitted from ActionPopup. This PR is rendering-only.
- **No per-caller plumbing**: callers already pass prefill downstream via the `{ ...action, prefill: ... }` spread idiom (see `HandoverContent.tsx:950`). No new `openActionPopup` call sites need edits.

## Cohort review tags

Requesting 48h review from:
- **EQUIPMENT05** — confirm the 10 equipment context fields render cleanly in the "Add to Handover" popup on a live equipment card
- **FAULT05** — confirm `fault_code`, `severity`, `equipment_id`, `equipment_name` render as you expect; also verify no visual regression on your other lens actions
- **CERT04** — verify cert-lens popup flows are unchanged (you don't pass prefill today so should be zero-diff)
- **PURCHASE05** — same as CERT04; confirm nothing breaks on the PO action popups

If any of you have contract requirements on (a) ordering of Source rows, (b) label casing, (c) mono-vs-sans rules for specific keys, (d) keys that should stay hidden — speak up on this draft. I'll incorporate before flipping to ready.

## Test plan
- [ ] Open an equipment card on the Vercel preview, click Add to Handover → verify all 10 context fields render in the Source block in the popup.
- [ ] Open a fault card, same flow → verify fault_code/severity/equipment_name render (numbers/strings/null filtered per rules).
- [ ] Open any other lens action popup (File Warranty Claim, Report Fault, Upload Document) → verify no Source block appears (those actions don't pass prefill).
- [ ] Screen reader smoke-check — the Source label + value pairs should read sensibly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)