### PR TITLE
fix(documents): add 'document' to SUPPRESS_LEDGER_HISTORY — remove read-only History on doc lens

### DIFF
--- a/apps/web/src/components/lens-v2/EntityLensPage.tsx
+++ b/apps/web/src/components/lens-v2/EntityLensPage.tsx
@@ -104,8 +104,15 @@ const SUPPRESS_LEDGER_HISTORY: ReadonlySet<string> = new Set<string>([
   // FAULT05/WORKORDER05 removed the ledger for work_order (audit + history
   // tabs already cover it, CEO directive 2026-04-24). Add here when a new
   // lens gains its own in-tab audit surface.
+  // DocumentContent renders AuditTrailSection (line 551) from the
+  // enriched /v1/entity/document/{id} — actor_name + actor_role +
+  // deleted flag. RenewalHistorySection (line 509) owns 'prior
+  // iterations' semantic. Appending LedgerHistory below duplicated
+  // the audit surface and only surfaced read-only view_document
+  // receipts — CEO directive 2026-04-24.
   'certificate',
   'work_order',
+  'document',
 ]);
 
 function LedgerHistory({ entityType, entityId }: { entityType: string; entityId: string }) {


### PR DESCRIPTION
One-line addition to `SUPPRESS_LEDGER_HISTORY` in `apps/web/src/components/lens-v2/EntityLensPage.tsx`.

CERT04's #709 restored the Set-based opt-out pattern with `'certificate'` + `'work_order'`. Documents needs the identical opt-out for the identical reason:

1. DocumentContent.tsx:509 — `RenewalHistorySection` owns the "previous iterations" semantic.
2. DocumentContent.tsx:551 — `AuditTrailSection` already renders mutation audit from the enriched `/v1/entity/document/{id}` (actor_name + actor_role + deleted flag).

The generic `LedgerHistory` appended below `<Content />` at the wrapper level only surfaced read-only `view_document` / `get_document_url` receipts — no value, duplicates the legitimate sections, confuses the "History" label.

**Citation (proves visible frontend delta):**
```ts
const SUPPRESS_LEDGER_HISTORY: ReadonlySet<string> = new Set<string>([
  'certificate',
  'work_order',
  'document',    // ← added in this PR
]);
```
Render guard:
```tsx
{!SUPPRESS_LEDGER_HISTORY.has(entityType) && (
  <LedgerHistory entityType={entityType} entityId={entityId} />
)}
```
For `entityType === 'document'` this guard is now false → the component never mounts → the stray "History" section disappears from /documents lens cards.

No `DocumentContent.tsx` change. Verification: tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
