### PR TITLE
feat(po): opt the purchase_order lens into .panelWide (1120px)

### DIFF
--- a/apps/web/src/components/lens-v2/EntityLensPage.tsx
+++ b/apps/web/src/components/lens-v2/EntityLensPage.tsx
@@ -64,7 +64,7 @@ function ErrorState({ message, onRetry }: { message: string; onRetry: () => void
  * extra horizontal room per 2026-04-23 UX spec. Add here when a new lens
  * gains a LensFileViewer.
  */
-const WIDE_LENS_TYPES: Set<string> = new Set(['certificate', 'document', 'receiving', 'shopping_list']);
+const WIDE_LENS_TYPES: Set<string> = new Set(['certificate', 'document', 'receiving', 'shopping_list', 'purchase_order']);
 
 function NotFoundState({ entityType, onBack }: { entityType: EntityType; onBack: () => void }) {
   return (


### PR DESCRIPTION
Step 11 of the PO lens UX plan ([LENS_UX_PLAN_2026-04-24.md](../blob/main/docs/ongoing_work/purchase%20order/LENS_UX_PLAN_2026-04-24.md)).

One-line addition to `WIDE_LENS_TYPES` in `EntityLensPage.tsx`. Same pattern CERT04 used for cert / document / receiving / shopping_list. No CSS change — the `.panelWide` class already exists.

PR #707's header rebuild already assumes the wider canvas (supplier title + person chain rows).