### PR TITLE
fix(documents): add 'document' to SUPPRESS_LEDGER_HISTORY

### DIFF
--- a/apps/web/src/components/lens-v2/EntityLensPage.tsx
+++ b/apps/web/src/components/lens-v2/EntityLensPage.tsx
@@ -111,6 +111,14 @@ const SUPPRESS_LEDGER_HISTORY: ReadonlySet<string> = new Set<string>([
   // receipt was wasteful and conflated with the real History above
   // (CEO directive 2026-04-24, list_of_faults.md Issue 7).
   'fault',
+  // DocumentContent.tsx:509 renders RenewalHistorySection (prior
+  // iterations — the legitimate 'history' semantic) + line 551
+  // renders AuditTrailSection from the enriched /v1/entity/document/{id}
+  // (pms_audit_log with actor_name+actor_role+deleted flag). Appending
+  // the generic LedgerHistory produced a stray section of read-only
+  // view_document receipts — zero value, duplicates both surfaces.
+  // CEO directive 2026-04-24.
+  'document',
 ]);
 
 function LedgerHistory({ entityType, entityId }: { entityType: string; entityId: string }) {


### PR DESCRIPTION
One-line addition to `SUPPRESS_LEDGER_HISTORY` in `apps/web/src/components/lens-v2/EntityLensPage.tsx`.

CERT04's #709 restored the Set-based opt-out pattern with `'certificate'` + `'work_order'`. Documents needs the identical opt-out for the identical reason:

1. DocumentContent.tsx:509 — `RenewalHistorySection` owns the "previous iterations" semantic.
2. DocumentContent.tsx:551 — `AuditTrailSection` already renders mutation audit from the enriched `/v1/entity/document/{id}` (actor_name + actor_role + deleted flag).

The generic `LedgerHistory` appended below `<Content />` at the wrapper level only surfaced read-only `view_document` / `get_document_url` receipts — no value, duplicates the legitimate sections, confuses the "History" label.

**Citation (proves visible frontend delta):**
```ts
const SUPPRESS_LEDGER_HISTORY: ReadonlySet<string> = new Set<string>([
  'certificate',
  'work_order',
  'document',    // ← added in this PR
]);
```
Render guard:
```tsx
{!SUPPRESS_LEDGER_HISTORY.has(entityType) && (
  <LedgerHistory entityType={entityType} entityId={entityId} />
)}
```
For `entityType === 'document'` this guard is now false → the component never mounts → the stray "History" section disappears from /documents lens cards.

No `DocumentContent.tsx` change. Verification: tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
