### PR TITLE
feat(receiving): Official Documents section — invoice/packing-slip hero (PR-B)

### DIFF
--- a/apps/web/src/components/lens-v2/entity/ReceivingContent.tsx
+++ b/apps/web/src/components/lens-v2/entity/ReceivingContent.tsx
@@ -27,6 +27,7 @@ import { useEntityLensContext } from '@/contexts/EntityLensContext';
 import { getEntityRoute } from '@/lib/entityRoutes';
 import { ActionPopup, type ActionPopupField } from '../ActionPopup';
 import { ReceivingPackingList, type PackingItem } from '../sections/ReceivingPackingList';
+import { ReceivingOfficialDocuments, type OfficialDoc, type DocKind } from '../sections/ReceivingOfficialDocuments';
 
 // Sections
 import {
@@ -253,6 +254,29 @@ export function ReceivingContent() {
     body: (n.body ?? n.note_text ?? n.text) as string ?? '',
   }));
 
+  // Official documents — hero-rendered at the TOP of the lens (canonical
+  // section order: Official Documents → Checklist → Notes → History …).
+  // Classifies each attachment so the thumb strip sorts invoice-first, then
+  // packing-slip, then photos, then other.
+  function classifyDoc(name: string, mime: string | undefined): DocKind {
+    const fn = (name || '').toLowerCase();
+    if (/invoice|inv[-_]?\d/.test(fn)) return 'invoice';
+    if (/packing|packlist|slip|delivery[-_]?note/.test(fn)) return 'packing_slip';
+    if ((mime || '').startsWith('image/')) return 'photo';
+    return 'other';
+  }
+  const officialDocs: OfficialDoc[] = attachments.map((a, i) => ({
+    id: (a.id as string) ?? `doc-${i}`,
+    filename: (a.filename ?? a.file_name ?? a.name) as string ?? `file-${i}`,
+    url: (a.url as string | null | undefined) ?? null,
+    mimeType: (a.mime_type ?? a.content_type) as string | undefined,
+    kind: classifyDoc(
+      (a.filename ?? a.file_name ?? a.name ?? '') as string,
+      (a.mime_type ?? a.content_type) as string | undefined,
+    ),
+    caption: (a.caption ?? a.description) as string | undefined,
+  }));
+
   const attachmentItems: AttachmentItem[] = attachments.map((a, i) => ({
     id: (a.id as string) ?? `att-${i}`,
     name: (a.name ?? a.file_name ?? a.filename) as string ?? 'File',
@@ -312,6 +336,15 @@ export function ReceivingContent() {
           ) : undefined
         }
       />
+
+      {/* Official Documents — canonical first section; renders the supplier
+          invoice / packing slip / arrival photos inline via LensFileViewer. */}
+      <ScrollReveal>
+        <ReceivingOfficialDocuments
+          docs={officialDocs}
+          onOpenInNewTab={(d) => { if (d.url) window.open(d.url, '_blank', 'noopener'); }}
+        />
+      </ScrollReveal>
 
       {/* Packing List — reconciliation grid (the hero section per philosophy) */}
       <ScrollReveal>

--- a/apps/web/src/components/lens-v2/sections/ReceivingOfficialDocuments.tsx
+++ b/apps/web/src/components/lens-v2/sections/ReceivingOfficialDocuments.tsx
@@ -1,0 +1,230 @@
+'use client';
+
+/**
+ * ReceivingOfficialDocuments — the "Official Documents" ruled section
+ * for the receiving lens. Renders the supplier invoice / packing slip /
+ * arrival photos inline as heroes, with a thumbnail strip to swap.
+ *
+ * Consumes the existing shared `LensFileViewer` (cert / document). Does
+ * NOT fork.
+ *
+ * Canonical section order per `.claude/skills/celeste-design-philosophy`:
+ *   Official Documents → Checklist → Notes → History → Attachments → Parts
+ * This sits in the first slot. Ruled line + 14px/600/uppercase heading +
+ * collapsible body — same pattern as every other lens section.
+ *
+ * Props are deliberately thin. Parent fetches the signed URLs and passes
+ * them through as a list of `OfficialDoc`. No network I/O here.
+ */
+
+import * as React from 'react';
+import { CollapsibleSection } from '../CollapsibleSection';
+import { LensFileViewer } from './LensFileViewer';
+
+// ── Types ──────────────────────────────────────────────────────────────────
+
+export type DocKind = 'invoice' | 'packing_slip' | 'photo' | 'other';
+
+export interface OfficialDoc {
+  id: string;
+  /** Filename for the download fallback / a11y label. */
+  filename: string;
+  /** Signed URL from the backend. Null while loading. */
+  url: string | null;
+  /** MIME type drives renderer choice (PDF vs image vs fallback). */
+  mimeType?: string;
+  /** Classifier for the thumbnail strip ordering. */
+  kind?: DocKind;
+  /** Optional short caption shown under the thumb (e.g. supplier note). */
+  caption?: string;
+}
+
+export interface ReceivingOfficialDocumentsProps {
+  docs: OfficialDoc[];
+  /** When provided, shows an "Open in new tab" button on the hero. */
+  onOpenInNewTab?: (doc: OfficialDoc) => void;
+  /** HOD-only "+ Upload" affordance; passed through as section header action. */
+  onUpload?: () => void;
+}
+
+// ── Section icon (folder + check — formal-documents metaphor) ──────────────
+
+const SECTION_ICON = (
+  <svg width="16" height="16" viewBox="0 0 16 16" fill="none" aria-hidden>
+    <path
+      d="M1.5 4.5a1 1 0 011-1h3.2l1.3 1.5h6.5a1 1 0 011 1v6a1 1 0 01-1 1h-11a1 1 0 01-1-1v-7.5z"
+      stroke="currentColor"
+      strokeWidth="1.3"
+      strokeLinejoin="round"
+    />
+    <path d="M6 8.5l1.5 1.5L10.5 7" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" strokeLinejoin="round" />
+  </svg>
+);
+
+// ── Kind ordering — invoice first, then packing slip, then photos ─────────
+
+const KIND_ORDER: Record<DocKind, number> = {
+  invoice: 0,
+  packing_slip: 1,
+  photo: 2,
+  other: 3,
+};
+
+function sortDocs(docs: OfficialDoc[]): OfficialDoc[] {
+  return [...docs].sort((a, b) => {
+    const ao = KIND_ORDER[a.kind ?? 'other'];
+    const bo = KIND_ORDER[b.kind ?? 'other'];
+    if (ao !== bo) return ao - bo;
+    return a.filename.localeCompare(b.filename);
+  });
+}
+
+// ── Thumbnail strip ────────────────────────────────────────────────────────
+
+function ThumbnailStrip({
+  docs,
+  activeId,
+  onPick,
+}: {
+  docs: OfficialDoc[];
+  activeId: string;
+  onPick: (id: string) => void;
+}) {
+  return (
+    <div
+      role="tablist"
+      aria-label="Document thumbnails"
+      style={{
+        display: 'flex',
+        gap: 8,
+        padding: '8px 0 12px',
+        overflowX: 'auto',
+        borderBottom: '1px solid var(--border-faint)',
+        marginBottom: 12,
+      }}
+    >
+      {docs.map((d) => {
+        const selected = d.id === activeId;
+        return (
+          <button
+            key={d.id}
+            role="tab"
+            aria-selected={selected}
+            onClick={() => onPick(d.id)}
+            style={{
+              display: 'inline-flex',
+              alignItems: 'center',
+              gap: 6,
+              minHeight: 32,
+              padding: '4px 10px',
+              borderRadius: 4,
+              border: `1px solid ${selected ? 'var(--mark-hover)' : 'var(--border-sub)'}`,
+              background: selected ? 'var(--teal-bg)' : 'var(--neutral-bg)',
+              color: selected ? 'var(--mark)' : 'var(--txt2)',
+              fontSize: 11,
+              fontFamily: 'var(--font-sans)',
+              cursor: 'pointer',
+              whiteSpace: 'nowrap',
+              flexShrink: 0,
+            }}
+          >
+            {/* kind chip */}
+            <span
+              style={{
+                fontSize: 9,
+                fontWeight: 600,
+                letterSpacing: '0.04em',
+                textTransform: 'uppercase',
+                color: selected ? 'var(--mark)' : 'var(--txt3)',
+              }}
+            >
+              {(d.kind ?? 'other').replace('_', ' ')}
+            </span>
+            <span
+              style={{
+                fontFamily: 'var(--font-mono)',
+                fontSize: 11,
+                color: selected ? 'var(--mark)' : 'var(--txt2)',
+              }}
+            >
+              {d.filename}
+            </span>
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+// ── Component ──────────────────────────────────────────────────────────────
+
+export function ReceivingOfficialDocuments({
+  docs,
+  onOpenInNewTab,
+  onUpload,
+}: ReceivingOfficialDocumentsProps) {
+  const sorted = React.useMemo(() => sortDocs(docs), [docs]);
+  const [activeId, setActiveId] = React.useState<string | null>(sorted[0]?.id ?? null);
+
+  // Keep the active id in sync if the docs list shrinks / changes.
+  React.useEffect(() => {
+    if (sorted.length === 0) {
+      setActiveId(null);
+      return;
+    }
+    if (!sorted.some((d) => d.id === activeId)) {
+      setActiveId(sorted[0].id);
+    }
+  }, [sorted, activeId]);
+
+  const active = sorted.find((d) => d.id === activeId) ?? null;
+
+  return (
+    <CollapsibleSection
+      id="sec-official-documents"
+      title="Official Documents"
+      count={docs.length}
+      icon={SECTION_ICON}
+      action={onUpload ? { label: '+ Upload', onClick: onUpload, testid: 'documents-upload' } : undefined}
+    >
+      {docs.length === 0 ? (
+        <div
+          style={{
+            fontSize: 13,
+            color: 'var(--txt3)',
+            padding: '16px 0',
+            textAlign: 'center',
+          }}
+        >
+          No packing slip, invoice, or arrival photos uploaded yet.
+        </div>
+      ) : (
+        <>
+          {sorted.length > 1 && (
+            <ThumbnailStrip docs={sorted} activeId={activeId ?? ''} onPick={setActiveId} />
+          )}
+          {active && (
+            <LensFileViewer
+              url={active.url}
+              filename={active.filename}
+              mimeType={active.mimeType}
+              onOpenNewTab={onOpenInNewTab ? () => onOpenInNewTab(active) : undefined}
+            />
+          )}
+          {active?.caption && (
+            <div
+              style={{
+                marginTop: 8,
+                fontSize: 12,
+                color: 'var(--txt3)',
+                fontStyle: 'italic',
+              }}
+            >
+              {active.caption}
+            </div>
+          )}
+        </>
+      )}
+    </CollapsibleSection>
+  );
+}


### PR DESCRIPTION
## Summary
Adds the canonical \"Official Documents\" ruled section at the top of the receiving lens — renders the supplier's invoice / packing slip / arrival photos inline as heroes. Consumes the existing shared \`LensFileViewer\` (cert / document), no fork. Philosophy-aligned scroll-document layout preserved.

## Changes
- New: \`apps/web/src/components/lens-v2/sections/ReceivingOfficialDocuments.tsx\` — ruled-line section + thumbnail strip + LensFileViewer hero.
- \`ReceivingContent.tsx\` classifies each attachment by filename regex + mime into \`invoice | packing_slip | photo | other\`, then sorts invoice-first.
- Section positioned BEFORE the Packing List grid, per canonical order.

## Test plan
- [ ] Open a receiving with at least one attachment → section appears at the top
- [ ] PDF attachment renders inline via iframe
- [ ] Image attachment renders inline via img
- [ ] Thumbnail strip shows multiple attachments sorted invoice-first
- [ ] Click a thumb → hero swaps
- [ ] 'Open in new tab' opens the signed URL
- [ ] Section collapses via the chevron like every other
- [ ] Empty state when no attachments

## Follow-up (PR-B2)
\`pms_receiving_documents\` (the structured invoice/PDF-link table, 33 rows live) is NOT yet surfaced — this PR uses the generic \`pms_attachments\` feed. Proper join + dedicated upload flow ships as PR-B2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)