### PR TITLE
feat(receiving): Discrepancies ruled section — auto-aggregated (PR-E)

### DIFF
--- a/apps/web/src/components/lens-v2/entity/ReceivingContent.tsx
+++ b/apps/web/src/components/lens-v2/entity/ReceivingContent.tsx
@@ -29,6 +29,7 @@ import { ActionPopup, type ActionPopupField } from '../ActionPopup';
 import { ReceivingPackingList, type PackingItem } from '../sections/ReceivingPackingList';
 import { ReceivingOfficialDocuments, type OfficialDoc, type DocKind } from '../sections/ReceivingOfficialDocuments';
 import { ReceivingLinkedPO, type POItem, type ReceivingLineSummary } from '../sections/ReceivingLinkedPO';
+import { ReceivingDiscrepancies, type Discrepancy, type LineDiscrepancy, type FlagDiscrepancy, type DiscrepancyKind } from '../sections/ReceivingDiscrepancies';
 
 // Sections
 import {
@@ -128,6 +129,47 @@ export function ReceivingContent() {
   const attachments = ((entity?.attachments ?? payload.attachments) as Array<Record<string, unknown>> | undefined) ?? [];
   const history = ((entity?.audit_history ?? payload.audit_history ?? entity?.history ?? payload.history) as Array<Record<string, unknown>> | undefined) ?? [];
   const linked_entities = ((entity?.linked_entities ?? payload.linked_entities ?? entity?.related_entities ?? payload.related_entities) as Array<Record<string, unknown>> | undefined) ?? [];
+
+  // Discrepancy entries — auto-aggregated from two sources:
+  //   (a) per-line dispositions on items where crew clicked Short/Damaged/Wrong/Over
+  //   (b) free-text flag_discrepancy events from ledger_events (event_category='discrepancy')
+  // Empty array → ReceivingDiscrepancies hides the section per philosophy.
+  const lineDiscrepancyKinds = new Set<DiscrepancyKind>(['short', 'damaged', 'wrong_item', 'over']);
+  const lineDiscrepancies: LineDiscrepancy[] = items
+    .filter((it) => lineDiscrepancyKinds.has((it.disposition as DiscrepancyKind | undefined) as DiscrepancyKind))
+    .map((it) => {
+      const code = (it.part_number ?? it.part_code ?? it.sku) as string | undefined;
+      const name = (it.part_name ?? it.name ?? it.description ?? 'Item') as string;
+      return {
+        source: 'line' as const,
+        itemId: (it.id as string) ?? '',
+        partLabel: code ? `${code} — ${name}` : name,
+        kind: (it.disposition as DiscrepancyKind),
+        expected: it.quantity_expected === null || it.quantity_expected === undefined
+          ? null
+          : Number(it.quantity_expected),
+        received: Number(it.quantity_received ?? 0),
+        rejected: Number(it.quantity_rejected ?? 0),
+      };
+    });
+  const flagDiscrepancies: FlagDiscrepancy[] = history
+    .filter((h) => (h.event_category as string | undefined) === 'discrepancy' || (h.action as string | undefined) === 'flag_discrepancy')
+    .map((h) => {
+      const meta = (h.metadata as Record<string, unknown> | undefined) ?? {};
+      const kind = ((meta.discrepancy_type as DiscrepancyKind | undefined) ?? 'partial') as DiscrepancyKind;
+      const description = (meta.description as string | undefined) ?? (h.change_summary as string | undefined) ?? '';
+      const affected = (meta.affected_items as Array<Record<string, unknown>> | undefined) ?? [];
+      return {
+        source: 'flag' as const,
+        ledgerId: (h.id as string) ?? '',
+        kind,
+        description,
+        actor: (h.actor_name ?? h.actor) as string | null ?? null,
+        timestamp: (h.created_at ?? h.timestamp) as string ?? '',
+        affectedItems: affected,
+      };
+    });
+  const discrepancyEntries: Discrepancy[] = [...lineDiscrepancies, ...flagDiscrepancies];
 
   // -- Action gates --
   // Primary CTA = SIGNED accept_receiving (every status->accepted must be
@@ -387,6 +429,12 @@ export function ReceivingContent() {
           <DocRowsSection title="Related Work" docs={docItems} />
         </ScrollReveal>
       )}
+
+      {/* Discrepancies — aggregated from line dispositions + flag_discrepancy events.
+          Hidden when there's nothing to show (per philosophy). */}
+      <ScrollReveal>
+        <ReceivingDiscrepancies entries={discrepancyEntries} />
+      </ScrollReveal>
 
       {/* Linked PO — side-by-side reconciliation. Hidden when no PO is linked. */}
       <ScrollReveal>

--- a/apps/web/src/components/lens-v2/sections/ReceivingDiscrepancies.tsx
+++ b/apps/web/src/components/lens-v2/sections/ReceivingDiscrepancies.tsx
@@ -1,0 +1,239 @@
+'use client';
+
+/**
+ * ReceivingDiscrepancies — auto-aggregated list of issues found while
+ * reconciling this delivery. Two sources merged into a single ruled
+ * section:
+ *
+ *   1. Per-line dispositions on pms_receiving_items where the crew clicked
+ *      [⚠ Short] / [⚠ Damaged] / [⚠ Wrong Item] / [⚠ Over]. Surfaced as
+ *      structured rows with the part / qty / reason.
+ *
+ *   2. Free-text flag_discrepancy events from ledger_events
+ *      (entity_type='receiving' AND event_category='discrepancy'). These are
+ *      whole-receiving notes — not tied to a specific line. Surfaced as
+ *      annotated rows with actor name+role, timestamp, payload.
+ *
+ * Per philosophy: hide the section entirely when there is nothing to show.
+ * Empty Discrepancies is just noise.
+ */
+
+import * as React from 'react';
+import { CollapsibleSection } from '../CollapsibleSection';
+
+// ── Types ──────────────────────────────────────────────────────────────────
+
+export type DiscrepancyKind = 'short' | 'over' | 'damaged' | 'wrong_item' | 'partial' | 'missing';
+
+export interface LineDiscrepancy {
+  source: 'line';
+  itemId: string;
+  partLabel: string;            // "@ HVC-0106-314 Compressor Clutch" or freeform desc
+  kind: DiscrepancyKind;
+  expected: number | null;
+  received: number;
+  rejected: number;             // quantity_rejected from pms_receiving_items
+}
+
+export interface FlagDiscrepancy {
+  source: 'flag';
+  ledgerId: string;
+  kind: DiscrepancyKind;
+  description: string;
+  actor: string | null;         // already resolved name+role server-side
+  timestamp: string;            // ISO from ledger_events.created_at
+  affectedItems?: Array<Record<string, unknown>>;
+}
+
+export type Discrepancy = LineDiscrepancy | FlagDiscrepancy;
+
+export interface ReceivingDiscrepanciesProps {
+  entries: Discrepancy[];
+}
+
+// ── Helpers ────────────────────────────────────────────────────────────────
+
+function fmtQty(n: number | null | undefined): string {
+  if (n === null || n === undefined) return '—';
+  return Number.isInteger(Number(n)) ? String(Number(n)) : Number(n).toFixed(2);
+}
+
+function fmtRelative(iso: string): string {
+  if (!iso) return '';
+  try {
+    const t = new Date(iso).getTime();
+    if (Number.isNaN(t)) return '';
+    const seconds = Math.max(1, Math.floor((Date.now() - t) / 1000));
+    if (seconds < 60) return `${seconds}s ago`;
+    if (seconds < 3600) return `${Math.floor(seconds / 60)}m ago`;
+    if (seconds < 86400) return `${Math.floor(seconds / 3600)}h ago`;
+    return `${Math.floor(seconds / 86400)}d ago`;
+  } catch {
+    return '';
+  }
+}
+
+const KIND_PALETTE: Record<DiscrepancyKind, { color: string; bg: string; border: string; label: string }> = {
+  short:      { color: 'var(--red)',   bg: 'var(--red-bg)',   border: 'var(--red-border)',   label: 'SHORT' },
+  missing:    { color: 'var(--red)',   bg: 'var(--red-bg)',   border: 'var(--red-border)',   label: 'MISSING' },
+  damaged:    { color: 'var(--red)',   bg: 'var(--red-bg)',   border: 'var(--red-border)',   label: 'DAMAGED' },
+  wrong_item: { color: 'var(--red)',   bg: 'var(--red-bg)',   border: 'var(--red-border)',   label: 'WRONG ITEM' },
+  partial:    { color: 'var(--amber)', bg: 'var(--amber-bg)', border: 'var(--amber-border)', label: 'PARTIAL' },
+  over:       { color: 'var(--amber)', bg: 'var(--amber-bg)', border: 'var(--amber-border)', label: 'OVER' },
+};
+
+function KindBadge({ kind }: { kind: DiscrepancyKind }) {
+  const p = KIND_PALETTE[kind];
+  return (
+    <span
+      style={{
+        display: 'inline-flex',
+        alignItems: 'center',
+        height: 17,
+        padding: '0 6px',
+        borderRadius: 3,
+        fontSize: 8.5,
+        fontWeight: 600,
+        letterSpacing: '0.04em',
+        textTransform: 'uppercase',
+        whiteSpace: 'nowrap',
+        background: p.bg,
+        color: p.color,
+        border: `1px solid ${p.border}`,
+      }}
+    >
+      ⚠ {p.label}
+    </span>
+  );
+}
+
+// ── Section icon (warning triangle) ────────────────────────────────────────
+
+const SECTION_ICON = (
+  <svg width="16" height="16" viewBox="0 0 16 16" fill="none" aria-hidden>
+    <path
+      d="M8 1.5l6.5 11.5h-13L8 1.5z"
+      stroke="currentColor"
+      strokeWidth="1.3"
+      strokeLinejoin="round"
+    />
+    <path d="M8 5.5v4M8 11v.5" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+  </svg>
+);
+
+// ── Component ──────────────────────────────────────────────────────────────
+
+export function ReceivingDiscrepancies({ entries }: ReceivingDiscrepanciesProps) {
+  // Per philosophy: empty discrepancies = hide the section entirely.
+  if (entries.length === 0) return null;
+
+  return (
+    <CollapsibleSection
+      id="sec-discrepancies"
+      title="Discrepancies"
+      count={entries.length}
+      icon={SECTION_ICON}
+    >
+      <div role="list" aria-label="Discrepancy entries" style={{ display: 'grid', rowGap: 8 }}>
+        {entries.map((entry, idx) => {
+          if (entry.source === 'line') {
+            const shortBy = entry.expected !== null ? entry.expected - entry.received : 0;
+            return (
+              <div
+                key={`line-${entry.itemId}-${idx}`}
+                role="listitem"
+                style={{
+                  display: 'grid',
+                  gridTemplateColumns: '110px 1fr',
+                  gap: 12,
+                  padding: '10px 12px',
+                  borderLeft: `2px solid ${KIND_PALETTE[entry.kind].color}`,
+                  borderTop: '1px solid var(--border-faint)',
+                  borderBottom: '1px solid var(--border-faint)',
+                  background: 'var(--surface-elevated)',
+                }}
+              >
+                <span style={{ display: 'flex', alignItems: 'flex-start', paddingTop: 1 }}>
+                  <KindBadge kind={entry.kind} />
+                </span>
+                <div style={{ minWidth: 0 }}>
+                  <div
+                    style={{
+                      fontSize: 13,
+                      fontWeight: 500,
+                      color: 'var(--txt)',
+                      lineHeight: 1.4,
+                      whiteSpace: 'nowrap',
+                      overflow: 'hidden',
+                      textOverflow: 'ellipsis',
+                    }}
+                  >
+                    {entry.partLabel}
+                  </div>
+                  <div
+                    style={{
+                      fontSize: 11.5,
+                      color: 'var(--txt3)',
+                      marginTop: 2,
+                      fontFamily: 'var(--font-mono)',
+                    }}
+                  >
+                    Expected {fmtQty(entry.expected)} · Received {fmtQty(entry.received)}
+                    {shortBy > 0 ? ` · Short by ${fmtQty(shortBy)}` : ''}
+                    {entry.rejected > 0 ? ` · Rejected ${fmtQty(entry.rejected)}` : ''}
+                  </div>
+                </div>
+              </div>
+            );
+          }
+
+          // Flag entry (free-text from crew)
+          return (
+            <div
+              key={`flag-${entry.ledgerId}`}
+              role="listitem"
+              style={{
+                display: 'grid',
+                gridTemplateColumns: '110px 1fr',
+                gap: 12,
+                padding: '10px 12px',
+                borderLeft: `2px solid ${KIND_PALETTE[entry.kind].color}`,
+                borderTop: '1px solid var(--border-faint)',
+                borderBottom: '1px solid var(--border-faint)',
+                background: 'var(--surface-elevated)',
+              }}
+            >
+              <span style={{ display: 'flex', alignItems: 'flex-start', paddingTop: 1 }}>
+                <KindBadge kind={entry.kind} />
+              </span>
+              <div style={{ minWidth: 0 }}>
+                <div
+                  style={{
+                    fontSize: 13,
+                    color: 'var(--txt)',
+                    lineHeight: 1.45,
+                  }}
+                >
+                  {entry.description}
+                </div>
+                <div
+                  style={{
+                    fontSize: 11.5,
+                    color: 'var(--txt3)',
+                    marginTop: 4,
+                    fontFamily: 'var(--font-sans)',
+                  }}
+                >
+                  {entry.actor ?? 'Unknown'} · <span style={{ fontFamily: 'var(--font-mono)' }}>{fmtRelative(entry.timestamp)}</span>
+                  {entry.affectedItems && entry.affectedItems.length > 0 && (
+                    <> · {entry.affectedItems.length} affected line{entry.affectedItems.length === 1 ? '' : 's'}</>
+                  )}
+                </div>
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </CollapsibleSection>
+  );
+}


### PR DESCRIPTION
## Summary
PR-E of the receiving redesign. Adds a structured discrepancy list aggregating two sources into one ruled section:

1. **Per-line dispositions** — items where crew clicked Short/Damaged/Wrong Item/Over. Shows part + expected/received + short-by + rejected.
2. **\`flag_discrepancy\` events** from \`ledger_events\` — free-text crew flags with actor + timestamp + structured payload.

## Behaviour
- Hidden entirely when no entries (per philosophy: empty sections are noise).
- Tokenised palette: red for short/damaged/wrong/missing, amber for over/partial.
- Left-border accent matches the badge colour for fast scanning.

## Wiring
\`ReceivingContent.tsx\` derives \`discrepancyEntries[]\` from \`items.disposition\` + \`history\` (audit_history from ledger_events). Section rendered between LinkedPO and Notes.

## Test plan
- [ ] Receiving with no flagged lines + no flag events → section hidden
- [ ] Receiving with one Short line → section appears with the line entry
- [ ] After flag_discrepancy action → flag entry appears alongside line entries
- [ ] Badge colour + left border match (red/amber)
- [ ] Actor + relative timestamp on flag entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)