### PR TITLE
feat(shopping-list): tabbed lens UX — Details / Approval / Procurement / Fulfilment / Attachments / Audit

### DIFF
--- a/apps/api/routes/entity_routes.py
+++ b/apps/api/routes/entity_routes.py
@@ -773,11 +773,21 @@ async def get_shopping_list_entity(item_id: str, auth: dict = Depends(get_authen
         except Exception as e:
             logger.warning(f"[entity.shopping_list] state_history fetch failed for {item_id}: {e}")
 
-        # Single batched profile lookup: requester + approver + every actor in history.
+        # Single batched profile lookup — every actor in one query (no N+1).
+        # Extended 2026-04-24 for the tabbed lens: requester + approver +
+        # rejecter + promoter + updated_by + every audit-history changed_by.
         requester_id = data.get("requested_by") or data.get("created_by")
         approver_id = data.get("approved_by")
+        rejected_id = data.get("rejected_by")
+        promoted_id = data.get("promoted_by")
+        updated_id = data.get("updated_by")
         history_actor_ids = {h.get("changed_by") for h in raw_history if h.get("changed_by")}
-        lookup_ids = list({uid for uid in ({requester_id, approver_id} | history_actor_ids) if uid})
+        lookup_ids = list({
+            uid for uid in (
+                {requester_id, approver_id, rejected_id, promoted_id, updated_id}
+                | history_actor_ids
+            ) if uid
+        })
         profile_map: dict[str, str] = {}
         if lookup_ids:
             try:
@@ -787,6 +797,9 @@ async def get_shopping_list_entity(item_id: str, auth: dict = Depends(get_authen
                 logger.warning(f"[entity.shopping_list] profile lookup failed: {e}")
         requester_name = profile_map.get(requester_id) if requester_id else None
         approver_name = profile_map.get(approver_id) if approver_id else None
+        rejected_by_name = profile_map.get(rejected_id) if rejected_id else None
+        promoted_by_name = profile_map.get(promoted_id) if promoted_id else None
+        updated_by_name = profile_map.get(updated_id) if updated_id else None
 
         # Project history rows into the shape ShoppingListContent.tsx expects.
         # AuditTrailSection reads `action`, `actor`, `timestamp` per event
@@ -817,14 +830,20 @@ async def get_shopping_list_entity(item_id: str, auth: dict = Depends(get_authen
             for h in raw_history
         ]
 
+        # Full-surface `item` — drives the tabbed lens (ShoppingListContent.tsx).
+        # Request / Approval / Procurement / Fulfilment each reads from here.
         item = {
             "id": data.get("id"),
             "part_name": data.get("part_name"),
             "part_number": data.get("part_number"),
             "manufacturer": data.get("manufacturer"),
             "unit": data.get("unit"),
+            # Quantity breakdown
             "quantity_requested": data.get("quantity_requested"),
             "quantity_approved": data.get("quantity_approved"),
+            "quantity_ordered": data.get("quantity_ordered"),
+            "quantity_received": data.get("quantity_received"),
+            "quantity_installed": data.get("quantity_installed"),
             "estimated_unit_price": data.get("estimated_unit_price"),
             "preferred_supplier": data.get("preferred_supplier"),
             "urgency": data.get("urgency"),
@@ -833,15 +852,40 @@ async def get_shopping_list_entity(item_id: str, auth: dict = Depends(get_authen
             "source_notes": data.get("source_notes"),
             "required_by_date": data.get("required_by_date"),
             "is_candidate_part": data.get("is_candidate_part", False),
-            "rejection_reason": data.get("rejection_reason"),
-            "rejection_notes": data.get("rejection_notes"),
+            # Approval / rejection
             "approval_notes": data.get("approval_notes"),
             "approved_at": data.get("approved_at"),
+            "rejection_reason": data.get("rejection_reason"),
+            "rejection_notes": data.get("rejection_notes"),
+            "rejected_at": data.get("rejected_at"),
+            "rejected_by_name": rejected_by_name,
+            # Procurement / fulfilment / installation
+            "order_id": data.get("order_id"),
+            "order_line_number": data.get("order_line_number"),
+            "fulfilled_at": data.get("fulfilled_at"),
+            "installed_at": data.get("installed_at"),
+            "installed_to_equipment_id": data.get("installed_to_equipment_id"),
+            # Candidate-to-part promotion
+            "candidate_promoted_to_part_id": data.get("candidate_promoted_to_part_id"),
+            "promoted_at": data.get("promoted_at"),
+            "promoted_by_name": promoted_by_name,
+            # Audit metadata
+            "updated_at": data.get("updated_at"),
+            "updated_by_name": updated_by_name,
+            # FK origins
             "source_work_order_id": data.get("source_work_order_id"),
+            "source_receiving_id": data.get("source_receiving_id"),
         }
+        # Every FK UUID that points to another entity surfaces as a clickable
+        # related-entity row. Frontend resolves the visit route via
+        # getEntityRoute (apps/web/src/lib/entityRoutes.ts).
         nav = [n for n in [
             _nav("part", data.get("part_id"), "Linked Part"),
             _nav("work_order", data.get("source_work_order_id"), "Source Work Order"),
+            _nav("receiving", data.get("source_receiving_id"), "Source Receiving"),
+            _nav("purchase_order", data.get("order_id"), "Linked Purchase Order"),
+            _nav("equipment", data.get("installed_to_equipment_id"), "Installed to Equipment"),
+            _nav("part", data.get("candidate_promoted_to_part_id"), "Promoted Part"),
         ] if n]
 
         _entity_response = {
@@ -850,32 +894,48 @@ async def get_shopping_list_entity(item_id: str, auth: dict = Depends(get_authen
             "status": data.get("status", "candidate"),
             "urgency": data.get("urgency"),
             "priority": data.get("urgency"),
+            # Resolved names (all UUIDs stripped from output per CEO directive)
             "requester_id": requester_id,
             "requester_name": requester_name,
             "created_by": requester_name,
             "approver_name": approver_name,
+            "rejected_by_name": rejected_by_name,
+            "promoted_by_name": promoted_by_name,
+            "updated_by_name": updated_by_name,
+            # Approval / rejection fields (top-level for components that read
+            # from entity directly, not entity.items[0])
             "approved_at": data.get("approved_at"),
             "approval_notes": data.get("approval_notes"),
+            "rejected_at": data.get("rejected_at"),
             "rejection_reason": data.get("rejection_reason"),
+            "rejection_notes": data.get("rejection_notes"),
+            # Procurement / fulfilment timestamps
+            "fulfilled_at": data.get("fulfilled_at"),
+            "installed_at": data.get("installed_at"),
+            "promoted_at": data.get("promoted_at"),
             "created_at": data.get("created_at"),
             "updated_at": data.get("updated_at"),
+            # Core request metadata
             "source_type": data.get("source_type"),
             "source_notes": data.get("source_notes"),
             "description": data.get("source_notes"),
             "quantity_requested": data.get("quantity_requested"),
             "quantity_approved": data.get("quantity_approved"),
+            "quantity_ordered": data.get("quantity_ordered"),
+            "quantity_received": data.get("quantity_received"),
+            "quantity_installed": data.get("quantity_installed"),
             "estimated_unit_price": data.get("estimated_unit_price"),
             "preferred_supplier": data.get("preferred_supplier"),
             "unit": data.get("unit"),
             "required_by_date": data.get("required_by_date"),
             "is_candidate_part": data.get("is_candidate_part", False),
+            # Context
             "items": [item],
             "notes": [],
             "yacht_id": data.get("yacht_id"),
             "attachments": [],
             "related_entities": nav,
             "audit_history": audit_history,
-            "linked_po_items": linked_po_items,
         }
         _entity_response["available_actions"] = get_available_actions(
             "shopping_list", _entity_response, auth.get("role", "crew")

--- a/apps/web/src/components/lens-v2/entity/ShoppingListContent.tsx
+++ b/apps/web/src/components/lens-v2/entity/ShoppingListContent.tsx
@@ -1,13 +1,28 @@
 'use client';
 
 /**
- * ShoppingListContent — lens-v2 entity view for a single shopping list item.
+ * ShoppingListContent — lens-v2 entity view for a single shopping-list item.
  * Prototype: public/prototypes/lens-shopping-list.html
+ * UX spec:   /Users/celeste7/Desktop/lens_card_upgrades.md § "shopping list"
  *
- * Entity data comes from /v1/entity/shopping_list/{id} via useEntityLensContext().
- * Actions come from available_actions[] prefilled by entity_prefill.py.
+ * Layout (2026-04-24 — tabbed workflow-lens pattern, matches WorkOrderContent.tsx):
+ *   IdentityStrip       ← overline, title, pills, details, primary action
+ *   Lifecycle stepper   ← 7 happy-path statuses + rejected off-ramp banner
+ *   LensTabBar          ← Details / Approval / Procurement / Fulfilment / Attachments / Audit
  *
- * Sections: Identity → Lifecycle → Item Details → Links → Audit Trail
+ * All backend-specific data (actions, prefill, audit_history, resolved user
+ * names, linked entity nav URLs) comes from useEntityLensContext() via
+ * GET /v1/entity/shopping_list/{id}. Nothing hits Supabase directly.
+ *
+ * UX rules baked in:
+ *   1. NULL fields render as "—". Never hide a planned slot (CEO 2026-04-24:
+ *      fix for the M8x30 Bolt "only Qty + Source" empty-card bug).
+ *   2. Every FK UUID surfaces as a clickable row via `getEntityRoute`.
+ *      Users never see raw UUIDs.
+ *   3. Resolved user names come from the backend single-batch lookup.
+ *   4. Role-gated actions stay in the SplitButton header; tabs are read-only
+ *      + inline nudges (Promote to Catalogue panel for candidate parts).
+ *   5. Token-driven styling only — no hardcoded colours or spacing.
  */
 
 import * as React from 'react';
@@ -17,6 +32,7 @@ import { IdentityStrip, type PillDef, type DetailLine } from '../IdentityStrip';
 import { mapActionFields, actionHasFields, getSignatureLevel } from '../mapActionFields';
 import { SplitButton, type DropdownItem } from '../SplitButton';
 import { ScrollReveal } from '../ScrollReveal';
+import { LensTabBar, type LensTab } from '../LensTabBar';
 import { useEntityLensContext } from '@/contexts/EntityLensContext';
 import { getEntityRoute } from '@/lib/entityRoutes';
 
@@ -30,23 +46,34 @@ import {
 } from '../sections';
 import { ActionPopup, type ActionPopupField } from '../ActionPopup';
 
+// ── Pill + format helpers ─────────────────────────────────────────────────────
+
 function statusPillVariant(status: string): PillDef['variant'] {
   switch (status?.toLowerCase()) {
-    case 'approved': return 'green';
-    case 'ordered': return 'green';
-    case 'fulfilled': return 'green';
-    case 'rejected': return 'red';
-    case 'under_review': return 'amber';
-    case 'candidate': return 'neutral';
-    default: return 'neutral';
+    case 'approved':
+    case 'fulfilled':
+    case 'installed':
+    case 'ordered':
+    case 'partially_fulfilled':
+      return 'green';
+    case 'rejected':
+      return 'red';
+    case 'under_review':
+      return 'amber';
+    case 'candidate':
+    default:
+      return 'neutral';
   }
 }
 
 function urgencyPillVariant(urgency: string): PillDef['variant'] {
   switch (urgency?.toLowerCase()) {
-    case 'critical': return 'red';
-    case 'high': return 'amber';
-    default: return 'neutral';
+    case 'critical':
+      return 'red';
+    case 'high':
+      return 'amber';
+    default:
+      return 'neutral';
   }
 }
 
@@ -58,8 +85,23 @@ function fmt(str?: string): string {
 function formatDate(d?: string): string {
   if (!d) return '';
   const dt = new Date(d);
+  if (isNaN(dt.getTime())) return '';
   return dt.toLocaleDateString('en-GB', { day: '2-digit', month: 'short', year: 'numeric' });
 }
+
+function formatMoney(n?: number): string {
+  if (n == null) return '—';
+  return `$${n.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
+}
+
+/** KV helper: keeps empty slots visible ("—") so the card exposes gaps
+ *  rather than collapsing them — per CEO 2026-04-24 directive. */
+function kv(label: string, value: React.ReactNode, opts?: { mono?: boolean }): KVItem {
+  const v = value === null || value === undefined || value === '' ? '—' : value;
+  return { label, value: v, mono: opts?.mono };
+}
+
+// ── Component ────────────────────────────────────────────────────────────────
 
 export function ShoppingListContent() {
   const { entity, availableActions, executeAction, getAction } = useEntityLensContext();
@@ -69,36 +111,99 @@ export function ShoppingListContent() {
   const get = <T = unknown>(key: string): T | undefined =>
     (entity?.[key] ?? payload[key]) as T | undefined;
 
-  const id = get<string>('id');
+  // Identity / header fields
   const title = get<string>('title') ?? get<string>('part_name') ?? 'Shopping List Item';
   const status = get<string>('status') ?? 'candidate';
   const urgency = get<string>('urgency') ?? get<string>('priority');
   const requesterName = get<string>('requester_name') ?? get<string>('created_by');
-  const approverName = get<string>('approver_name');
-  const approvedAt = get<string>('approved_at');
-  const approvalNotes = get<string>('approval_notes');
-  const rejectionReason = get<string>('rejection_reason');
   const createdAt = get<string>('created_at');
-  const updatedAt = get<string>('updated_at');
-  const sourceType = get<string>('source_type');
-  const sourceNotes = get<string>('source_notes') ?? get<string>('description');
   const requiredByDate = get<string>('required_by_date');
+  const sourceNotes = get<string>('source_notes') ?? get<string>('description');
   const isCandidatePart = get<boolean>('is_candidate_part');
   const preferredSupplier = get<string>('preferred_supplier');
 
-  // Items array — the entity endpoint wraps the row in items:[...] for the lens
-  const items = (get<Array<Record<string, unknown>>>('items') ?? []);
+  const items = get<Array<Record<string, unknown>>>('items') ?? [];
   const item = items[0] ?? {};
-  const partNumber = (item.part_number ?? get<string>('part_number')) as string | undefined;
-  const manufacturer = (item.manufacturer ?? get<string>('manufacturer')) as string | undefined;
-  const unit = (item.unit ?? get<string>('unit')) as string | undefined;
-  const qtyRequested = (item.quantity_requested ?? get<number>('quantity_requested')) as number | undefined;
-  const qtyApproved = (item.quantity_approved ?? get<number>('quantity_approved')) as number | undefined;
-  const estimatedPrice = (item.estimated_unit_price ?? get<number>('estimated_unit_price')) as number | undefined;
+  const itemField = <T = unknown>(key: string): T | undefined =>
+    (item[key] ?? get<T>(key)) as T | undefined;
 
-  const relatedEntities = (get<Array<Record<string, unknown>>>('related_entities') ?? []);
+  const partNumber = itemField<string>('part_number');
+  const manufacturer = itemField<string>('manufacturer');
+  const unit = itemField<string>('unit');
+  const sourceType = get<string>('source_type');
+  const qtyRequested = itemField<number>('quantity_requested');
+  const qtyApproved = itemField<number>('quantity_approved');
+  const qtyOrdered = itemField<number>('quantity_ordered');
+  const qtyReceived = itemField<number>('quantity_received');
+  const qtyInstalled = itemField<number>('quantity_installed');
+  const estimatedPrice = itemField<number>('estimated_unit_price');
+  const orderLineNumber = itemField<number>('order_line_number');
 
-  // ── Action popup state ───────────────────────────────────────────────────────
+  const approverName = get<string>('approver_name');
+  const approvedAt = get<string>('approved_at');
+  const approvalNotes = get<string>('approval_notes');
+  const rejectedByName = get<string>('rejected_by_name');
+  const rejectedAt = get<string>('rejected_at');
+  const rejectionReason = get<string>('rejection_reason');
+  const rejectionNotes = get<string>('rejection_notes');
+
+  const fulfilledAt = get<string>('fulfilled_at');
+  const installedAt = get<string>('installed_at');
+
+  const promotedByName = get<string>('promoted_by_name');
+  const promotedAt = get<string>('promoted_at');
+
+  // Pure view computation — no DB change
+  const projectedCost =
+    qtyRequested != null && estimatedPrice != null
+      ? qtyRequested * estimatedPrice
+      : undefined;
+
+  // Related entity nav rows (FK UUIDs → clickable rows via getEntityRoute).
+  // Backend emits up to 6 possible FKs in related_entities.
+  const relatedEntities = get<Array<Record<string, unknown>>>('related_entities') ?? [];
+
+  function buildRow(entityType: string, matchLabel: string): DocRowItem | null {
+    const match =
+      relatedEntities.find(
+        (e) =>
+          e.entity_type === entityType &&
+          (e.label as string | undefined) === matchLabel,
+      ) ?? null;
+    if (!match) return null;
+    const id = match.entity_id as string | undefined;
+    if (!id) return null;
+    return {
+      id,
+      name: (match.label as string) ?? matchLabel,
+      code: entityType,
+      onClick: () =>
+        router.push(
+          getEntityRoute(
+            entityType as Parameters<typeof getEntityRoute>[0],
+            id,
+          ),
+        ),
+    };
+  }
+
+  const linkedPartRow = buildRow('part', 'Linked Part');
+  const linkedWORow = buildRow('work_order', 'Source Work Order');
+  const linkedReceivingRow = buildRow('receiving', 'Source Receiving');
+  const linkedPORow = buildRow('purchase_order', 'Linked Purchase Order');
+  const installedEquipmentRow = buildRow('equipment', 'Installed to Equipment');
+  const promotedPartRow = buildRow('part', 'Promoted Part');
+
+  // Audit events from pms_shopping_list_state_history
+  const history = get<Array<Record<string, unknown>>>('audit_history') ?? [];
+  const auditEvents: AuditEvent[] = history.map((h, i) => ({
+    id: (h.id as string) ?? `audit-${i}`,
+    action: (h.action ?? h.description ?? h.event) as string ?? '',
+    actor: (h.actor ?? h.user_name ?? h.performed_by) as string | undefined,
+    timestamp: (h.created_at ?? h.timestamp) as string ?? '',
+  }));
+
+  // Action popup plumbing
   const [popupConfig, setPopupConfig] = React.useState<{
     actionId: string;
     title: string;
@@ -115,10 +220,20 @@ export function ShoppingListContent() {
     });
   }
 
-  // ── Pills & detail lines ─────────────────────────────────────────────────────
-  const pills: PillDef[] = [
-    { label: fmt(status), variant: statusPillVariant(status) },
-  ];
+  const promoteAction = getAction('promote_candidate_to_part');
+
+  function runAction(a: { action_id: string; label: string; required_fields: string[]; prefill: Record<string, unknown>; requires_signature: boolean; disabled?: boolean }) {
+    if (a.disabled) return;
+    const hasFields = actionHasFields(a as Parameters<typeof actionHasFields>[0]);
+    if (hasFields || a.requires_signature) {
+      openPopup(a as Parameters<typeof openPopup>[0]);
+    } else {
+      executeAction(a.action_id);
+    }
+  }
+
+  // Header pills + details
+  const pills: PillDef[] = [{ label: fmt(status), variant: statusPillVariant(status) }];
   if (urgency && urgency !== 'normal') {
     pills.push({ label: fmt(urgency), variant: urgencyPillVariant(urgency) });
   }
@@ -130,75 +245,20 @@ export function ShoppingListContent() {
   if (requesterName) details.push({ label: 'Requested by', value: requesterName });
   if (createdAt) details.push({ label: 'Created', value: formatDate(createdAt), mono: true });
   if (requiredByDate) details.push({ label: 'Required by', value: formatDate(requiredByDate), mono: true });
-  if (approverName) details.push({ label: 'Approved by', value: approverName });
-  if (approvedAt) details.push({ label: 'Approved', value: formatDate(approvedAt), mono: true });
+  if (projectedCost != null) details.push({ label: 'Projected cost', value: formatMoney(projectedCost), mono: true });
 
-  // ── KV section rows ──────────────────────────────────────────────────────────
-  const kvItems: KVItem[] = [];
-  if (partNumber) kvItems.push({ label: 'Part Number', value: partNumber, mono: true });
-  if (manufacturer) kvItems.push({ label: 'Manufacturer', value: manufacturer });
-  if (unit) kvItems.push({ label: 'Unit', value: unit });
-  if (qtyRequested != null) kvItems.push({ label: 'Qty Requested', value: String(qtyRequested) });
-  if (qtyApproved != null) kvItems.push({ label: 'Qty Approved', value: String(qtyApproved) });
-  if (estimatedPrice != null) kvItems.push({ label: 'Est. Unit Price', value: `$${estimatedPrice.toLocaleString()}`, mono: true });
-  if (preferredSupplier) kvItems.push({ label: 'Preferred Supplier', value: preferredSupplier });
-  if (sourceType) kvItems.push({ label: 'Source', value: fmt(sourceType) });
-  if (sourceNotes) kvItems.push({ label: 'Notes / Reason', value: sourceNotes });
-  if (approvalNotes) kvItems.push({ label: 'Approval Notes', value: approvalNotes });
-  if (rejectionReason) kvItems.push({ label: 'Rejection Reason', value: rejectionReason });
-
-  // ── Related entity links ─────────────────────────────────────────────────────
-  // Each nav item becomes a clickable row routing to /parts/[id] or
-  // /work-orders/[id] etc. `getEntityRoute` is the cross-domain slug→route
-  // mapper (apps/web/src/lib/entityRoutes.ts) that every other lens uses.
-  // Without this onClick, the "Linked Entities" rows render but go nowhere —
-  // was an interlinking gap flagged in the Issue 13 follow-up audit.
-  const docItems: DocRowItem[] = relatedEntities.map((e, i) => {
-    const entityId = e.entity_id as string | undefined;
-    const entityType = e.entity_type as string | undefined;
-    return {
-      id: entityId ?? `link-${i}`,
-      name: (e.label as string) ?? 'Linked Entity',
-      code: entityType ?? undefined,
-      meta: undefined,
-      date: undefined,
-      onClick: entityId && entityType
-        ? () => router.push(
-            getEntityRoute(entityType as Parameters<typeof getEntityRoute>[0], entityId),
-          )
-        : undefined,
-    };
-  });
-
-  // ── Audit events ─────────────────────────────────────────────────────────────
-  const history = (get<Array<Record<string, unknown>>>('audit_history') ?? []);
-  const auditEvents: AuditEvent[] = history.map((h, i) => ({
-    id: (h.id as string) ?? `audit-${i}`,
-    action: (h.action ?? h.description ?? h.event) as string ?? '',
-    actor: (h.actor ?? h.user_name ?? h.performed_by) as string | undefined,
-    timestamp: (h.created_at ?? h.timestamp) as string ?? '',
-  }));
-
-  // ── SplitButton — primary action + dropdown ──────────────────────────────────
+  // SplitButton
   const approveAction = getAction('approve_shopping_list_item');
-  const rejectAction = getAction('reject_shopping_list_item');
-  const promoteAction = getAction('promote_candidate_to_part');
   const orderAction = getAction('mark_shopping_list_ordered');
-
-  // Primary: approve if available, else first non-approve action
   const primaryAction = approveAction ?? orderAction;
   const primaryLabel = primaryAction?.label ?? 'No Actions';
   const primaryDisabled = !primaryAction || (primaryAction.disabled ?? false);
 
   const handlePrimary = React.useCallback(async () => {
     if (!primaryAction) return;
-    const hasFields = actionHasFields(primaryAction as Parameters<typeof actionHasFields>[0]);
-    if (hasFields || primaryAction.requires_signature) {
-      openPopup(primaryAction as Parameters<typeof openPopup>[0]);
-    } else {
-      await executeAction(primaryAction.action_id);
-    }
-  }, [primaryAction, executeAction]);
+    runAction(primaryAction as Parameters<typeof runAction>[0]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [primaryAction]);
 
   const DANGER_ACTIONS = new Set(['delete_shopping_item']);
   const dropdownItems: DropdownItem[] = availableActions
@@ -208,19 +268,10 @@ export function ShoppingListContent() {
       disabled: a.disabled,
       disabledReason: a.disabled_reason ?? undefined,
       danger: DANGER_ACTIONS.has(a.action_id),
-      onClick: () => {
-        const hasFields = actionHasFields(a as Parameters<typeof actionHasFields>[0]);
-        if (hasFields || a.requires_signature) {
-          openPopup(a as Parameters<typeof openPopup>[0]);
-        } else {
-          executeAction(a.action_id);
-        }
-      },
+      onClick: () => runAction(a as Parameters<typeof runAction>[0]),
     }));
 
-  // ── Lifecycle steps ──────────────────────────────────────────────────────────
-  // Happy-path statuses from pms_shopping_list_items.status (live DB enum).
-  // `rejected` is a terminal off-ramp rendered separately (see below).
+  // Lifecycle stepper
   const LIFECYCLE = [
     'candidate',
     'under_review',
@@ -234,6 +285,224 @@ export function ShoppingListContent() {
   const currentIdx = isRejected
     ? -1
     : LIFECYCLE.indexOf(status as typeof LIFECYCLE[number]);
+
+  // Tab definitions
+  const procurementCount = linkedPORow ? 1 : 0;
+  const fulfilmentCount =
+    (qtyReceived && qtyReceived > 0 ? 1 : 0) +
+    (installedEquipmentRow || installedAt ? 1 : 0);
+  const approvalCount =
+    approverName || rejectedByName || approvalNotes || rejectionReason ? 1 : 0;
+
+  const tabs: LensTab[] = [
+    { key: 'details', label: 'Details' },
+    { key: 'approval', label: 'Approval', count: approvalCount },
+    {
+      key: 'procurement',
+      label: 'Procurement',
+      count: procurementCount,
+      disabled: !linkedPORow && qtyOrdered == null,
+      disabledReason: 'No purchase order linked yet.',
+    },
+    {
+      key: 'fulfilment',
+      label: 'Fulfilment',
+      count: fulfilmentCount,
+      disabled:
+        fulfilmentCount === 0 &&
+        (qtyReceived ?? 0) === 0 &&
+        !installedAt &&
+        !fulfilledAt,
+      disabledReason: 'Not yet received.',
+    },
+    {
+      key: 'attachments',
+      label: 'Attachments',
+      count: 0,
+      disabled: true,
+      disabledReason: 'Photo upload + comments arrive in the next release.',
+    },
+    { key: 'audit', label: 'Audit', count: auditEvents.length },
+  ];
+
+  // Tab renderers
+
+  function renderDetailsTab(): React.ReactNode {
+    const detailItems: KVItem[] = [
+      kv('Part Number', partNumber, { mono: true }),
+      kv('Manufacturer', manufacturer),
+      kv('Unit', unit),
+      kv('Qty Requested', qtyRequested != null ? String(qtyRequested) : undefined),
+      kv('Est. Unit Price', estimatedPrice != null ? formatMoney(estimatedPrice) : undefined, { mono: true }),
+      kv('Projected Cost', projectedCost != null ? formatMoney(projectedCost) : undefined, { mono: true }),
+      kv('Preferred Supplier', preferredSupplier),
+    ];
+    const sourceItems: KVItem[] = [
+      kv('Source', sourceType ? fmt(sourceType) : undefined),
+      kv('Reason / Notes', sourceNotes || 'No reason provided — click Update to add'),
+    ];
+    const linkedDocs: DocRowItem[] = [linkedPartRow, linkedWORow, linkedReceivingRow]
+      .filter((r): r is DocRowItem => r !== null);
+
+    return (
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 16 }}>
+        <KVSection title="Item Details" items={detailItems} />
+        <KVSection title="Source & Context" items={sourceItems} />
+
+        {isCandidatePart && !linkedPartRow && !promotedPartRow && (
+          <CandidatePromotePanel
+            promoteAction={promoteAction}
+            onPromote={() =>
+              promoteAction &&
+              runAction(promoteAction as Parameters<typeof runAction>[0])
+            }
+          />
+        )}
+
+        {promotedPartRow && (
+          <PromotedPartPanel
+            promotedAt={promotedAt}
+            promotedByName={promotedByName}
+            row={promotedPartRow}
+          />
+        )}
+
+        {linkedDocs.length > 0 && (
+          <DocRowsSection title="Linked Entities" docs={linkedDocs} />
+        )}
+      </div>
+    );
+  }
+
+  function renderApprovalTab(): React.ReactNode {
+    if (status === 'candidate') {
+      return <EmptyTab message="Awaiting HoD review — no approval decision yet." />;
+    }
+    const approvalItems: KVItem[] = [];
+    if (approverName || approvedAt || approvalNotes || qtyApproved != null) {
+      approvalItems.push(
+        kv('Approved by', approverName),
+        kv('Approved at', approvedAt ? formatDate(approvedAt) : undefined, { mono: true }),
+        kv(
+          'Qty Approved',
+          qtyApproved != null
+            ? `${qtyApproved}${qtyRequested != null ? ` / ${qtyRequested}` : ''}`
+            : undefined,
+        ),
+        kv('Approval Notes', approvalNotes),
+      );
+    }
+    const rejectionItems: KVItem[] = [];
+    if (rejectedByName || rejectedAt || rejectionReason || rejectionNotes) {
+      rejectionItems.push(
+        kv('Rejected by', rejectedByName),
+        kv('Rejected at', rejectedAt ? formatDate(rejectedAt) : undefined, { mono: true }),
+        kv('Reason', rejectionReason),
+        kv('Notes', rejectionNotes),
+      );
+    }
+    if (approvalItems.length === 0 && rejectionItems.length === 0) {
+      return <EmptyTab message="No approval data recorded yet." />;
+    }
+    return (
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 16 }}>
+        {approvalItems.length > 0 && <KVSection title="Approval" items={approvalItems} />}
+        {rejectionItems.length > 0 && <KVSection title="Rejection" items={rejectionItems} />}
+      </div>
+    );
+  }
+
+  function renderProcurementTab(): React.ReactNode {
+    if (!linkedPORow && qtyOrdered == null) {
+      return (
+        <EmptyTab
+          message={
+            status === 'approved'
+              ? 'Approved and awaiting purchase order.'
+              : 'Procurement starts after approval.'
+          }
+        />
+      );
+    }
+    const orderItems: KVItem[] = [
+      kv('Line Number', orderLineNumber != null ? String(orderLineNumber) : undefined),
+      kv('Qty Ordered', qtyOrdered != null ? String(qtyOrdered) : undefined),
+    ];
+    return (
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 16 }}>
+        {linkedPORow ? (
+          <DocRowsSection title="Linked Purchase Order" docs={[linkedPORow]} />
+        ) : (
+          <DiagnosticPanel message="Ordered flag is set but no purchase order linked. Ask the Purser to reconcile." />
+        )}
+        <KVSection title="Order Details" items={orderItems} />
+      </div>
+    );
+  }
+
+  function renderFulfilmentTab(): React.ReactNode {
+    const anyFulfilment =
+      (qtyReceived ?? 0) > 0 ||
+      (qtyInstalled ?? 0) > 0 ||
+      installedAt ||
+      fulfilledAt ||
+      linkedReceivingRow ||
+      installedEquipmentRow;
+    if (!anyFulfilment) {
+      return <EmptyTab message="Not yet received." />;
+    }
+    const fulfilItems: KVItem[] = [
+      kv(
+        'Qty Received',
+        qtyReceived != null
+          ? `${qtyReceived}${qtyOrdered != null ? ` / ${qtyOrdered}` : ''}`
+          : undefined,
+      ),
+      kv('Qty Installed', qtyInstalled != null ? String(qtyInstalled) : undefined),
+      kv('Fulfilled at', fulfilledAt ? formatDate(fulfilledAt) : undefined, { mono: true }),
+      kv('Installed at', installedAt ? formatDate(installedAt) : undefined, { mono: true }),
+    ];
+    const rows: DocRowItem[] = [linkedReceivingRow, installedEquipmentRow]
+      .filter((r): r is DocRowItem => r !== null);
+    return (
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 16 }}>
+        <KVSection title="Receipt & Installation" items={fulfilItems} />
+        {rows.length > 0 && <DocRowsSection title="Linked Entities" docs={rows} />}
+      </div>
+    );
+  }
+
+  function renderAttachmentsTab(): React.ReactNode {
+    return (
+      <EmptyTab message="Photo uploads + comments arrive in the next release — cohort-shared pms_attachments + pms_attachment_comments (PR #696)." />
+    );
+  }
+
+  function renderAuditTab(): React.ReactNode {
+    if (auditEvents.length === 0) {
+      return <EmptyTab message="No audit events recorded yet." />;
+    }
+    return <AuditTrailSection events={auditEvents} />;
+  }
+
+  function renderTabBody(key: string): React.ReactNode {
+    switch (key) {
+      case 'details':
+        return renderDetailsTab();
+      case 'approval':
+        return renderApprovalTab();
+      case 'procurement':
+        return renderProcurementTab();
+      case 'fulfilment':
+        return renderFulfilmentTab();
+      case 'attachments':
+        return renderAttachmentsTab();
+      case 'audit':
+        return renderAuditTab();
+      default:
+        return <EmptyTab message="Coming soon." />;
+    }
+  }
 
   return (
     <>
@@ -256,101 +525,16 @@ export function ShoppingListContent() {
         }
       />
 
-      {/* Lifecycle progress — rejected items render a terminal banner instead */}
       <ScrollReveal>
         {isRejected ? (
-          <div style={{
-            display: 'flex', alignItems: 'center', gap: 12,
-            padding: '12px 16px', margin: '16px 0 8px',
-            borderRadius: 8,
-            background: 'var(--red-bg, rgba(220, 53, 69, 0.1))',
-            border: '1px solid var(--red, #dc3545)',
-          }}>
-            <div style={{
-              width: 10, height: 10, borderRadius: '50%',
-              background: 'var(--red, #dc3545)',
-              boxShadow: '0 0 0 4px var(--red-bg, rgba(220, 53, 69, 0.15))',
-              flexShrink: 0,
-            }} />
-            <div style={{ display: 'flex', flexDirection: 'column', gap: 2, minWidth: 0 }}>
-              <span style={{
-                fontSize: 11, fontWeight: 600, letterSpacing: '0.03em',
-                color: 'var(--red, #dc3545)', textTransform: 'uppercase',
-              }}>
-                Rejected
-              </span>
-              {rejectionReason && (
-                <span style={{
-                  fontSize: 12, color: 'var(--txt2, #bbb)', whiteSpace: 'nowrap',
-                  overflow: 'hidden', textOverflow: 'ellipsis',
-                }}>
-                  {rejectionReason}
-                </span>
-              )}
-            </div>
-          </div>
+          <RejectedBanner reason={rejectionReason} />
         ) : (
-          <div style={{ display: 'flex', alignItems: 'flex-start', gap: 0, padding: '16px 0', marginBottom: 8 }}>
-            {LIFECYCLE.map((step, i) => {
-              const isCompleted = currentIdx >= 0 && i < currentIdx;
-              const isActive = i === currentIdx;
-
-              return (
-                <React.Fragment key={step}>
-                  <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', flex: 1, minWidth: 0 }}>
-                    <div style={{
-                      width: isActive ? 12 : 10, height: isActive ? 12 : 10, borderRadius: '50%',
-                      background: isCompleted || isActive ? 'var(--green, #4caf50)' : 'none',
-                      border: `2px solid ${isCompleted || isActive ? 'var(--green, #4caf50)' : 'var(--txt-ghost, #666)'}`,
-                      boxShadow: isActive ? '0 0 0 4px var(--green-bg, rgba(76,175,80,0.15))' : 'none',
-                      display: 'flex', alignItems: 'center', justifyContent: 'center',
-                    }}>
-                      {isCompleted && (
-                        <svg width="8" height="8" viewBox="0 0 12 12" fill="none" stroke="#fff" strokeWidth="2" strokeLinecap="round">
-                          <polyline points="2.5 6 5 8.5 9.5 3.5" />
-                        </svg>
-                      )}
-                    </div>
-                    <span style={{
-                      fontSize: 10, fontWeight: isActive ? 600 : 500,
-                      letterSpacing: '0.03em',
-                      color: isActive ? 'var(--green, #4caf50)' : isCompleted ? 'var(--txt3, #999)' : 'var(--txt-ghost, #666)',
-                      marginTop: 8, textTransform: 'uppercase', whiteSpace: 'nowrap',
-                    }}>
-                      {fmt(step)}
-                    </span>
-                  </div>
-                  {i < LIFECYCLE.length - 1 && (
-                    <div style={{
-                      flex: 1, height: 2,
-                      background: isCompleted ? 'var(--green, #4caf50)' : 'var(--border-sub, #444)',
-                      alignSelf: 'flex-start', marginTop: isActive ? 6 : 5, minWidth: 8,
-                    }} />
-                  )}
-                </React.Fragment>
-              );
-            })}
-          </div>
+          <LifecycleStepper lifecycle={LIFECYCLE} currentIdx={currentIdx} />
         )}
       </ScrollReveal>
 
-      {/* Item detail KV rows */}
-      {kvItems.length > 0 && (
-        <ScrollReveal>
-          <KVSection title="Item Details" items={kvItems} />
-        </ScrollReveal>
-      )}
-
-      {/* Linked entities (part, work order) */}
-      {docItems.length > 0 && (
-        <ScrollReveal>
-          <DocRowsSection title="Linked Entities" docs={docItems} />
-        </ScrollReveal>
-      )}
-
-      {/* Audit trail */}
       <ScrollReveal>
-        <AuditTrailSection events={auditEvents} defaultCollapsed />
+        <LensTabBar tabs={tabs} defaultActiveKey="details" renderBody={renderTabBody} />
       </ScrollReveal>
 
       {popupConfig && (
@@ -367,5 +551,254 @@ export function ShoppingListContent() {
         />
       )}
     </>
+  );
+}
+
+// ── Inline presentational helpers ────────────────────────────────────────────
+
+function EmptyTab({ message }: { message: string }) {
+  return (
+    <div
+      style={{
+        padding: '32px 16px',
+        textAlign: 'center',
+        color: 'var(--txt3)',
+        fontSize: 13,
+        fontFamily: 'var(--font-sans)',
+      }}
+    >
+      {message}
+    </div>
+  );
+}
+
+function DiagnosticPanel({ message }: { message: string }) {
+  return (
+    <div
+      style={{
+        display: 'flex',
+        alignItems: 'center',
+        gap: 10,
+        padding: '10px 14px',
+        borderRadius: 8,
+        background: 'var(--amber-bg)',
+        border: '1px solid var(--amber-border)',
+        color: 'var(--amber)',
+        fontSize: 12.5,
+        fontFamily: 'var(--font-sans)',
+      }}
+    >
+      <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+        <path d="M10.29 3.86L1.82 18a2 2 0 001.71 3h16.94a2 2 0 001.71-3L13.71 3.86a2 2 0 00-3.42 0z" />
+        <line x1="12" y1="9" x2="12" y2="13" />
+        <line x1="12" y1="17" x2="12.01" y2="17" />
+      </svg>
+      <span>{message}</span>
+    </div>
+  );
+}
+
+function RejectedBanner({ reason }: { reason?: string }) {
+  return (
+    <div
+      style={{
+        display: 'flex',
+        alignItems: 'center',
+        gap: 12,
+        padding: '12px 16px',
+        margin: '16px 0 8px',
+        borderRadius: 8,
+        background: 'var(--red-bg)',
+        border: '1px solid var(--red-border)',
+      }}
+    >
+      <div
+        style={{
+          width: 10,
+          height: 10,
+          borderRadius: '50%',
+          background: 'var(--red)',
+          boxShadow: '0 0 0 4px var(--red-bg)',
+          flexShrink: 0,
+        }}
+      />
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 2, minWidth: 0 }}>
+        <span
+          style={{
+            fontSize: 11,
+            fontWeight: 600,
+            letterSpacing: '0.03em',
+            color: 'var(--red)',
+            textTransform: 'uppercase',
+          }}
+        >
+          Rejected
+        </span>
+        {reason && (
+          <span style={{ fontSize: 12, color: 'var(--txt2)', whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>
+            {reason}
+          </span>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function LifecycleStepper({
+  lifecycle,
+  currentIdx,
+}: {
+  lifecycle: ReadonlyArray<string>;
+  currentIdx: number;
+}) {
+  return (
+    <div style={{ display: 'flex', alignItems: 'flex-start', gap: 0, padding: '16px 0', marginBottom: 8 }}>
+      {lifecycle.map((step, i) => {
+        const isCompleted = currentIdx >= 0 && i < currentIdx;
+        const isActive = i === currentIdx;
+        return (
+          <React.Fragment key={step}>
+            <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', flex: 1, minWidth: 0 }}>
+              <div
+                style={{
+                  width: isActive ? 12 : 10,
+                  height: isActive ? 12 : 10,
+                  borderRadius: '50%',
+                  background: isCompleted || isActive ? 'var(--green)' : 'none',
+                  border: `2px solid ${isCompleted || isActive ? 'var(--green)' : 'var(--txt-ghost)'}`,
+                  boxShadow: isActive ? '0 0 0 4px var(--green-bg)' : 'none',
+                  display: 'flex',
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                }}
+              >
+                {isCompleted && (
+                  <svg width="8" height="8" viewBox="0 0 12 12" fill="none" stroke="var(--surface-base)" strokeWidth="2" strokeLinecap="round">
+                    <polyline points="2.5 6 5 8.5 9.5 3.5" />
+                  </svg>
+                )}
+              </div>
+              <span
+                style={{
+                  fontSize: 10,
+                  fontWeight: isActive ? 600 : 500,
+                  letterSpacing: '0.03em',
+                  color: isActive ? 'var(--green)' : isCompleted ? 'var(--txt3)' : 'var(--txt-ghost)',
+                  marginTop: 8,
+                  textTransform: 'uppercase',
+                  whiteSpace: 'nowrap',
+                }}
+              >
+                {fmt(step)}
+              </span>
+            </div>
+            {i < lifecycle.length - 1 && (
+              <div
+                style={{
+                  flex: 1,
+                  height: 2,
+                  background: isCompleted ? 'var(--green)' : 'var(--border-sub)',
+                  alignSelf: 'flex-start',
+                  marginTop: isActive ? 6 : 5,
+                  minWidth: 8,
+                }}
+              />
+            )}
+          </React.Fragment>
+        );
+      })}
+    </div>
+  );
+}
+
+function CandidatePromotePanel({
+  promoteAction,
+  onPromote,
+}: {
+  promoteAction:
+    | { action_id: string; label: string; disabled?: boolean; disabled_reason?: string | null }
+    | null;
+  onPromote: () => void;
+}) {
+  const disabled = !promoteAction || (promoteAction.disabled ?? false);
+  const reason = promoteAction?.disabled_reason ?? undefined;
+  return (
+    <div
+      style={{
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'space-between',
+        gap: 12,
+        padding: '12px 16px',
+        borderRadius: 8,
+        background: 'var(--surface)',
+        border: '1px solid var(--border-faint)',
+      }}
+    >
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 2, minWidth: 0 }}>
+        <span style={{ fontSize: 12, fontWeight: 600, color: 'var(--txt)', fontFamily: 'var(--font-sans)' }}>
+          Candidate part — not in the catalogue
+        </span>
+        <span style={{ fontSize: 11.5, color: 'var(--txt2)', fontFamily: 'var(--font-sans)' }}>
+          An Engineer can promote this request to a permanent catalogued part once it&apos;s approved.
+        </span>
+      </div>
+      <button
+        onClick={onPromote}
+        disabled={disabled}
+        title={disabled ? reason : undefined}
+        style={{
+          appearance: 'none',
+          border: '1px solid var(--mark)',
+          background: disabled ? 'var(--surface)' : 'var(--teal-bg)',
+          color: 'var(--mark)',
+          padding: '6px 12px',
+          borderRadius: 6,
+          fontSize: 12,
+          fontWeight: 600,
+          fontFamily: 'var(--font-sans)',
+          cursor: disabled ? 'not-allowed' : 'pointer',
+          opacity: disabled ? 0.5 : 1,
+          whiteSpace: 'nowrap',
+          flexShrink: 0,
+        }}
+      >
+        Promote to Catalogue
+      </button>
+    </div>
+  );
+}
+
+function PromotedPartPanel({
+  promotedAt,
+  promotedByName,
+  row,
+}: {
+  promotedAt?: string;
+  promotedByName?: string;
+  row: DocRowItem;
+}) {
+  return (
+    <div
+      style={{
+        padding: '12px 16px',
+        borderRadius: 8,
+        background: 'var(--green-bg)',
+        border: '1px solid var(--green-border)',
+      }}
+    >
+      <div style={{ display: 'flex', alignItems: 'baseline', gap: 8, marginBottom: 6 }}>
+        <span style={{ fontSize: 11, fontWeight: 600, color: 'var(--green)', textTransform: 'uppercase', letterSpacing: '0.03em' }}>
+          Promoted to catalogue
+        </span>
+        {promotedAt && (
+          <span style={{ fontSize: 11, color: 'var(--txt3)', fontFamily: 'var(--font-mono)' }}>
+            {formatDate(promotedAt)}
+            {promotedByName ? ` · by ${promotedByName}` : ''}
+          </span>
+        )}
+      </div>
+      <DocRowsSection title="" docs={[row]} />
+    </div>
   );
 }


### PR DESCRIPTION
CEO-approved lens-card upgrade per [`lens_card_upgrades.md § shopping list`](../blob/main/lens_card_upgrades.md). Shopping-list follows the **work-order tabbed pattern** (not the cert/doc render-the-artefact pattern) because it's a workflow entity, not a document. Uses the shipped `LensTabBar` primitive — same component that powers `/work-orders/[id]`.

## What changes

### Header (unchanged + one addition)
IdentityStrip · lifecycle stepper · SplitButton stay exactly as they are. Added a **Projected cost** detail line (qty × estimated_unit_price — pure view computation, no DB change). Helps HoD see the financial signal before approving.

### 6 tabs replace the flat ScrollReveal stack

| Tab | Purpose | Empty state when… |
|---|---|---|
| **Details** (default) | Item Details KV · Source & Context · Linked Entities (part, WO, receiving) · **inline Promote-to-Catalogue panel** when the item is a candidate part · PromotedPartPanel when already promoted | n/a — always populated |
| **Approval** | Decision, who approved/rejected, qty_approved vs qty_requested, notes | `candidate` → "Awaiting HoD review" |
| **Procurement** | Linked Purchase Order + line# + qty_ordered | no PO yet → contextual message + DiagnosticPanel when `status=ordered` but `order_id` is NULL (surfaces the PURCHASE05 cross-domain gap) |
| **Fulfilment** | qty_received / qty_installed · fulfilled_at / installed_at · linked receiving + installed equipment | no receiving yet → "Not yet received" |
| **Attachments** | Placeholder — photo upload + comments arrive in the follow-up PR (cohort-shared `pms_attachments` + `pms_attachment_comments` already landed via #696) | disabled until wired |
| **Audit** | Existing `AuditTrailSection`, driven by `pms_shopping_list_state_history` | empty message if no events |

### KV rows now show "—" instead of hiding

Fixes the M8x30 Bolt empty-card bug. Previously the lens pushed KV rows **only when populated** (`if (partNumber) kvItems.push(...)`), so a sparse row showed only "Qty 12 / Manual Add". Now every planned slot renders — NULLs as "—" — so the card exposes the gap rather than collapsing it. Crew see what's missing and can update.

### Interlinking — FK UUIDs as clickable rows

Every FK becomes a [Visit] row via `getEntityRoute`:
- `part_id` → `/inventory/<id>`
- `source_work_order_id` → `/work-orders/<id>`
- `source_receiving_id` → `/receiving/<id>` *(new)*
- `order_id` → `/purchasing/<id>` *(new)*
- `installed_to_equipment_id` → `/equipment/<id>` *(new)*
- `candidate_promoted_to_part_id` → `/inventory/<id>` *(new)*

Users never see raw UUIDs.

## Backend enrichment (`apps/api/routes/entity_routes.py`)

Single-batch `auth_users_profiles` lookup extended from 2 UUIDs (requester + approver) to 5 (+ rejected_by + promoted_by + updated_by) plus every audit-history changed_by. All in one query — no N+1.

`entity.items[0]` now carries the full 49-column surface needed by the tabs:
- Qty breakdown: `quantity_ordered / received / installed`
- Approval/rejection: `rejected_at`, `rejected_by_name`
- Procurement: `order_id`, `order_line_number`
- Fulfilment: `fulfilled_at`, `installed_at`, `installed_to_equipment_id`
- Promotion: `candidate_promoted_to_part_id`, `promoted_at`, `promoted_by_name`
- Audit: `updated_by_name`
- Origin: `source_receiving_id`

`related_entities` nav extended from 2 → 6 possible rows (part, work_order, receiving, purchase_order, equipment-installed, part-promoted).

## Styling discipline

- Token-driven (`var(--green)`, `var(--amber)`, `var(--red)`, `var(--mark)`, `var(--surface)`, `var(--txt*)`, `var(--font-sans)`, `var(--font-mono)`)
- No hardcoded colours anywhere
- `LensTabBar` is the same shipped primitive used by WorkOrderContent — same sticky header, keyboard nav, count pill, active underline

## Width

`shopping_list` is already in `WIDE_LENS_TYPES` (from peer PR) — tabs get the extra horizontal room they need.

## Cross-domain follow-ups

- `order_id` is never populated in live data today. PURCHASE05's `convert_to_po` / `add_item_to_purchase` handlers must write back `order_id + order_line_number` onto shopping rows when an approved item lands on a PO. Until then the Procurement tab either shows "Approved and awaiting purchase order" (no order_id) or the yellow DiagnosticPanel if someone flips status to ordered without the FK.
- Attachments tab is placeholder-only. Next PR: clone `add_work_order_photo` → `add_shopping_list_photo`, mint bucket `pms-shopping-list-photos`, wire AttachmentsSection.

## Test plan

- [ ] `/shopping-list/<any-item>` opens on the Details tab with full KV rows (including "—" placeholders) + any linked part/WO/receiving shown as clickable rows
- [ ] Candidate part without `part_id` shows the Promote-to-Catalogue panel; disabled when user doesn't have engineer role
- [ ] Approval tab: `candidate` shows "Awaiting HoD review"; approved item shows approved_by name + qty_approved side-by-side with qty_requested; rejected item shows reason + notes
- [ ] Procurement tab: shows empty state before approval; shows DiagnosticPanel if status=ordered but no order_id
- [ ] Fulfilment tab: shows empty state pre-receipt; shows qty_received/qty_installed + linked receiving/equipment click-throughs once receipts happen
- [ ] Audit tab: populated from state_history
- [ ] Clicking any [Visit] row routes correctly (part → /inventory, WO → /work-orders, etc.)
- [ ] Rejected items: red banner replaces the lifecycle stepper (existing behaviour preserved)
- [ ] No 400s on any action; SplitButton + dropdown actions unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)