### PR TITLE
fix(documents): suppress generic read-only LedgerHistory — matches cert + work_order opt-out

### DIFF
--- a/apps/web/src/components/lens-v2/EntityLensPage.tsx
+++ b/apps/web/src/components/lens-v2/EntityLensPage.tsx
@@ -220,8 +220,20 @@ export function EntityLensPage({
                               appended ledger surfaces read-only receipts that
                               duplicate those tabs + break the tab layout
                               (CEO directive 2026-04-24). Removed per spec.
+              - document    → DocumentContent.tsx:551 renders AuditTrailSection
+                              from the enriched /v1/entity/document/{id} audit
+                              trail (pms_audit_log, actor_name + actor_role +
+                              deleted flag). Appending LedgerHistory produces
+                              a second 'History'-titled section that shows
+                              ONLY read events (view_document, get_document_url)
+                              — no mutation info, duplicates the Renewal
+                              History section semantically, confuses users
+                              who correctly expect "History" to mean prior
+                              iterations of the document (renewals/revisions),
+                              not a receipt log of who viewed it. CEO
+                              directive 2026-04-24.
            Add here when a new lens gains its own in-tab audit surface. */}
-        {entityType !== 'certificate' && entityType !== 'work_order' && (
+        {entityType !== 'certificate' && entityType !== 'work_order' && entityType !== 'document' && (
           <LedgerHistory entityType={entityType} entityId={entityId} />
         )}
       </EntityLensProvider>


### PR DESCRIPTION
CEO flagged: /documents lens card renders a stray 'History' section showing ONLY read-action receipts (view_document, get_document_url). It's injected by `EntityLensPage.tsx:225` — the same wrapper-level `LedgerHistory` that `certificate` and `work_order` already opted out of on line 224.

**Two reasons this is wrong on documents per CEO spec:**
1. 'History' as a user label = "previous iterations" (renewals/revisions) — that's owned by `RenewalHistorySection` in DocumentContent.tsx:509.
2. Mutation audit is already rendered by DocumentContent.tsx:551 via `AuditTrailSection` from the enriched `/v1/entity/document/{id}` with `actor_name`/`actor_role`/`deleted` flag.

**Fix:** add `'document'` to the opt-out guard alongside `'certificate'` and `'work_order'`. One-line change, expanded comment documenting the rationale.

**Citation (prove the visible frontend change):**
- Code: `apps/web/src/components/lens-v2/EntityLensPage.tsx` line 235 — the rendered JSX guard:
  ```tsx
  {entityType !== 'certificate' && entityType !== 'work_order' && entityType !== 'document' && (
    <LedgerHistory entityType={entityType} entityId={entityId} />
  )}
  ```
- After merge + deploy: open any document on `app.celeste7.ai/documents`, the bottom of the lens card shows Audit Trail (last) — **no 'History' section below it**.

**Verification:** tsc clean; no DocumentContent.tsx changes; opt-in mechanism (add another `entityType !==` term when a new lens gains its own in-tab audit) documented inline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)